### PR TITLE
Force encoding at open() calls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,14 +26,14 @@ def get_version() -> str:
     """Get the package version."""
     version_path = os.path.join(
         os.path.dirname(__file__), 'src', 'aihwkit', 'VERSION.txt')
-    with open(version_path) as version_file:
+    with open(version_path, encoding='utf-8') as version_file:
         return version_file.read().strip()
 
 
 def get_long_description() -> str:
     """Get the package long description."""
     readme_path = os.path.join(os.path.dirname(__file__), 'README.md')
-    with open(readme_path) as readme_file:
+    with open(readme_path, encoding='utf-8') as readme_file:
         return readme_file.read().strip()
 
 

--- a/src/aihwkit/version.py
+++ b/src/aihwkit/version.py
@@ -15,5 +15,5 @@
 import os
 
 VERSION_FILE = os.path.join(os.path.dirname(__file__), 'VERSION.txt')
-with open(VERSION_FILE) as version_file:
+with open(VERSION_FILE, encoding='utf-8') as version_file:
     __version__ = version_file.read().strip()


### PR DESCRIPTION

## Related issues

#11 

## Description

Set explicitly the file encoding to `utf-8` in the `open()` calls, in
order to prevent issues with different system locales.


## Details

<!-- A more elaborate description of the changes, if needed. -->
