### PR TITLE
Expose all C++ resistive devices and unit cells to pytorch

### DIFF
--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -44,8 +44,8 @@ class AnalogModuleBase(Module):
     """
     # pylint: disable=abstract-method
 
-    TILE_CLASS_FLOATING_POINT = FloatingPointTile
-    TILE_CLASS_ANALOG = AnalogTile
+    TILE_CLASS_FLOATING_POINT: Any = FloatingPointTile
+    TILE_CLASS_ANALOG: Any = AnalogTile
 
     def _setup_tile(
             self,

--- a/src/aihwkit/simulator/devices.py
+++ b/src/aihwkit/simulator/devices.py
@@ -14,16 +14,26 @@
 
 """High level analog devices."""
 
-from dataclasses import asdict
+from dataclasses import is_dataclass
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, List, Union
 
 from aihwkit.simulator.parameters import (
     FloatingPointTileParameters, AnalogTileParameters,
+    AbstractResistiveDeviceParameters,
+    IdealResistiveDeviceParameters,
+    PulsedResistiveDeviceBaseParameters,
     ConstantStepResistiveDeviceParameters,
+    LinearStepResistiveDeviceParameters,
+    SoftBoundsResistiveDeviceParameters,
+    ExpStepResistiveDeviceParameters,
+    DifferenceUnitCellParameters,
+    VectorUnitCellParameters,
+    TransferUnitCellParameters,
     AnalogTileBackwardInputOutputParameters,
     AnalogTileInputOutputParameters,
     AnalogTileUpdateParameters,
+    PulseType
 )
 from aihwkit.simulator.rpu_base.tiles import FloatingPointTile, AnalogTile
 from aihwkit.simulator.rpu_base import devices
@@ -45,12 +55,14 @@ class BaseResistiveDevice:
     def _parameters_to_bindings(params: Any) -> Any:
         """Convert a dataclass parameter into a bindings class."""
         result = params.bindings_class()
-        for field, value in asdict(params).items():
+        for field, value in params.__dict__.items():
             # Convert enums to the bindings enums.
             if isinstance(value, Enum):
                 enum_class = getattr(devices, value.__class__.__name__)
                 enum_value = getattr(enum_class, value.value)
                 setattr(result, field, enum_value)
+            elif is_dataclass(value):
+                setattr(result, field, BaseResistiveDevice._parameters_to_bindings(value))
             else:
                 setattr(result, field, value)
 
@@ -58,10 +70,9 @@ class BaseResistiveDevice:
 
 
 class FloatingPointResistiveDevice(BaseResistiveDevice):
-    """Floating point resistive devices.
+    """Floating point reference.
 
-    This implements ideal devices update behavior (floating
-    point update).
+    This implements ideal devices forward/backward/update behavior.
     """
 
     def __init__(self,
@@ -74,13 +85,11 @@ class FloatingPointResistiveDevice(BaseResistiveDevice):
         meta_parameter = self._parameters_to_bindings(self.params_devices)
         tile = meta_parameter.create_array(x_size, d_size)
 
-        # Initialize the weights.
-        tile.set_weights_uniform_random(-0.1, 0.1)
         return tile
 
 
-class ConstantStepResistiveDevice(BaseResistiveDevice):
-    r"""ConstantStep resistive devices.
+class PulsedResistiveDevice(BaseResistiveDevice):
+    r"""Pulsed update resistive devices.
 
     Device are used as part of an
     :class:`~aihwkit.simulator.tiles.AnalogTile` to implement the
@@ -88,29 +97,7 @@ class ConstantStepResistiveDevice(BaseResistiveDevice):
     when a single update pulse is given (a coincidence between row and
     column pulse train happened).
 
-    The form implemented for `ConstantStep` is:
-
-    .. math::
-
-       w_{ij}  &\leftarrow&  w_{ij} - \Delta w_{ij}^d(1 + \sigma_\text{c-to-c}\,\xi)
-
-       w_{ij}  &\leftarrow& \text{clip}(w_{ij},b^\text{min}_{ij},b^\text{max}_{ij})
-
-    where :math:`d` is the direction of the update (product of signs
-    of input and error). :math:`\Delta w_{ij}^d` is the update step
-    size of the cross-point `ij` in direction :math:`d` (up or down).
-    Note that each cross-point has separate update sizes so that
-    device-to-device fluctuations and biases in the directions can be
-    given.
-
-    Moreover, the clipping bounds of each cross-point `ij`
-    (i.e. :math:`b_{ij}^\text{max/min}`) are also different in
-    general. The mean and the amount of systematic spread from
-    device-to-device can be given as parameters, see below.
-
-    For parameters regarding the devices settings, see
-    :class:`~aihwkit.simulator.parameters.ConstantStepResistiveDeviceParameters`.
-
+    Common properties of all pulsed devices include:
 
     **Reset**:
 
@@ -148,7 +135,9 @@ class ConstantStepResistiveDevice(BaseResistiveDevice):
     """
 
     def __init__(self,
-                 params_devices: Optional[ConstantStepResistiveDeviceParameters] = None,
+                 params_devices: Optional[Union[AbstractResistiveDeviceParameters,
+                                                List[PulsedResistiveDeviceBaseParameters]
+                                                ]] = None,
                  params_forward: Optional[AnalogTileInputOutputParameters] = None,
                  params_backward: Optional[AnalogTileBackwardInputOutputParameters] = None,
                  params_update: Optional[AnalogTileUpdateParameters] = None
@@ -177,7 +166,407 @@ class ConstantStepResistiveDevice(BaseResistiveDevice):
         devices_parameters = self._parameters_to_bindings(self.params_devices)
         tile = meta_parameter.create_array(x_size, d_size, devices_parameters)
 
-        # Initialize the weights.
-        tile.set_weights_uniform_random(self.params_devices.w_min,
-                                        self.params_devices.w_max)
+        return tile
+
+
+class IdealResistiveDevice(PulsedResistiveDevice):
+    """ Ideal update behavior (floating point reference), however,
+    forward/backward might still have a non-ideal ADC or noise added.
+    """
+    def __init__(self,
+                 params_devices: Optional[IdealResistiveDeviceParameters] = None,
+                 params_forward: Optional[AnalogTileInputOutputParameters] = None,
+                 params_backward: Optional[AnalogTileBackwardInputOutputParameters] = None,
+                 params_update: Optional[AnalogTileUpdateParameters] = None
+                 ):
+        params_update = params_update or AnalogTileUpdateParameters()
+        params_update.pulse_type = PulseType.NONE
+        params_devices = params_devices or IdealResistiveDeviceParameters()
+        super().__init__(params_devices, params_forward, params_backward, params_update)
+
+
+class ConstantStepResistiveDevice(PulsedResistiveDevice):
+    r""" Pulsed update behavioral model, where the update step of
+    material is constant throughout the resistive range (up to hard
+    bounds).
+
+    In mare detail, the update behavior implemented for `ConstantStep`
+    is:
+
+    .. math::
+
+       w_{ij}  &\leftarrow&  w_{ij} - \Delta w_{ij}^d(1 + \sigma_\text{c-to-c}\,\xi)
+
+       w_{ij}  &\leftarrow& \text{clip}(w_{ij},b^\text{min}_{ij},b^\text{max}_{ij})
+
+    where :math:`d` is the direction of the update (product of signs
+    of input and error). :math:`\Delta w_{ij}^d` is the update step
+    size of the cross-point `ij` in direction :math:`d` (up or down).
+    Note that each cross-point has separate update sizes so that
+    device-to-device fluctuations and biases in the directions can be
+    given.
+
+    Moreover, the clipping bounds of each cross-point `ij`
+    (i.e. :math:`b_{ij}^\text{max/min}`) are also different in
+    general. The mean and the amount of systematic spread from
+    device-to-device can be given as parameters, see below.
+
+    For parameters regarding the devices settings, see e.g.
+    :class:`~aihwkit.simulator.parameters.ConstantStepResistiveDeviceParameters`.
+
+    """
+
+    def __init__(self,
+                 params_devices: Optional[ConstantStepResistiveDeviceParameters] = None,
+                 params_forward: Optional[AnalogTileInputOutputParameters] = None,
+                 params_backward: Optional[AnalogTileBackwardInputOutputParameters] = None,
+                 params_update: Optional[AnalogTileUpdateParameters] = None
+                 ):
+        params_devices = params_devices or ConstantStepResistiveDeviceParameters()
+        super().__init__(params_devices, params_forward, params_backward, params_update)
+
+
+class LinearStepResistiveDevice(PulsedResistiveDevice):
+    r""" Pulsed update behavioral model, where the update step response
+    size of the material is linearly dependent with resistance (up to
+    hard bounds).
+
+    This model is very similar to :class:`~ConstantStepResistiveDevice` and thus
+    shares all parameters and functionality. In addition, it only
+    implements a more general `update once` function, where the update
+    step size can depend linearly on the weight itself.
+
+    For each coincidence the weights is updated once. Here, the
+    positive (negative) update step size decreases linearly in the
+    following manner (compare to the `update once` for
+    :class:`~ConstantStepResistiveDevice`):
+
+    .. math::
+       :nowrap:
+
+       \begin{eqnarray*}
+       w_{ij}  &\leftarrow&  w_{ij} - \Delta w_{ij}^d(\gamma_{ij}^d\;w_{ij}
+       + 1 + \sigma_\text{c-to-c}\,\xi)\\
+       w_{ij}  &\leftarrow& \text{clip}(w_{ij},b^\text{min}_{ij},b^\text{max}_{ij})
+       \end{eqnarray*}
+
+
+    in case of additive noise.  Optionally, multiplicative noise can
+    be chosen in which case the first equation becomes:
+
+    .. math::
+
+       w_{ij}  \leftarrow  w_{ij} - \Delta w_{ij}^d (\gamma_{ij}^d \;w_{ij} + 1)
+       (1 + \sigma_\text{c-to-c}\,\xi)
+
+    The cross-point `ij` dependent slope parameter
+    :math:`\gamma_{ij}^d` are given during initialization by
+
+    .. math::
+       :nowrap:
+
+       \begin{eqnarray*}
+       \gamma_{ij}^+ &=& - |\gamma^+ + \gamma_\text{d-to-d}^+ \xi|/b^\text{max}_{ij}\\
+       \gamma_{ij}^- &=& - |\gamma^- + \gamma_\text{d-to-d}^- \xi|/b^\text{min}_{ij}
+       \end{eqnarray*}
+
+    where the :math:`\xi` are standard Gaussian random variables and
+    :math:`b^\text{min}_{ij}` and :math:`b^\text{max}_{ij}` the
+    cross-point `ij` specific minimal and maximal weight bounds,
+    respectively (see description for :class:`~ConstantStepResistiveDevice`).
+
+    Note:
+
+       If :math:`\gamma=1` and :math:`\gamma_\text{d-to-d}=0` this
+       update implements `soft bounds`, since the updates step becomes
+       equal to :math:`1/b`.
+
+    Note:
+
+       If :math:`\gamma=0` and :math:`\gamma_\text{d-to-d}=0` and
+       additive noise, this update is identical to
+       :class:`~ConstantStepResistiveDevice`.
+
+    """
+    def __init__(self,
+                 params_devices: Optional[LinearStepResistiveDeviceParameters] = None,
+                 params_forward: Optional[AnalogTileInputOutputParameters] = None,
+                 params_backward: Optional[AnalogTileBackwardInputOutputParameters] = None,
+                 params_update: Optional[AnalogTileUpdateParameters] = None
+                 ):
+        params_devices = params_devices or LinearStepResistiveDeviceParameters()
+        super().__init__(params_devices, params_forward, params_backward, params_update)
+
+
+class SoftBoundsResistiveDevice(PulsedResistiveDevice):
+    r""" Pulsed update behavioral model, where the update step response size
+    of the material is linearly dependent and at goes to zero at the
+    bound.
+
+    This model is based on :class:`~LinearStepResistiveDevice` with
+    parameters set to model soft bounds.
+
+    """
+    def __init__(self,
+                 params_devices: Optional[SoftBoundsResistiveDeviceParameters] = None,
+                 params_forward: Optional[AnalogTileInputOutputParameters] = None,
+                 params_backward: Optional[AnalogTileBackwardInputOutputParameters] = None,
+                 params_update: Optional[AnalogTileUpdateParameters] = None
+                 ):
+        params_devices = params_devices or SoftBoundsResistiveDeviceParameters()
+        super().__init__(params_devices, params_forward, params_backward, params_update)
+
+
+class ExpStepResistiveDevice(PulsedResistiveDevice):
+    r""" Exponential update step or CMOS-like update behavior.
+
+    This model is derived from RPUPulsed and uses all its
+    parameters. RPUExpStep only implements a new 'update once'
+    functionality, where the minimal weight step change with weight is
+    fitted by an exponential function as detailed below.
+
+    .. math::
+
+        w_{ij}  \leftarrow  w_{ij} -  \max(y_{ij},0)  \Delta w_{ij}^d
+        (1 + \sigma_\text{c-to-c}\,\xi)
+
+    and :math:`y_{ij}` is given as
+
+    .. math::
+        z_{ij} = 2 a_\text{es} \frac{w_{ij}}{b^\text{max}_{ij} - b^\text{min}_{ij}}
+        + b_\text{es}
+
+        y_{ij} = 1 - A^{(d)} e^{d \gamma^{(d)} z_{ij}}
+
+    where :math:`d` is the direction if the update (+ or -), see also
+    :class:`~ConstantStepResistiveDevice` for details.
+
+    All additional parameter (:math:`a_\text{es}`,
+    :math:`b_\text{es}`, :math:`\gamma^{(d)}`, :math:`A^{(d)}` ) are
+    tile-wise fitting parameters (ie. no device-to-device variation in
+    these parameters).  Note that the other parameter involved can be
+    still defined with device-to-device variation and (additional)
+    up-down bias (see :class:`~ConstantStepResistiveDevice`).
+
+    """
+    def __init__(self,
+                 params_devices: Optional[ExpStepResistiveDeviceParameters] = None,
+                 params_forward: Optional[AnalogTileInputOutputParameters] = None,
+                 params_backward: Optional[AnalogTileBackwardInputOutputParameters] = None,
+                 params_update: Optional[AnalogTileUpdateParameters] = None
+                 ):
+        params_devices = params_devices or ExpStepResistiveDeviceParameters()
+        super().__init__(params_devices, params_forward, params_backward, params_update)
+
+
+class VectorUnitCell(PulsedResistiveDevice):
+    """ An abstract resistive device that combines multiple pulsed resistive
+    devices in a single 'unit cell'.
+
+    For instance, a vector device can consist of 2 resistive devices
+    where the sum of the two resistive values are coded for each
+    weight of a cross point.
+
+    Parameters:
+       params_devices: List of pulsed resistive device parameters
+       params_forward: Parameters governing the forward pass
+       params_backward: Parameters governing the backward pass
+       params_update: Parameters governing update pulse selection etc.
+
+       **vector_kwargs: args that we be passed to
+         class:`~aihwkit.simulator.parameters.VectorUnitCellParameters`
+
+    """
+    def __init__(self,
+                 params_devices: Optional[List[PulsedResistiveDeviceBaseParameters]] = None,
+                 params_forward: Optional[AnalogTileInputOutputParameters] = None,
+                 params_backward: Optional[AnalogTileBackwardInputOutputParameters] = None,
+                 params_update: Optional[AnalogTileUpdateParameters] = None,
+                 **vector_kwargs: Any
+                 ):
+
+        self.params_vector = VectorUnitCellParameters(**vector_kwargs)
+
+        super().__init__(params_devices, params_forward, params_backward, params_update)
+
+    def create_tile(self, x_size: int, d_size: int) -> AnalogTile:
+        """Returns an analog tile of the specified dimensions.
+
+        Args:
+            x_size: number of rows.
+            d_size: number of columns.
+        """
+        # Prepare the basic parameters.
+        meta_parameter = self.params.bindings_class()
+        meta_parameter.forward_io = self._parameters_to_bindings(self.params.forward_io)
+        meta_parameter.backward_io = self._parameters_to_bindings(self.params.backward_io)
+        meta_parameter.update = self._parameters_to_bindings(self.params.update)
+
+        # Create the tile.
+        if not isinstance(self.params_devices, list):
+            raise ValueError('Expect a list of device parameters')
+
+        vector_parameters = self._parameters_to_bindings(self.params_vector)
+
+        for param in self.params_devices:
+            device_parameters = self._parameters_to_bindings(param)
+            vector_parameters.append_parameter(device_parameters)
+
+        tile = meta_parameter.create_array(x_size, d_size, vector_parameters)
+
+        return tile
+
+
+class DifferenceUnitCell(PulsedResistiveDevice):
+    """ This device model takes an arbitrary device per crosspoint and
+    implements an explicit plus-minus device pair.
+
+    A plus minus pair is implemented by using only one-sided updated
+    of the given devices. Note that reset might need to be called
+    otherwise the one-sided device quickly saturates during learning.
+
+    The output current is the difference of both devices
+
+    Meta parameter setting of the pairs are assumed to be identical
+    (however, device-to-device variation is still present).
+
+    Caution:
+
+       Reset needs to be added `manually` by calling the
+       reset_columns method of a tile.
+
+    """
+    def __init__(self,
+                 params_devices: Optional[PulsedResistiveDeviceBaseParameters] = None,
+                 params_forward: Optional[AnalogTileInputOutputParameters] = None,
+                 params_backward: Optional[AnalogTileBackwardInputOutputParameters] = None,
+                 params_update: Optional[AnalogTileUpdateParameters] = None
+                 ):
+        super().__init__(params_devices, params_forward, params_backward, params_update)
+
+    def create_tile(self, x_size: int, d_size: int) -> AnalogTile:
+        """Returns an analog tile of the specified dimensions.
+
+        Args:
+            x_size: number of rows.
+            d_size: number of columns.
+        """
+        # Prepare the basic parameters.
+        meta_parameter = self.params.bindings_class()
+        meta_parameter.forward_io = self._parameters_to_bindings(self.params.forward_io)
+        meta_parameter.backward_io = self._parameters_to_bindings(self.params.backward_io)
+        meta_parameter.update = self._parameters_to_bindings(self.params.update)
+
+        difference_parameters = self._parameters_to_bindings(DifferenceUnitCellParameters())
+        device_parameters = self._parameters_to_bindings(self.params_devices)
+
+        # need to be exactly 2 and same parameters
+        difference_parameters.append_parameter(device_parameters)
+        difference_parameters.append_parameter(device_parameters)
+
+        tile = meta_parameter.create_array(x_size, d_size, difference_parameters)
+
+        return tile
+
+
+class TransferUnitCell(PulsedResistiveDevice):
+    r""" This abstract device model takes 2 or more devices per crosspoint and
+    implements a 'transfer' based learning rule.
+
+    It uses a (partly) hidden weight (where the SGD update is
+    accumulated), which then is transferred partly and occasionally to
+    the visible weight.
+
+    The rate of transfer (e.g. learning rate and how often and how
+    many columns per transfer) and the type (ie. with ADC or without,
+    with noise etc.) can be adjusted.
+
+    The weight that is seen in the forward and backward pass is
+    governed by the :math:`\gamma` weightening setting.
+
+    In principle, a deeper chain of transferred weights can be setup,
+    however, only the device parameters of the first versus the others
+    can be different.
+
+
+
+    Parameters:
+       params_devices: List of pulsed resistive device parameters
+
+          Note:
+
+              This has to be a list, where the length of the list is
+              the length of the chain of devices to transfer
+              to. However, for all resistive devices that are
+              transferred two (all except the first) the device
+              parameter are taken to be the same (copied from the
+              second in this list)
+
+       params_forward: Parameters governing the forward pass
+       params_backward: Parameters governing the backward pass
+       params_update: Parameters governing update pulse selection etc. of the SGD update
+
+       params_transfer_update: Parameters governing the update when doing the transfer
+
+       params_transfer_forward: Parameters governing the forward when
+          doing the read-out for the transfer
+
+       **transfer_kwargs: additional args that we be passed to
+         class:`~aihwkit.simulator.parameters.TransferUnitCellParameters`
+
+    """
+    def __init__(self,
+                 params_devices: Optional[List[PulsedResistiveDeviceBaseParameters]] = None,
+                 params_forward: Optional[AnalogTileInputOutputParameters] = None,
+                 params_backward: Optional[AnalogTileBackwardInputOutputParameters] = None,
+                 params_update: Optional[AnalogTileUpdateParameters] = None,
+                 params_transfer_forward: Optional[AnalogTileInputOutputParameters] = None,
+                 params_transfer_update: Optional[AnalogTileUpdateParameters] = None,
+                 **transfer_kwargs: Any
+                 ):
+
+        transfer_forward = params_transfer_forward or params_forward or \
+                           AnalogTileInputOutputParameters()
+
+        transfer_up = params_transfer_update or params_update or AnalogTileUpdateParameters()
+
+        self.transfer_params = TransferUnitCellParameters(**transfer_kwargs)
+        self.transfer_params.params_transfer_update = transfer_up
+        self.transfer_params.params_transfer_forward = transfer_forward
+
+        super().__init__(params_devices, params_forward, params_backward, params_update)
+
+    def create_tile(self, x_size: int, d_size: int) -> AnalogTile:
+        """Returns an analog tile of the specified dimensions.
+
+        Args:
+            x_size: number of rows.
+            d_size: number of columns.
+        """
+        # Prepare the basic parameters.
+        meta_parameter = self.params.bindings_class()
+        meta_parameter.forward_io = self._parameters_to_bindings(self.params.forward_io)
+        meta_parameter.backward_io = self._parameters_to_bindings(self.params.backward_io)
+        meta_parameter.update = self._parameters_to_bindings(self.params.update)
+
+        # Create the tile.
+        if not isinstance(self.params_devices, list):
+            raise ValueError('Expect a list of device parameters!')
+
+        transfer_parameters = self._parameters_to_bindings(self.transfer_params)
+
+        n_devices = len(self.params_devices)
+        if n_devices < 2:
+            raise RuntimeError('Expect at least 2 device parameters!')
+
+        param_fast = self._parameters_to_bindings(self.params_devices[0])
+        param_slow = self._parameters_to_bindings(self.params_devices[1])
+
+        transfer_parameters.append_parameter(param_fast)
+
+        for _ in range(n_devices-1):
+            transfer_parameters.append_parameter(param_slow)
+
+        tile = meta_parameter.create_array(x_size, d_size, transfer_parameters)
+
         return tile

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base.h
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base.h
@@ -11,8 +11,14 @@
  */
 #pragma once
 #include "rpu.h"
-#include "rpu_constantstep_device.h"
 #include "rpu_pulsed.h"
+#include "rpu_simple_device.h"
+#include "rpu_constantstep_device.h"
+#include "rpu_difference_device.h"
+#include "rpu_expstep_device.h"
+#include "rpu_linearstep_device.h"
+#include "rpu_transfer_device.h"
+#include "rpu_vector_device.h"
 
 #ifdef RPU_USE_CUDA
 #include "cuda_util.h"

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -15,8 +15,16 @@
 void declare_rpu_devices(py::module &m) {
 
   using AbstractParam = RPU::AbstractRPUDeviceMetaParameter<T>;
+  using SimpleParam = RPU::SimpleRPUDeviceMetaParameter<T>;
+  using PulsedBaseParam = RPU::PulsedRPUDeviceMetaParameterBase<T>;
   using PulsedParam = RPU::PulsedRPUDeviceMetaParameter<T>;
   using ConstantStepParam = RPU::ConstantStepRPUDeviceMetaParameter<T>;
+  using LinearStepParam = RPU::LinearStepRPUDeviceMetaParameter<T>;
+  using SoftBoundsParam = RPU::SoftBoundsRPUDeviceMetaParameter<T>;
+  using ExpStepParam = RPU::ExpStepRPUDeviceMetaParameter<T>;
+  using VectorParam = RPU::VectorRPUDeviceMetaParameter<T>;
+  using DifferenceParam = RPU::DifferenceRPUDeviceMetaParameter<T>;
+  using TransferParam = RPU::TransferRPUDeviceMetaParameter<T>;
 
   /*
    * Trampoline classes for allowing inheritance.
@@ -36,6 +44,42 @@ void declare_rpu_devices(py::module &m) {
     createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
       PYBIND11_OVERLOAD_PURE(
           RPU::AbstractRPUDevice<T> *, AbstractParam, createDevice, x_size, d_size, rng);
+    }
+  };
+  class PySimpleParam : public SimpleParam {
+  public:
+    std::string getName() const override {
+      PYBIND11_OVERLOAD_PURE(std::string, SimpleParam, getName, );
+    }
+    SimpleParam *clone() const override {
+      PYBIND11_OVERLOAD_PURE(SimpleParam *, SimpleParam, clone, );
+    }
+    RPU::DeviceUpdateType implements() const override {
+      PYBIND11_OVERLOAD_PURE(RPU::DeviceUpdateType, SimpleParam, implements, );
+    }
+    RPU::SimpleRPUDevice<T> *
+    createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
+      PYBIND11_OVERLOAD_PURE(
+          RPU::SimpleRPUDevice<T> *, SimpleParam, createDevice, x_size, d_size, rng);
+    }
+  };
+
+  
+  class PyPulsedBaseParam : public PulsedBaseParam {
+  public:
+    std::string getName() const override {
+      PYBIND11_OVERLOAD_PURE(std::string, PulsedBaseParam, getName, );
+    }
+    PulsedBaseParam *clone() const override {
+      PYBIND11_OVERLOAD_PURE(PulsedBaseParam *, PulsedBaseParam, clone, );
+    }
+    RPU::DeviceUpdateType implements() const override {
+      PYBIND11_OVERLOAD_PURE(RPU::DeviceUpdateType, PulsedBaseParam, implements, );
+    }
+    RPU::PulsedRPUDeviceBase<T> *
+    createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
+      PYBIND11_OVERLOAD_PURE(
+          RPU::PulsedRPUDeviceBase<T> *, PulsedBaseParam, createDevice, x_size, d_size, rng);
     }
   };
 
@@ -73,6 +117,101 @@ void declare_rpu_devices(py::module &m) {
     }
   };
 
+  class PyLinearStepParam : public LinearStepParam {
+  public:
+    std::string getName() const override {
+      PYBIND11_OVERLOAD(std::string, LinearStepParam, getName, );
+    }
+    LinearStepParam *clone() const override {
+      PYBIND11_OVERLOAD(LinearStepParam *, LinearStepParam, clone, );
+    }
+    RPU::DeviceUpdateType implements() const override {
+      PYBIND11_OVERLOAD(RPU::DeviceUpdateType, LinearStepParam, implements, );
+    }
+    RPU::LinearStepRPUDevice<T> *
+    createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
+      PYBIND11_OVERLOAD(
+          RPU::LinearStepRPUDevice<T> *, LinearStepParam, createDevice, x_size, d_size, rng);
+    }
+  };
+
+  class PySoftBoundsParam : public SoftBoundsParam {
+  public:
+    std::string getName() const override {
+      PYBIND11_OVERLOAD(std::string, SoftBoundsParam, getName, );
+    }
+    SoftBoundsParam *clone() const override {
+      PYBIND11_OVERLOAD(SoftBoundsParam *, SoftBoundsParam, clone, );
+    }
+  };
+
+  class PyExpStepParam : public ExpStepParam {
+  public:
+    std::string getName() const override {
+      PYBIND11_OVERLOAD(std::string, ExpStepParam, getName, );
+    }
+    ExpStepParam *clone() const override {
+      PYBIND11_OVERLOAD(ExpStepParam *, ExpStepParam, clone, );
+    }
+    RPU::DeviceUpdateType implements() const override {
+      PYBIND11_OVERLOAD(RPU::DeviceUpdateType, ExpStepParam, implements, );
+    }
+    RPU::ExpStepRPUDevice<T> *
+    createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
+      PYBIND11_OVERLOAD(
+          RPU::ExpStepRPUDevice<T> *, ExpStepParam, createDevice, x_size, d_size, rng);
+    }
+  };
+
+  class PyVectorParam : public VectorParam {
+  public:
+    std::string getName() const override { PYBIND11_OVERLOAD(std::string, VectorParam, getName, ); }
+    VectorParam *clone() const override { PYBIND11_OVERLOAD(VectorParam *, VectorParam, clone, ); }
+    RPU::DeviceUpdateType implements() const override {
+      PYBIND11_OVERLOAD(RPU::DeviceUpdateType, VectorParam, implements, );
+    }
+    RPU::VectorRPUDevice<T> *
+    createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
+      PYBIND11_OVERLOAD(RPU::VectorRPUDevice<T> *, VectorParam, createDevice, x_size, d_size, rng);
+    }
+  };
+
+  class PyDifferenceParam : public DifferenceParam {
+  public:
+    std::string getName() const override {
+      PYBIND11_OVERLOAD(std::string, DifferenceParam, getName, );
+    }
+    DifferenceParam *clone() const override {
+      PYBIND11_OVERLOAD(DifferenceParam *, DifferenceParam, clone, );
+    }
+    RPU::DeviceUpdateType implements() const override {
+      PYBIND11_OVERLOAD(RPU::DeviceUpdateType, DifferenceParam, implements, );
+    }
+    RPU::DifferenceRPUDevice<T> *
+    createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
+      PYBIND11_OVERLOAD(
+          RPU::DifferenceRPUDevice<T> *, DifferenceParam, createDevice, x_size, d_size, rng);
+    }
+  };
+
+  class PyTransferParam : public TransferParam {
+  public:
+    std::string getName() const override {
+      PYBIND11_OVERLOAD(std::string, TransferParam, getName, );
+    }
+    TransferParam *clone() const override {
+      PYBIND11_OVERLOAD(TransferParam *, TransferParam, clone, );
+    }
+    RPU::DeviceUpdateType implements() const override {
+      PYBIND11_OVERLOAD(RPU::DeviceUpdateType, TransferParam, implements, );
+    }
+    RPU::TransferRPUDevice<T> *
+    createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
+      PYBIND11_OVERLOAD(
+          RPU::TransferRPUDevice<T> *, TransferParam, createDevice, x_size, d_size, rng);
+    }
+  };
+
   /*
    * Python class definitions.
    */
@@ -95,10 +234,8 @@ void declare_rpu_devices(py::module &m) {
   py::class_<RPU::PulsedMetaParameter<T>>(m, "AnalogTileParameter")
       .def(py::init<>())
       .def(
-          "create_array",
-          [](RPU::PulsedMetaParameter<T> &self, int n_cols, int n_rows, ConstantStepParam *dp) {
-            return self.createRPUArray(n_cols, n_rows, dp);
-          })
+          "create_array", [](RPU::PulsedMetaParameter<T> &self, int n_cols, int n_rows,
+                             AbstractParam *dp) { return self.createRPUArray(n_cols, n_rows, dp); })
       .def(
           "__str__",
           [](RPU::PulsedMetaParameter<T> &self) {
@@ -109,36 +246,6 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("forward_io", &RPU::PulsedMetaParameter<T>::f_io)
       .def_readwrite("backward_io", &RPU::PulsedMetaParameter<T>::b_io)
       .def_readwrite("update", &RPU::PulsedMetaParameter<T>::up);
-
-  py::class_<AbstractParam, PyAbstractParam, RPU::SimpleMetaParameter<T>>(
-      m, "AbstractResistiveDevicesParameter")
-      .def(py::init<>());
-
-  py::class_<PulsedParam, PyPulsedParam, AbstractParam>(m, "PulsedResistiveDeviceParameter")
-      .def(py::init<>())
-      // Properties from this class.
-      .def_readwrite("corrupt_devices_prob", &PulsedParam::corrupt_devices_prob)
-      .def_readwrite("corrupt_devices_range", &PulsedParam::corrupt_devices_range)
-      .def_readwrite("diffusion_dtod", &PulsedParam::diffusion_dtod)
-      .def_readwrite("dw_min", &PulsedParam::dw_min)
-      .def_readwrite("dw_min_dtod", &PulsedParam::dw_min_dtod)
-      .def_readwrite("dw_min_std", &PulsedParam::dw_min_std)
-      .def_readwrite("enforce_consistency", &PulsedParam::enforce_consistency)
-      .def_readwrite("lifetime_dtod", &PulsedParam::lifetime_dtod)
-      .def_readwrite("perfect_bias", &PulsedParam::perfect_bias)
-      .def_readwrite("reset", &PulsedParam::reset)
-      .def_readwrite("reset_dtod", &PulsedParam::reset_dtod)
-      .def_readwrite("reset_std", &PulsedParam::reset_std)
-      .def_readwrite("up_down", &PulsedParam::up_down)
-      .def_readwrite("up_down_dtod", &PulsedParam::up_down_dtod)
-      .def_readwrite("w_max", &PulsedParam::w_max)
-      .def_readwrite("w_max_dtod", &PulsedParam::w_max_dtod)
-      .def_readwrite("w_min", &PulsedParam::w_min)
-      .def_readwrite("w_min_dtod", &PulsedParam::w_min_dtod);
-
-  py::class_<ConstantStepParam, PyConstantStepParam, PulsedParam>(
-      m, "ConstantStepResistiveDeviceParameter")
-      .def(py::init<>());
 
   py::class_<RPU::PulsedUpdateMetaParameter<T>>(m, "AnalogTileUpdateParameter")
       .def(py::init<>())
@@ -171,6 +278,107 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("out_sto_round", &RPU::IOMetaParameter<T>::out_sto_round)
       .def_readwrite("w_noise", &RPU::IOMetaParameter<T>::w_noise)
       .def_readwrite("w_noise_type", &RPU::IOMetaParameter<T>::w_noise_type);
+
+  // device params
+  py::class_<AbstractParam, PyAbstractParam, RPU::SimpleMetaParameter<T>>(
+      m, "AbstractResistiveDeviceParameter")
+      .def(py::init<>())
+      .def_readwrite("construction_seed", &AbstractParam::construction_seed);
+
+  py::class_<PulsedBaseParam, PyPulsedBaseParam, AbstractParam>(
+      m, "PulsedBaseResistiveDeviceParameter")
+      .def(py::init<>());
+
+  py::class_<SimpleParam, PySimpleParam, AbstractParam>(
+      m, "IdealResistiveDeviceParameter")
+      .def(py::init<>());
+  
+  py::class_<PulsedParam, PyPulsedParam, AbstractParam>(m, "PulsedResistiveDeviceParameter")
+      .def(py::init<>())
+      // Properties from this class.
+      .def_readwrite("corrupt_devices_prob", &PulsedParam::corrupt_devices_prob)
+      .def_readwrite("corrupt_devices_range", &PulsedParam::corrupt_devices_range)
+      .def_readwrite("diffusion_dtod", &PulsedParam::diffusion_dtod)
+      .def_readwrite("dw_min", &PulsedParam::dw_min)
+      .def_readwrite("dw_min_dtod", &PulsedParam::dw_min_dtod)
+      .def_readwrite("dw_min_std", &PulsedParam::dw_min_std)
+      .def_readwrite("enforce_consistency", &PulsedParam::enforce_consistency)
+      .def_readwrite("lifetime_dtod", &PulsedParam::lifetime_dtod)
+      .def_readwrite("perfect_bias", &PulsedParam::perfect_bias)
+      .def_readwrite("reset", &PulsedParam::reset)
+      .def_readwrite("reset_dtod", &PulsedParam::reset_dtod)
+      .def_readwrite("reset_std", &PulsedParam::reset_std)
+      .def_readwrite("up_down", &PulsedParam::up_down)
+      .def_readwrite("up_down_dtod", &PulsedParam::up_down_dtod)
+      .def_readwrite("w_max", &PulsedParam::w_max)
+      .def_readwrite("w_max_dtod", &PulsedParam::w_max_dtod)
+      .def_readwrite("w_min", &PulsedParam::w_min)
+      .def_readwrite("w_min_dtod", &PulsedParam::w_min_dtod);
+
+  py::class_<ConstantStepParam, PyConstantStepParam, PulsedParam>(
+      m, "ConstantStepResistiveDeviceParameter")
+      .def(py::init<>());
+
+  py::class_<LinearStepParam, PyLinearStepParam, PulsedParam>(
+      m, "LinearStepResistiveDeviceParameter")
+      .def(py::init<>())
+      .def_readwrite("gamma_up", &LinearStepParam::ls_decrease_up)
+      .def_readwrite("gamma_down", &LinearStepParam::ls_decrease_down)
+      .def_readwrite("gamma_up_dtod", &LinearStepParam::ls_decrease_up_dtod)
+      .def_readwrite("gamma_down_dtod", &LinearStepParam::ls_decrease_down_dtod)
+      .def_readwrite("allow_increasing", &LinearStepParam::ls_allow_increasing_slope)
+      .def_readwrite("mean_bound_reference", &LinearStepParam::ls_mean_bound_reference)
+      .def_readwrite("mult_noise", &LinearStepParam::ls_mult_noise);
+
+  py::class_<SoftBoundsParam, PySoftBoundsParam, PulsedParam>(
+      m, "SoftBoundsResistiveDeviceParameter")
+      .def_readwrite("mult_noise", &SoftBoundsParam::ls_mult_noise)
+      .def(py::init<>());
+
+  py::class_<ExpStepParam, PyExpStepParam, PulsedParam>(m, "ExpStepResistiveDeviceParameter")
+      .def(py::init<>())
+      .def_readwrite("A_up", &ExpStepParam::es_A_up)
+      .def_readwrite("A_down", &ExpStepParam::es_A_down)
+      .def_readwrite("gamma_up", &ExpStepParam::es_gamma_up)
+      .def_readwrite("gamma_down", &ExpStepParam::es_gamma_down)
+      .def_readwrite("a", &ExpStepParam::es_a)
+      .def_readwrite("b", &ExpStepParam::es_b);
+
+  py::class_<VectorParam, PyVectorParam, PulsedBaseParam>(m, "VectorResistiveDeviceParameter")
+      .def(py::init<>())
+      .def_readwrite("single_device_update", &VectorParam::single_device_update)
+      .def_readwrite("single_device_update_random", &VectorParam::single_device_update_random)
+      .def(
+          "append_parameter",
+          [](VectorParam &self, RPU::AbstractRPUDeviceMetaParameter<T> &dp) {
+            return self.appendVecPar(dp.clone());
+          },
+          py::arg("parameter"),
+          R"pbdoc(
+           Adds a pulsed base device parameter to the vector device.
+           )pbdoc");
+
+  py::class_<DifferenceParam, PyDifferenceParam, VectorParam>(
+      m, "DifferenceResistiveDeviceParameter")
+      .def(py::init<>());
+
+  py::class_<TransferParam, PyTransferParam, VectorParam>(m, "TransferResistiveDeviceParameter")
+      .def(py::init<>())
+      .def_readwrite("gamma", &TransferParam::gamma)
+      .def_readwrite("gamma_vec", &TransferParam::gamma_vec)
+      .def_readwrite("transfer_every", &TransferParam::transfer_every)
+      .def_readwrite("no_self_transfer", &TransferParam::no_self_transfer)
+      .def_readwrite(
+          "transfer_every_vec", &TransferParam::transfer_every_vec) // can this be filled?
+      .def_readwrite("units_in_mbatch", &TransferParam::units_in_mbatch)
+      .def_readwrite("n_cols_per_transfer", &TransferParam::n_cols_per_transfer)
+      .def_readwrite("with_reset_prob", &TransferParam::with_reset_prob)
+      .def_readwrite("random_column", &TransferParam::random_column)
+      .def_readwrite("transfer_lr", &TransferParam::transfer_lr)
+      .def_readwrite("transfer_lr_vec", &TransferParam::transfer_lr_vec)
+      .def_readwrite("scale_transfer_lr", &TransferParam::scale_transfer_lr)
+      .def_readwrite("params_transfer_forward", &TransferParam::transfer_io)
+      .def_readwrite("params_transfer_update", &TransferParam::transfer_up);
 
   /**
    * Helper enums.

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
@@ -405,6 +405,23 @@ void declare_rpu_tiles(py::module &m) {
                bias_no_decay: Whether to not decay the bias row
            )pbdoc")
       .def(
+          "reset_columns",
+          [](Class &self, int start_col, int n_cols, T reset_prob) {
+            return self.resetCols(start_col, n_cols, reset_prob);
+          },
+          py::arg("start_column_idx") = 0, py::arg("num_columns") = 1, py::arg("reset_prob") = 1.0,
+          R"pbdoc(
+           Resets the weights with device-to-device and cycle-to-cycle
+           variability (depending on device type), typically::
+
+              W_ij = xi*reset_std + reset_bias_ij
+
+           Args:
+               start_col: a start index of columns (0..x_size-1)
+               n_col: how many consecutive columns to reset (with circular warping)
+               reset_prob: individial probability of reset.
+           )pbdoc")
+      .def(
           "forward",
           [](Class &self, const torch::Tensor &x_input_, bool bias = false, bool x_trans = false,
              bool d_trans = false, bool is_test = false) {
@@ -615,10 +632,10 @@ void declare_rpu_tiles(py::module &m) {
           R"pbdoc(
            Compute the dot product using an index matrix (forward pass).
 
-           Caution: 
+           Caution:
                Internal use for convolutions only.
 
-           Args: 
+           Args:
                x_input: 4D torch::tensor in order N,C,H,W
                d_height: height of output image(s)
                d_width: width of output image(s)
@@ -649,10 +666,10 @@ void declare_rpu_tiles(py::module &m) {
           R"pbdoc(
            Compute the dot product using an index matrix (backward pass).
 
-           Caution: 
+           Caution:
                Internal use for convolutions only.
 
-           Args: 
+           Args:
                d_input: 4D torch::tensor in order N,C,H,W
                x_channel: number of grad_input channels
                x_height: height of grad_input image(s)
@@ -685,7 +702,7 @@ void declare_rpu_tiles(py::module &m) {
            Caution:
                Internal use for convolutions only.
 
-           Args: 
+           Args:
                x_input: 4D torch::tensor input in order N,C,H,W
                d_input: 4D torch::tensor (grad_output) in order N,C,oH,oW
            )pbdoc")
@@ -699,10 +716,10 @@ void declare_rpu_tiles(py::module &m) {
           R"pbdoc(
            Sets the index vector for the ``*_indexed`` functionality.
 
-           Caution: 
+           Caution:
                Internal use only.
 
-           Args: 
+           Args:
                indices: int torch::Tensor
           )pbdoc")
       .def(

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles_cuda.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles_cuda.cpp
@@ -361,7 +361,7 @@ void declare_rpu_tiles_cuda(py::module &m) {
     )pbdoc")
       .def(
           py::init([](RPU::RPUPulsed<T> &rpu) {
-            // TODO: why does directly passing a stream gets
+            // TODO: why does directly passing a stream is a problem?
             return std::unique_ptr<ClassPulsed>(
                 new ClassPulsed(at::cuda::getCurrentCUDAStream(), rpu));
           }),

--- a/src/rpucuda/cuda/rpucuda.h
+++ b/src/rpucuda/cuda/rpucuda.h
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include "cuda_util.h"
 #include "cuda_math_util.h"
+#include "cuda_util.h"
 #include "io_iterator.h"
 #include "rng.h"
 #include "rpu.h"

--- a/src/rpucuda/rpu_transfer_device.h
+++ b/src/rpucuda/rpu_transfer_device.h
@@ -61,7 +61,7 @@ template <typename T> struct TransferRPUDeviceMetaParameter : VectorRPUDeviceMet
   bool units_in_mbatch = false;
   int n_cols_per_transfer = 1;
   T with_reset_prob = (T)0.0;
-  bool no_self_transfer = false;
+  bool no_self_transfer = true;
   bool random_column = false;
 
   T transfer_lr = (T)1.0;


### PR DESCRIPTION
## Related issues

addresses #6 

## Description

Exposes all the resistive devices in the RPUCUDA library to the pytorch level. These resistive devices include:
* IdealResistiveDevice (FP update, but potentially with output noise,  ADC, etc in forward/backward)
* LinearStep (linear dependence of update step with current resistive value)
* SoftBounds (saturating bounds, e.g. used for RRAM-like devices)
* ExpStep (exponential model, similar to CMOS)
* VectorUnitCell (abstract model that combines n arbitrary devices per crosspoint, where the output is the sum of all,  and update is done together or in sequence)
* TransferUnitCell (abstract model that implements learning with sparse and partial transfer (forward read + update) events from one device to another, and can be used to implement analog hardware friendly momentum-like learning rules, e.g. the "Tiki-taka" learning rule see  https://www.frontiersin.org/articles/10.3389/fnins.2020.00103/full )
* DifferenceUnitCell (abstract device model that combines a pair of arbitrary devices and uses them as a plus - minus pair with one sided updates)

