### PR TITLE
Make cuda tiles init based on existing tile

### DIFF
--- a/src/aihwkit/simulator/tiles_indexed.py
+++ b/src/aihwkit/simulator/tiles_indexed.py
@@ -222,7 +222,7 @@ class CudaIndexedFloatingPointTile(IndexedFloatingPointTile):
 
     is_cuda = True
 
-    def __init__(self, source_tile: FloatingPointTile):
+    def __init__(self, source_tile: IndexedFloatingPointTile):
         if not cuda.is_compiled():
             raise RuntimeError('aihwkit has not been compiled with CUDA support')
 


### PR DESCRIPTION
## Related issues

#6

## Description

Follow-up to #14 

Make the the `CudaXTile` instantiation always based on an existing `XTile` which is passed as the only parameter to `__init__`. This prevents isolated creation of cuda-tiles, but simplifies the codebase and avoids the creation of a temporary simulator tile.

## Details

<!-- A more elaborate description of the changes, if needed. -->
