### PR TITLE
Add decorators for parametrized tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -344,7 +344,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=
+generated-members=get_layer,get_tile,get_resistive_device,bias
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ job_compile_common: &job_compile_common
     - cd ../..
     - VERBOSE=1 pip install -v -e .
   script:
+    - pip install "parameterized==0.7.4"
     - make pytest
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ mypy==0.782
 pycodestyle==2.6.0
 pylint==2.5.3
 pytest==5.4.3
+parameterized==0.7.4

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Helpers for aihwkit tests."""

--- a/tests/helpers/decorators.py
+++ b/tests/helpers/decorators.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Decorators for aihwkit tests."""
+
+from itertools import product
+from typing import List
+
+from parameterized import parameterized_class
+
+
+def parametrize_over_tiles(tiles: List):
+    """Parametrize a TestCase over different kind of tiles.
+
+    Args:
+        tiles: list of tile descriptions. The ``TestCase`` will be repeated
+            for each of the entries in the list.
+    """
+
+    def object_to_dict(obj):
+        """Convert the public members of an object to a dictionary."""
+        ret = {key: value for key, value in vars(obj).items()
+               if not key.startswith('_')}
+        ret['parameter'] = obj.__name__
+
+        return ret
+
+    def class_name(cls, _, params_dict):
+        """Return a user-friendly name for a parametrized test."""
+        return '{}_{}'.format(cls.__name__, params_dict['parameter'])
+
+    return parameterized_class([object_to_dict(tile) for tile in tiles],
+                               class_name_func=class_name)
+
+
+def parametrize_over_layers(layers: List, tiles: List, biases: List):
+    """Parametrize a TestCase over different kind of layers.
+
+    The ``TestCase`` will be repeated for each combination of
+    `layer`, `tile` and `bias`.
+
+    Args:
+        layers: list of layer descriptions.
+        tiles: list of tile descriptions.
+        biases: list of bias values.
+    """
+
+    def object_to_dict(layer, tile, bias):
+        """Convert the public members of an object to a dictionary."""
+        ret = {key: value for key, value in vars(layer).items()
+               if not key.startswith('_')}
+        ret['parameter'] = '{}_{}_{}'.format(layer.__name__,
+                                             tile.__name__,
+                                             'Bias' if bias else 'NoBias')
+        ret['get_resistive_device'] = tile.get_resistive_device
+        ret['bias'] = bias
+
+        return ret
+
+    def class_name(cls, _, params_dict):
+        """Return a user-friendly name for a parametrized test."""
+        return '{}_{}'.format(cls.__name__, params_dict['parameter'])
+
+    return parameterized_class(
+        [object_to_dict(layer, tile, bias) for
+         layer, tile, bias in product(layers, tiles, biases)],
+        class_name_func=class_name)

--- a/tests/helpers/layers.py
+++ b/tests/helpers/layers.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-function-docstring,too-few-public-methods
+
+"""Layer helpers for aihwkit tests."""
+
+from aihwkit.nn import AnalogConv2d, AnalogLinear
+
+
+class Linear:
+    """AnalogLinear."""
+
+    use_cuda = False
+
+    def get_layer(self, in_features=3, out_features=4, **kwargs):
+        kwargs.setdefault('resistive_device', self.get_resistive_device())
+        kwargs.setdefault('bias', self.bias)
+
+        return AnalogLinear(in_features, out_features, **kwargs)
+
+
+class Conv2d:
+    """AnalogConv2d."""
+
+    use_cuda = False
+
+    def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
+        kwargs.setdefault('resistive_device', self.get_resistive_device())
+        kwargs.setdefault('bias', self.bias)
+
+        return AnalogConv2d(in_channels, out_channels, kernel_size,
+                            padding=padding,
+                            **kwargs)
+
+
+class LinearCuda:
+    """AnalogLinear."""
+
+    use_cuda = True
+
+    def get_layer(self, in_features=3, out_features=4, **kwargs):
+        kwargs.setdefault('resistive_device', self.get_resistive_device())
+        kwargs.setdefault('bias', self.bias)
+
+        return AnalogLinear(in_features, out_features, **kwargs).cuda()
+
+
+class Conv2dCuda:
+    """AnalogConv2d."""
+
+    use_cuda = True
+
+    def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
+        kwargs.setdefault('resistive_device', self.get_resistive_device())
+        kwargs.setdefault('bias', self.bias)
+
+        return AnalogConv2d(in_channels, out_channels, kernel_size,
+                            padding=padding,
+                            **kwargs).cuda()

--- a/tests/helpers/testcases.py
+++ b/tests/helpers/testcases.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""TestCases for aihwkit tests."""
+
+from typing import Type
+from unittest import SkipTest, TestCase
+
+from numpy.testing import assert_array_almost_equal, assert_raises
+
+from aihwkit.simulator.rpu_base import cuda
+
+
+class ParametrizedTestCase(TestCase):
+    """Test case that is parametrized using aihwkit test decorators.
+
+    Base class for aihwkit parametrized tests. This base class should be used
+    in combination with the decorators in the ``.decorators`` package
+    (``@parametrize_over_tiles``, ``@parametrize_over_layers``).
+
+    The decorators will set the class attributes and methods accordingly at
+    runtime for each parametrized test.
+    """
+
+    use_cuda: bool = False
+    """Determines if the test case requires CUDA support."""
+
+    simulator_tile_class: Type = None
+    """rpu_base tile class that is expected to be used internally in this test."""
+
+    first_hidden_field: str = ''
+    """First of the hidden fields to check during hidden parameters."""
+
+    bias: bool = False
+    """If True, the tiles and layer in this test will use bias."""
+
+    parameter: str = ''
+    """Friendly name of the parameters used in this test."""
+
+    def setUp(self) -> None:
+        if self.use_cuda and not cuda.is_compiled():
+            raise SkipTest('not compiled with CUDA support')
+
+        super().setUp()
+
+    # Custom asserts.
+
+    def assertTensorAlmostEqual(self, tensor_a, tensor_b):
+        """Assert that two tensors are almost equal."""
+        # pylint: disable=invalid-name
+        array_a = tensor_a.detach().cpu().numpy()
+        array_b = tensor_b.detach().cpu().numpy()
+        assert_array_almost_equal(array_a, array_b)
+
+    def assertNotAlmostEqualTensor(self, tensor_a, tensor_b):
+        """Assert that two tensors are not equal."""
+        # pylint: disable=invalid-name
+        assert_raises(AssertionError, self.assertTensorAlmostEqual, tensor_a, tensor_b)

--- a/tests/helpers/tiles.py
+++ b/tests/helpers/tiles.py
@@ -1,0 +1,325 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tile helpers for aihwkit tests."""
+
+# pylint: disable=missing-function-docstring,too-few-public-methods
+
+from aihwkit.simulator.devices import (FloatingPointResistiveDevice,
+                                       IdealResistiveDevice,
+                                       ConstantStepResistiveDevice,
+                                       LinearStepResistiveDevice,
+                                       ExpStepResistiveDevice,
+                                       PulsedResistiveDevice,
+                                       DifferenceUnitCell,
+                                       VectorUnitCell,
+                                       TransferUnitCell)
+from aihwkit.simulator.tiles import AnalogTile, FloatingPointTile
+from aihwkit.simulator.parameters import (ConstantStepResistiveDeviceParameters,
+                                          LinearStepResistiveDeviceParameters,
+                                          ExpStepResistiveDeviceParameters,
+                                          SoftBoundsResistiveDeviceParameters,
+                                          AnalogTileInputOutputParameters)
+from aihwkit.simulator.rpu_base import tiles
+
+
+class FloatingPoint:
+    """FloatingPointTile."""
+
+    simulator_tile_class = tiles.FloatingPointTile
+    first_hidden_field = None
+    use_cuda = False
+
+    def get_resistive_device(self):
+        return FloatingPointResistiveDevice()
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return FloatingPointTile(out_size, in_size, resistive_device, **kwargs)
+
+
+class Ideal:
+    """AnalogTile with IdealResistiveDevice."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = None
+    use_cuda = False
+
+    def get_resistive_device(self):
+        return IdealResistiveDevice()
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs)
+
+
+class ConstantStep:
+    """AnalogTile with ConstantStepResistiveDevice."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = 'max_bound'
+    use_cuda = False
+
+    def get_resistive_device(self):
+        return ConstantStepResistiveDevice(
+            ConstantStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs)
+
+
+class LinearStep:
+    """AnalogTile with LinearStepResistiveDevice."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = 'max_bound'
+    use_cuda = False
+
+    def get_resistive_device(self):
+        return LinearStepResistiveDevice(
+            LinearStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs)
+
+
+class Pulsed:
+    """AnalogTile with PulsedResistiveDevice."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = 'max_bound'
+    use_cuda = False
+
+    def get_resistive_device(self):
+        return PulsedResistiveDevice(
+            LinearStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs)
+
+
+class ExpStep:
+    """AnalogTile with ExpStepResistiveDevice."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = 'max_bound'
+    use_cuda = False
+
+    def get_resistive_device(self):
+        return ExpStepResistiveDevice(
+            ExpStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs)
+
+
+class Vector:
+    """AnalogTile with VectorUnitCell."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = 'max_bound_0'
+    use_cuda = False
+
+    def get_resistive_device(self):
+        return VectorUnitCell(
+            [ConstantStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0),
+             ConstantStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0)])
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs)
+
+
+class Difference:
+    """AnalogTile with DifferenceUnitCell."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = 'max_bound_0'
+    use_cuda = False
+
+    def get_resistive_device(self):
+        return DifferenceUnitCell(
+            ConstantStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0)
+        )
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs)
+
+
+class Transfer:
+    """AnalogTile with TransferUnitCell."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = 'max_bound_0'
+    use_cuda = False
+
+    def get_resistive_device(self):
+        return TransferUnitCell(
+            [SoftBoundsResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0),
+             SoftBoundsResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0)],
+            params_transfer_forward=AnalogTileInputOutputParameters(is_perfect=True)
+        )
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs)
+
+
+class FloatingPointCuda:
+    """FloatingPointTile."""
+
+    simulator_tile_class = getattr(tiles, 'CudaFloatingPointTile', None)
+    first_hidden_field = None
+    use_cuda = True
+
+    def get_resistive_device(self):
+        return None
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        return FloatingPointTile(out_size, in_size, resistive_device, **kwargs).cuda()
+
+
+class IdealCuda:
+    """AnalogTile with IdealResistiveDevice."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = None
+    use_cuda = True
+
+    def get_resistive_device(self):
+        return IdealResistiveDevice()
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs).cuda()
+
+
+class ConstantStepCuda:
+    """AnalogTile with ConstantStepResistiveDevice."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = 'max_bound'
+    use_cuda = True
+
+    def get_resistive_device(self):
+        return ConstantStepResistiveDevice(
+            ConstantStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs).cuda()
+
+
+class LinearStepCuda:
+    """AnalogTile with LinearStepResistiveDevice."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = 'max_bound'
+    use_cuda = True
+
+    def get_resistive_device(self):
+        return LinearStepResistiveDevice(
+            LinearStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs).cuda()
+
+
+class PulsedCuda:
+    """AnalogTile with PulsedResistiveDevice."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = 'max_bound'
+    use_cuda = True
+
+    def get_resistive_device(self):
+        return PulsedResistiveDevice(
+            LinearStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs).cuda()
+
+
+class ExpStepCuda:
+    """AnalogTile with ExpStepResistiveDevice."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = 'max_bound'
+    use_cuda = True
+
+    def get_resistive_device(self):
+        return ExpStepResistiveDevice(
+            ExpStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs).cuda()
+
+
+class VectorCuda:
+    """AnalogTile with VectorUnitCell."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = 'max_bound_0'
+    use_cuda = True
+
+    def get_resistive_device(self):
+        return VectorUnitCell(
+            [ConstantStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0),
+             ConstantStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0)])
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs).cuda()
+
+
+class DifferenceCuda:
+    """AnalogTile with DifferenceUnitCell."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = 'max_bound_0'
+    use_cuda = True
+
+    def get_resistive_device(self):
+        return DifferenceUnitCell(
+            ConstantStepResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0)
+        )
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs).cuda()
+
+
+class TransferCuda:
+    """AnalogTile with TransferUnitCell."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = 'max_bound_0'
+    use_cuda = True
+
+    def get_resistive_device(self):
+        return TransferUnitCell(
+            [SoftBoundsResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0),
+             SoftBoundsResistiveDeviceParameters(w_max_dtod=0, w_min_dtod=0)],
+            params_transfer_forward=AnalogTileInputOutputParameters(is_perfect=True)
+        )
+
+    def get_tile(self, out_size, in_size, resistive_device=None, **kwargs):
+        resistive_device = resistive_device or self.get_resistive_device()
+        return AnalogTile(out_size, in_size, resistive_device, **kwargs).cuda()


### PR DESCRIPTION
## Related issues

Closes #7 

## Description

Revise the tests, making use of decorators for parameterising the tests instead of relying on subclasses:

```python
@parametrize_over_layers(
    layers=[Linear, Conv2d, LinearCuda, Conv2dCuda],
    tiles=[ConstantStep],
    biases=[True, False]
)
class AnalogLayerTest(ParametrizedTestCase):
    """Analog layers abstraction tests."""
    def test_foo():
        print(1)
```

will automatically create `4 kinds of layers * 1 kind of device * 2 bias variations` = 8 `TestCases`.

This is aimed to reduce the copy-paste and repetition over the tests that require checking the same properties over a number of entities, specially with the new devices we have since #14 and future ones.

It is achieved via:
* adding two new decorators, parametrising over tiles and over layers
* adding a new base class for those tests (`ParametrizedTestCase`)
* using [parameterized](https://pypi.org/project/parameterized/) as an additional test dependency

## Details

Most of the existing logic for creating specific tiles and layers have been moved to `helpers.tiles` and `helpers.layers`, and will benefit from some simplification in further PRs.

The picking of `parameterized` as the underlying library was due to it supporting both `pytest` and standard `unittest` runner directly (as well as others). This is the reason for favoring using it over the `pytest` decorators, which would make our tests only compatible with `pytest`. There are other similar libraries but that offered more features or had a slightly different scope (`ddt`, `hypothesis`) - I tried to stick with the minimal that would give support to our needs.
