### PR TITLE
Add conda instructions, adjust openblas

### DIFF
--- a/cmake/Modules/FindOpenBLAS.cmake
+++ b/cmake/Modules/FindOpenBLAS.cmake
@@ -28,26 +28,28 @@ SET(Open_BLAS_INCLUDE_SEARCH_PATHS
   $ENV{OpenBLAS_HOME}/include
   $ENV{OPENBLAS_ROOT_DIR}
   $ENV{OPENBLAS_ROOT_DIR}/include
+  $ENV{CONDA_PREFIX}/include
 )
 
 SET(Open_BLAS_LIB_SEARCH_PATHS
-        /lib/
-        /lib/openblas-base
-        /lib64/
-        /usr/lib
-        /usr/lib/openblas-base
-        /usr/lib64
-        /usr/local/lib
-        /usr/local/lib64
-        /usr/local/opt/openblas/lib
-        /opt/OpenBLAS/lib
-        $ENV{OpenBLAS}cd
-        $ENV{OpenBLAS}/lib
-        $ENV{OpenBLAS_HOME}
-        $ENV{OpenBLAS_HOME}/lib
-        $ENV{OPENBLAS_ROOT_DIR}
-        $ENV{OPENBLAS_ROOT_DIR}/lib
- )
+  /lib/
+  /lib/openblas-base
+  /lib64/
+  /usr/lib
+  /usr/lib/openblas-base
+  /usr/lib64
+  /usr/local/lib
+  /usr/local/lib64
+  /usr/local/opt/openblas/lib
+  /opt/OpenBLAS/lib
+  $ENV{OpenBLAS}
+  $ENV{OpenBLAS}/lib
+  $ENV{OpenBLAS_HOME}
+  $ENV{OpenBLAS_HOME}/lib
+  $ENV{OPENBLAS_ROOT_DIR}
+  $ENV{OPENBLAS_ROOT_DIR}/lib
+  $ENV{CONDA_PREFIX}/lib
+)
 
 FIND_PATH(OpenBLAS_INCLUDE_DIR NAMES openblas_config.h PATHS ${Open_BLAS_INCLUDE_SEARCH_PATHS})
 FIND_LIBRARY(OpenBLAS_LIB NAMES openblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS})

--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -42,12 +42,19 @@ CUDA                             9.0+      Optional, for GPU-enabled simulator
 ===============================  ========  ======
 
 Please refer to your operative system documentation for instructions on how
-to install the different dependencies. On a Debian-based operative system,
-the following commands can be used for installing the minimal
-dependencies::
+to install the different dependencies. The following section contains quick
+instructions for several operative systems:
+
+Debian-based
+""""""""""""
+On a Debian-based operative system, the following commands can be used for
+installing the minimal dependencies::
 
     $ sudo apt-get install python3-pybind11 python3-dev libopenblas-dev
     $ pip install cmake scikit-build torch
+
+OSX
+"""
 
 On an OSX-based system, the following commands can be used for installing the
 minimal dependencies (note that ``Xcode`` needs to be installed)::
@@ -55,6 +62,15 @@ minimal dependencies (note that ``Xcode`` needs to be installed)::
     $ brew install pybind11
     $ brew install openblas
     $ pip install cmake scikit-build torch
+
+miniconda
+"""""""""
+
+On a miniconda-based system, the following commands can be used for installing
+the minimal dependencies [#f3]_::
+
+    $ conda install cmake openblas pybind11 scikit-build
+    $ conda install pytorch -c pytorch
 
 Installing and compiling
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -92,6 +108,9 @@ of the command will help diagnosing the issue.
    dependency. Please ensure that your torch installation includes ``libtorch``
    and the development headers - they are included by default if installing
    torch from ``pip``.
+
+.. [#f3] Please note that currently support for conda-based distributions is
+   experimental, and further commands might be needed.
 
 .. _virtual environment: https://docs.python.org/3/library/venv.html
 


### PR DESCRIPTION


## Related issues

#21 

## Description

* Add quick-start snippet for miniconda in the install documentation in sphinx, reorganizing the rest of quick-starts a bit in the process.
* Adjust the finding of openblas adding the miniconda default paths.

## Details

This allows for compiling the package by installing only packages directly from conda, as `pybind11` includes the right `.cmake` file in its conda version, plus `openblas` takes care of installing the compiled shared libraries as well. 
