### PR TITLE
More advanced hardware-aware training

### DIFF
--- a/src/aihwkit/optim/analog_sgd.py
+++ b/src/aihwkit/optim/analog_sgd.py
@@ -74,7 +74,6 @@ class AnalogSGD(SGD):
                 and returns the loss.
         """
         # pylint: disable=too-many-branches
-
         loss = None
         if closure is not None:
             loss = closure()
@@ -96,10 +95,14 @@ class AnalogSGD(SGD):
                 weights = next(param for param in group['params']
                                if getattr(param, 'is_weight', False))
 
+                # Call `update` in the tile.
                 if weights.use_indexed:
                     analog_tile.update_indexed(weights.input, weights.grad_output)
                 else:
                     analog_tile.update(weights.input, weights.grad_output)
+
+                # Apply post-update step operations (diffuse, decay, etc).
+                analog_tile.post_update_step()
                 continue
 
             for param in group['params']:

--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -22,6 +22,7 @@ from aihwkit.simulator.configs.devices import (
 
 from aihwkit.simulator.configs.utils import (
     BackwardIOParameters, IOParameters, UpdateParameters, PulseType,
+    WeightClipParameter, WeightModifierParameter,
     tile_parameters_to_bindings
 )
 from aihwkit.simulator.rpu_base import devices
@@ -113,6 +114,10 @@ class InferenceRPUConfig:
 
     device: IdealDevice = field(default_factory=IdealDevice)
     """Ideal device."""
+
+    clip: WeightClipParameter = field(default_factory=WeightClipParameter)
+
+    modifier: WeightModifierParameter = field(default_factory=WeightModifierParameter)
 
     def as_bindings(self) -> devices.AnalogTileParameter:
         """Return a representation of this instance as a simulator bindings object."""

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -685,7 +685,7 @@ class TransferUnitCellDevice(UnitCellDevice):
 
     params_transfer_update: UpdateParameters = field(
         default_factory=UpdateParameters)
-    """ Update parameters :class:`~AnalogTileUpdateParameters` that
+    """Update parameters :class:`~AnalogTileUpdateParameters` that
     define the type of update used for each transfer event.
     """
 

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base.h
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base.h
@@ -19,6 +19,8 @@
 #include "rpu_simple_device.h"
 #include "rpu_transfer_device.h"
 #include "rpu_vector_device.h"
+#include "weight_clipper.h"
+#include "weight_modifier.h"
 
 #ifdef RPU_USE_CUDA
 #include "cuda_util.h"

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
@@ -22,6 +22,38 @@ void declare_rpu_tiles(py::module &m) {
   using Class = RPU::RPUSimple<T>;
   using ClassPulsed = RPU::RPUPulsed<T>;
 
+  py::class_<RPU::WeightModifierParameter>(m, "WeightModifierParameter")
+      .def(py::init<>())
+      .def_readwrite("std_dev", &RPU::WeightModifierParameter::std_dev)
+      .def_readwrite("res", &RPU::WeightModifierParameter::res)
+      .def_readwrite("sto_round", &RPU::WeightModifierParameter::sto_round)
+      .def_readwrite("dorefa_clip", &RPU::WeightModifierParameter::dorefa_clip)
+      .def_readwrite("pdrop", &RPU::WeightModifierParameter::pdrop)
+      .def_readwrite("enable_during_test", &RPU::WeightModifierParameter::enable_during_test)
+      .def_readwrite("rel_to_actual_wmax", &RPU::WeightModifierParameter::rel_to_actual_wmax)
+      .def_readwrite("assumed_wmax", &RPU::WeightModifierParameter::assumed_wmax)
+      .def_readwrite("type", &RPU::WeightModifierParameter::type);
+
+  py::enum_<RPU::WeightModifierType>(m, "WeightModifierType")
+      .value("Copy", RPU::WeightModifierType::Copy)
+      .value("Discretize", RPU::WeightModifierType::Discretize)
+      .value("MultNormal", RPU::WeightModifierType::MultNormal)
+      .value("AddNormal", RPU::WeightModifierType::AddNormal)
+      .value("DiscretizeAddNormal", RPU::WeightModifierType::DiscretizeAddNormal)
+      .value("DoReFa", RPU::WeightModifierType::DoReFa);
+
+  py::class_<RPU::WeightClipParameter>(m, "WeightClipParameter")
+      .def(py::init<>())
+      .def_readwrite("fixed_value", &RPU::WeightClipParameter::fixed_value)
+      .def_readwrite("sigma", &RPU::WeightClipParameter::sigma)
+      .def_readwrite("type", &RPU::WeightClipParameter::type);
+
+  py::enum_<RPU::WeightClipType>(m, "WeightClipType")
+      .value("None", RPU::WeightClipType::None)
+      .value("FixedValue", RPU::WeightClipType::FixedValue)
+      .value("LayerGaussian", RPU::WeightClipType::LayerGaussian)
+      .value("AverageChannelMax", RPU::WeightClipType::AverageChannelMax);
+
   py::class_<Class>(
       m, "FloatingPointTile",
       R"pbdoc(
@@ -390,6 +422,31 @@ void declare_rpu_tiles(py::module &m) {
                alpha: decay scale
            )pbdoc")
       .def(
+          "clip_weights",
+          [](Class &self, ::RPU::WeightClipParameter &wclip_par) { self.clipWeights(wclip_par); },
+          py::arg("weight_clipper_params"),
+          R"pbdoc(
+           Clips the weights for use of hardware-aware training.
+
+           Several clipping types are available, see ``WeightClipParameter``.
+
+           Args:
+               weight_clipper_params: parameters of the clipping.
+           )pbdoc")
+      .def(
+          "modify_weights",
+          [](Class &self, ::RPU::WeightModifierParameter &wmpar) { self.modifyFBWeights(wmpar); },
+          py::arg("weight_modifier_params"),
+          R"pbdoc(
+           Modifies the weights in forward and backward (but not update) pass for use of hardware-aware training.
+
+           Several modifier types are available, see ``WeightModifierParameter``.
+
+           Args:
+               weight_modifier_params: parameters of the modifications.
+           )pbdoc")
+
+      .def(
           "diffuse_weights", &Class::diffuseWeights,
           R"pbdoc(
            Diffuse the weights.
@@ -404,6 +461,7 @@ void declare_rpu_tiles(py::module &m) {
                alpha: decay scale
                bias_no_decay: Whether to not decay the bias row
            )pbdoc")
+
       .def(
           "reset_columns",
           [](Class &self, int start_col, int n_cols, T reset_prob) {

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles_cuda.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles_cuda.cpp
@@ -272,10 +272,10 @@ void declare_rpu_tiles_cuda(py::module &m) {
           R"pbdoc(
            Compute the dot product using an index matrix (forward pass).
 
-           Caution: 
+           Caution:
               Internal use for convolutions only.
 
-           Args: 
+           Args:
               x_input: 4D torch::tensor in order N,C,H,W
               d_height: height of output image(s)
               d_width: width of output image(s)
@@ -308,10 +308,10 @@ void declare_rpu_tiles_cuda(py::module &m) {
           R"pbdoc(
            Compute the dot product using an index matrix (backward pass).
 
-           Caution: 
+           Caution:
               Internal use for convolutions only.
 
-           Args: 
+           Args:
               d_input: 4D torch::tensor in order N,C,H,W
               x_channel: number of grad_input channels
               x_height: height of grad_input image(s)
@@ -343,10 +343,10 @@ void declare_rpu_tiles_cuda(py::module &m) {
           R"pbdoc(
            Compute the dot product using an index matrix (backward pass).
 
-           Caution: 
+           Caution:
               Internal use for convolutions only.
 
-           Args: 
+           Args:
               x_input: 4D torch::tensor input in order N,C,H,W
               d_input: 4D torch::tensor (grad_output) in order N,C,oH,oW
            )pbdoc");

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -400,3 +400,11 @@ class BaseTile(Generic[RPUConfigGeneric]):
             d_input: ``[N, out_size]`` tensor. If ``out_trans`` is set, transposed.
         """
         return self.tile.update_indexed(x_input, d_input)
+
+    @no_grad()
+    def post_update_step(self) -> None:
+        """Operators that need to be called once per mini-batch."""
+        if self.rpu_config.device.diffusion > 0.0:  # type: ignore
+            self.diffuse_weights()
+        if self.rpu_config.device.lifetime > 0.0:  # type: ignore
+            self.decay_weights()

--- a/src/rpucuda/cuda/cuda_math_util.cu
+++ b/src/rpucuda/cuda/cuda_math_util.cu
@@ -22,19 +22,17 @@
   cublasHandle_t handle = context->getBlasHandle();                                                \
   CUBLAS_CALL(cublasSetStream(handle, context->getStream()))
 
-#define RPU_SET_CUBLAS_POINTER_MODE_DEVICE				\
-  cublasPointerMode_t p_mode;						\
-  CUBLAS_CALL(cublasGetPointerMode(handle, &p_mode));			\
-  CUBLAS_CALL(cublasSetPointerMode(handle,CUBLAS_POINTER_MODE_DEVICE))
+#define RPU_SET_CUBLAS_POINTER_MODE_DEVICE                                                         \
+  cublasPointerMode_t p_mode;                                                                      \
+  CUBLAS_CALL(cublasGetPointerMode(handle, &p_mode));                                              \
+  CUBLAS_CALL(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE))
 
-#define RPU_SET_CUBLAS_POINTER_MODE_HOST				\
-  cublasPointerMode_t p_mode;						\
-  CUBLAS_CALL(cublasGetPointerMode(handle, &p_mode));			\
-  CUBLAS_CALL(cublasSetPointerMode(handle,CUBLAS_POINTER_MODE_HOST))
+#define RPU_SET_CUBLAS_POINTER_MODE_HOST                                                           \
+  cublasPointerMode_t p_mode;                                                                      \
+  CUBLAS_CALL(cublasGetPointerMode(handle, &p_mode));                                              \
+  CUBLAS_CALL(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST))
 
-#define RPU_RESTORE_CUBLAS_POINTER_MODE		    \
-  CUBLAS_CALL(cublasSetPointerMode(handle,p_mode))
-
+#define RPU_RESTORE_CUBLAS_POINTER_MODE CUBLAS_CALL(cublasSetPointerMode(handle, p_mode))
 
 namespace RPU {
 namespace math {
@@ -245,7 +243,6 @@ void ger<double>(
   CUBLAS_CALL(cublasDger(handle, M, N, &alpha, X, incX, Y, incY, A, lda));
   RPU_RESTORE_CUBLAS_POINTER_MODE;
 };
-
 
 // W += A
 template <typename T> __global__ void kernelElemAdd(T *dev_W, const int size, const T *dev_A) {

--- a/src/rpucuda/cuda/rpucuda.h
+++ b/src/rpucuda/cuda/rpucuda.h
@@ -18,6 +18,7 @@
 #include "rng.h"
 #include "rpu.h"
 #include "utility_functions.h"
+#include "weight_clipper_cuda.h"
 #include "weight_modifier_cuda.h"
 #include <memory>
 #include <random>
@@ -66,6 +67,7 @@ public:
     swap(a.rnd_diffusion_context_, b.rnd_diffusion_context_);
     swap(a.dev_diffusion_nrnd_, b.dev_diffusion_nrnd_);
 
+    swap(a.wclipper_cuda_, b.wclipper_cuda_);
     swap(a.fb_wmodifier_cuda_, b.fb_wmodifier_cuda_);
   }
 
@@ -151,6 +153,8 @@ public:
 
   void decayWeights(bool bias_no_decay) override;
   void decayWeights(T alpha, bool bias_no_decay) override;
+
+  void clipWeights(const WeightClipParameter &wclpar) override;
   void diffuseWeights() override;
 
   T **getWeights() override; // host weights. implicit copy from CUDA
@@ -191,6 +195,7 @@ private:
   initFrom(const RPUSimple<T> &rpu_in); // to populate from CPU->CUDA, will be called by constructor
   void initialize(CudaContext *c);
   std::unique_ptr<WeightModifierCuda<T>> fb_wmodifier_cuda_ = nullptr;
+  std::unique_ptr<WeightClipperCuda<T>> wclipper_cuda_ = nullptr;
 };
 
 } // namespace RPU

--- a/src/rpucuda/cuda/weight_clipper_cuda.cu
+++ b/src/rpucuda/cuda/weight_clipper_cuda.cu
@@ -1,0 +1,125 @@
+#include "cuda_math_util.h"
+#include "io_iterator.h"
+#include "weight_clipper_cuda.h"
+#include <cub/cub.cuh>
+
+namespace RPU {
+
+template <typename T> struct StdFunctor {
+  StdFunctor(T size, T *sum) : size_(size), sum_(sum){};
+
+  __device__ __forceinline__ T operator()(const T &a) const {
+    T m = *sum_ / size_;
+    return T((a - m) * (a - m));
+  }
+  T size_;
+  T *sum_;
+};
+
+template <typename T> __global__ void kernelAClipC(T *values, int size, T *a, T c) {
+  int tid = blockDim.x * blockIdx.x + threadIdx.x;
+  T abs_a = fabs(*a / c);
+  if (tid < size) {
+    values[tid] = MIN(MAX(values[tid], -abs_a), abs_a);
+  }
+}
+
+template <typename T> __global__ void kernelAClipSqrt(T *values, int size, T *a, T sigma) {
+  int tid = blockDim.x * blockIdx.x + threadIdx.x;
+  T abs_a = sqrtf(fabs(*a) / (size - 1)) * sigma;
+  if (tid < size) {
+    values[tid] = MIN(MAX(values[tid], -abs_a), abs_a);
+  }
+}
+
+// ctor
+template <typename T>
+WeightClipperCuda<T>::WeightClipperCuda(CudaContext *context, int x_size, int d_size)
+    : context_(context), x_size_(x_size), d_size_(d_size), size_(x_size * d_size) {
+
+  T *tmp = nullptr;
+  StdFunctor<T> std_functor((T)x_size_, tmp);
+  cub::TransformInputIterator<T, StdFunctor<T>, T *> std_input(tmp, std_functor);
+
+  cub::DeviceReduce::Sum(
+      nullptr, temp_storage_bytes_, std_input, tmp, size_, context_->getStream());
+  dev_temp_storage_ = make_unique<CudaArray<char>>(context, temp_storage_bytes_);
+}
+
+template <typename T>
+void WeightClipperCuda<T>::apply(T *weights, const WeightClipParameter &wclpar) {
+  // does a weight remap to the scales.
+
+  int nthreads = context_->getNThreads();
+  int nblocks = context_->getNBlocks(size_, nthreads);
+  auto s = context_->getStream();
+
+  // this is to remap the weights
+  switch (wclpar.type) {
+  case WeightClipType::None: {
+    break;
+  }
+  case WeightClipType::AverageChannelMax: {
+
+    if (!row_amaximizer_) {
+      row_amaximizer_ = make_unique<Maximizer<T>>(context_, x_size_, true);
+      dev_sum_value_ = make_unique<CudaArray<T>>(context_, 1);
+    }
+    row_amaximizer_->compute(weights, d_size_, true);
+
+    cub::DeviceReduce::Sum(
+        dev_temp_storage_->getData(), temp_storage_bytes_, row_amaximizer_->getMaxValues(),
+        dev_sum_value_->getData(), d_size_, s);
+
+    kernelAClipC<T>
+        <<<nblocks, nthreads, 0, s>>>(weights, size_, dev_sum_value_->getData(), (T)d_size_);
+    break;
+  }
+
+  case WeightClipType::LayerGaussian: {
+
+    if (!dev_sum_value_) {
+      dev_sum_value_ = make_unique<CudaArray<T>>(context_, 1);
+    }
+    if (!dev_std_value_) {
+      dev_std_value_ = make_unique<CudaArray<T>>(context_, 1);
+    }
+
+    StdFunctor<T> std_functor((T)size_, dev_sum_value_->getData());
+    cub::TransformInputIterator<T, StdFunctor<T>, T *> std_input(weights, std_functor);
+
+    // mean (sum)
+    cub::DeviceReduce::Sum(
+        dev_temp_storage_->getData(), temp_storage_bytes_, weights, dev_sum_value_->getData(),
+        size_, s);
+
+    // std
+    cub::DeviceReduce::Sum(
+        dev_temp_storage_->getData(), temp_storage_bytes_, std_input, dev_std_value_->getData(),
+        size_, s);
+
+    kernelAClipSqrt<T>
+        <<<nblocks, nthreads, 0, s>>>(weights, size_, dev_std_value_->getData(), wclpar.sigma);
+
+    break;
+  }
+
+  case WeightClipType::FixedValue: {
+    if (wclpar.fixed_value >= 0) {
+      RPU::math::aclip(context_, weights, size_, (T)wclpar.fixed_value);
+    }
+    break;
+  }
+
+  default:
+    RPU_FATAL("Clipping type not implemented.");
+  } // switch
+}
+
+template class WeightClipperCuda<float>;
+#ifdef RPU_USE_DOUBLE
+template class WeightClipperCuda<double>;
+#endif
+
+#undef RPU_WM_KERNEL_LOOP
+} // namespace RPU

--- a/src/rpucuda/cuda/weight_clipper_cuda.h
+++ b/src/rpucuda/cuda/weight_clipper_cuda.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "cuda_util.h"
+#include "maximizer.h"
+#include "weight_clipper.h"
+
+namespace RPU {
+
+template <typename T> class WeightClipperCuda {
+
+public:
+  explicit WeightClipperCuda(CudaContext *context, int x_size, int d_size);
+  WeightClipperCuda(){};
+
+  void apply(T *weights, const WeightClipParameter &wclpar);
+
+private:
+  CudaContext *context_ = nullptr;
+  int x_size_ = 0;
+  int d_size_ = 0;
+  int size_ = 0;
+  size_t temp_storage_bytes_ = 0;
+
+  // no need to copy
+  std::unique_ptr<Maximizer<T>> row_amaximizer_ = nullptr;
+  std::unique_ptr<CudaArray<T>> dev_std_value_ = nullptr;
+  std::unique_ptr<CudaArray<T>> dev_sum_value_ = nullptr;
+  std::unique_ptr<CudaArray<char>> dev_temp_storage_ = nullptr;
+};
+
+} // namespace RPU

--- a/src/rpucuda/cuda/weight_clipper_cuda_test.cpp
+++ b/src/rpucuda/cuda/weight_clipper_cuda_test.cpp
@@ -1,0 +1,125 @@
+#include "cuda.h"
+#include "cuda_util.h"
+#include "utility_functions.h"
+#include "weight_clipper.h"
+#include "weight_clipper_cuda.h"
+#include "gtest/gtest.h"
+#include <chrono>
+#include <memory>
+#include <random>
+
+#define TOLERANCE 1e-5
+
+#ifdef RPU_USE_DOUBLE
+typedef double num_t;
+#else
+typedef float num_t;
+#endif
+
+namespace {
+
+using namespace RPU;
+
+class WeightClipperTestFixture : public ::testing::TestWithParam<bool> {
+public:
+  void SetUp() {
+
+    x_size = 100;
+    d_size = 130;
+    size = d_size * x_size;
+
+    w = new num_t[size];
+    v = new num_t[size]();
+
+    auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    std::default_random_engine generator{seed};
+    std::normal_distribution<num_t> ndist{0.0, 1.0};
+    auto nrnd = std::bind(ndist, generator);
+
+    wclipper = make_unique<WeightClipper<num_t>>(x_size, d_size);
+    wclipper_cuda = make_unique<WeightClipperCuda<num_t>>(&context, x_size, d_size);
+
+    // just assign some numbers from the weigt matrix
+    for (int i = 0; i < size; i++) {
+      w[i] = nrnd();
+    }
+
+    dev_w = make_unique<CudaArray<num_t>>(&context, size, w);
+    dev_w->assignTranspose(w, d_size, x_size);
+    context.synchronize();
+  }
+
+  void TearDown() {
+    delete[] w;
+    delete[] v;
+  }
+
+  int x_size, d_size;
+  int size;
+  WeightClipParameter wclpar;
+  std::unique_ptr<WeightClipper<num_t>> wclipper;
+  std::unique_ptr<WeightClipperCuda<num_t>> wclipper_cuda;
+  num_t *w, *v;
+  std::unique_ptr<CudaArray<num_t>> dev_w;
+  CudaContext context{0};
+};
+
+TEST_F(WeightClipperTestFixture, FixedValue) {
+
+  wclpar.type = WeightClipType::FixedValue;
+  wclpar.fixed_value = 0.4;
+
+  wclipper->apply(w, wclpar);
+  wclipper_cuda->apply(dev_w->getData(), wclpar);
+  context.synchronize();
+
+  num_t w_max = Find_Absolute_Max<num_t>(w, size);
+
+  dev_w->copyTo(v);
+  num_t dev_w_max = Find_Absolute_Max<num_t>(v, size);
+  std::cout << "w_max " << w_max << ", dev_w_max " << dev_w_max << std::endl;
+  EXPECT_FLOAT_EQ(w_max, dev_w_max);
+  EXPECT_FLOAT_EQ(w_max, wclpar.fixed_value);
+}
+
+TEST_F(WeightClipperTestFixture, LayerGaussian) {
+
+  wclpar.type = WeightClipType::LayerGaussian;
+  wclpar.sigma = 0.4;
+
+  wclipper->apply(w, wclpar);
+  wclipper_cuda->apply(dev_w->getData(), wclpar);
+  context.synchronize();
+
+  num_t w_max = Find_Absolute_Max<num_t>(w, size);
+
+  dev_w->copyTo(v);
+  num_t dev_w_max = Find_Absolute_Max<num_t>(v, size);
+  std::cout << "w_max " << w_max << ", dev_w_max " << dev_w_max << std::endl;
+  EXPECT_NEAR(w_max, dev_w_max, 0.01);
+  EXPECT_NEAR(w_max, wclpar.sigma, 0.01);
+}
+
+TEST_F(WeightClipperTestFixture, AverageChannelMax) {
+
+  wclpar.type = WeightClipType::AverageChannelMax;
+
+  wclipper->apply(w, wclpar);
+  wclipper_cuda->apply(dev_w->getData(), wclpar);
+  context.synchronize();
+
+  num_t w_max = Find_Absolute_Max<num_t>(w, size);
+
+  dev_w->copyTo(v);
+  num_t dev_w_max = Find_Absolute_Max<num_t>(v, size);
+  std::cout << "w_max " << w_max << ", dev_w_max " << dev_w_max << std::endl;
+  EXPECT_NEAR(w_max, dev_w_max, 0.0001);
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  resetCuda();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/rpucuda/rpu.cpp
+++ b/src/rpucuda/rpu.cpp
@@ -285,6 +285,9 @@ template <typename T> RPUSimple<T>::RPUSimple(const RPUSimple<T> &other) : RPUAb
     this->setSharedWeights(*other.weights_);
   }
 
+  // no copy needed
+  wclipper_ = nullptr;
+
   // do NOT copy external weights...
   if (other.delta_weights_extern_[0]) {
     std::cout << "WARNING cannot copy external delta weight pointer..." << std::endl;
@@ -1197,6 +1200,15 @@ template <typename T> void RPUSimple<T>::decayWeights(T alpha, bool bias_no_deca
 template <typename T> void RPUSimple<T>::decayWeights(bool bias_no_decay) {
   RPUSimple<T>::decayWeights(1., bias_no_decay);
 };
+
+template <typename T> void RPUSimple<T>::clipWeights(const WeightClipParameter &wclpar) {
+
+  if (wclipper_ == nullptr) {
+    wclipper_ = make_unique<WeightClipper<T>>(this->x_size_, this->d_size_);
+  }
+
+  wclipper_->apply(getWeightsPtr()[0], wclpar);
+}
 
 template <typename T> void RPUSimple<T>::diffuseWeights() {
 

--- a/src/rpucuda/rpu.h
+++ b/src/rpucuda/rpu.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "rng.h"
+#include "weight_clipper.h"
 #include "weight_modifier.h"
 #include <cfenv>
 #include <iostream>
@@ -208,6 +209,7 @@ public:
     swap(a.fb_weights_, b.fb_weights_);
     swap(a.delta_weights_extern_, b.delta_weights_extern_);
 
+    swap(a.wclipper_, b.wclipper_);
     swap(a.fb_weight_modifier_, b.fb_weight_modifier_);
     swap(a.last_update_m_batch_, b.last_update_m_batch_);
 
@@ -293,6 +295,10 @@ public:
      applied to the current decay rate*/
   virtual void decayWeights(bool bias_no_decay);
   virtual void decayWeights(T alpha, bool bias_no_decay);
+
+  /* Clip weights once. Uses the weight clipper to clip weights in
+     some manner, only for HWA training.*/
+  virtual void clipWeights(const WeightClipParameter &wclpar);
 
   /* Applying a potential reset with given probabilties to a selection of columns */
   virtual void resetCols(int start_col, int n_cols, T reset_prob) {
@@ -569,6 +575,7 @@ private:
   int temp_tensor_size_ = 0;
 
   std::unique_ptr<WeightModifier<T>> fb_weight_modifier_ = nullptr;
+  std::unique_ptr<WeightClipper<T>> wclipper_ = nullptr;
 
   int *matrix_indices_ = nullptr;
   bool matrix_indices_set_ = false;

--- a/src/rpucuda/weight_clipper.cpp
+++ b/src/rpucuda/weight_clipper.cpp
@@ -1,0 +1,101 @@
+#include "weight_clipper.h"
+#include "math_util.h"
+#include "utility_functions.h"
+#include <limits>
+
+namespace RPU {
+
+/***********************************************************/
+// ctors
+
+template <typename T>
+WeightClipper<T>::WeightClipper(int x_size, int d_size)
+    : x_size_(x_size), d_size_(d_size), size_(d_size * x_size) {}
+
+template <typename T> void WeightClipper<T>::clip(T *weights, T value) {
+
+  PRAGMA_SIMD
+  for (int i = 0; i < size_; ++i) {
+    weights[i] = MIN(MAX(weights[i], -value), value);
+  }
+}
+
+template <typename T> void WeightClipper<T>::apply(T *weights, const WeightClipParameter &wclpar) {
+
+  T clip_value = -1.0;
+
+  switch (wclpar.type) {
+  case WeightClipType::FixedValue: {
+    clip_value = wclpar.fixed_value;
+    break;
+  }
+  case WeightClipType::AverageChannelMax: {
+
+    if (amax_values_.size() < (size_t)d_size_) {
+      amax_values_.resize(d_size_);
+    }
+    std::fill(amax_values_.begin(), amax_values_.end(), 0.0);
+
+    // compute max per row
+    PRAGMA_SIMD
+    for (int i = 0; i < size_; i++) {
+      int row_idx = i / x_size_;
+      T a = fabs(weights[i]);
+      T mv = amax_values_[row_idx];
+
+      amax_values_[row_idx] = a > mv ? a : mv;
+    }
+
+    T sum_amax = 0;
+    PRAGMA_SIMD
+    for (int i = 0; i < d_size_; i++) {
+      sum_amax += amax_values_[i];
+    }
+
+    clip_value = fabs(sum_amax / d_size_);
+
+    break;
+  }
+  case WeightClipType::LayerGaussian: {
+
+    T mean_value = 0.0;
+    T std_value = 0.0;
+
+    // compute mean
+    PRAGMA_SIMD
+    for (int i = 0; i < size_; i++) {
+      mean_value += weights[i];
+    }
+    mean_value /= size_;
+
+    // compute std
+    T s = size_ - 1;
+    PRAGMA_SIMD
+    for (int i = 0; i < size_; i++) {
+      T m = weights[i] - mean_value;
+      std_value += m * m / s;
+    }
+    std_value = sqrt(std_value);
+
+    clip_value = std_value * wclpar.sigma;
+    break;
+  }
+
+  case WeightClipType::None: {
+    clip_value = -1.0;
+    break;
+  }
+  default:
+    RPU_FATAL("Clipping type not implemented for CPU.");
+  } // switch
+
+  // do the clippping
+  clip(weights, clip_value);
+}
+
+template class WeightClipper<float>;
+#ifdef RPU_USE_DOUBLE
+template class WeightClipper<double>;
+#endif
+
+} // namespace RPU

--- a/src/rpucuda/weight_clipper.h
+++ b/src/rpucuda/weight_clipper.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "rng.h"
+#include <memory>
+
+namespace RPU {
+
+enum class WeightClipType {
+  None,
+  FixedValue,
+  LayerGaussian,
+  AverageChannelMax,
+};
+
+// no template. Just double
+struct WeightClipParameter {
+
+  WeightClipType type = WeightClipType::None;
+  double fixed_value = 1.0;
+  double sigma = 2.5;
+
+  void print() const {
+    std::stringstream ss;
+    printToStream(ss);
+    std::cout << ss.str();
+  };
+
+  void printToStream(std::stringstream &ss) const {
+
+    ss << "\t weight clipper type:\t" << getTypeName() << std::endl;
+    if (type == WeightClipType::None) {
+      return;
+    }
+    if (type == WeightClipType::FixedValue) {
+      ss << "\t fixed value:\t\t" << fixed_value << std::endl;
+    }
+    if (type == WeightClipType::LayerGaussian) {
+      ss << "\t sigma:\t\t" << sigma << std::endl;
+    }
+
+    ss << std::endl;
+  };
+
+  inline std::string getTypeName() const {
+    switch (type) {
+    case WeightClipType::None:
+      return "None";
+    case WeightClipType::FixedValue:
+      return "FixedValue";
+    case WeightClipType::AverageChannelMax:
+      return "AverageChannelMax";
+    case WeightClipType::LayerGaussian:
+      return "LayerGaussian";
+    default:
+      return "Unknown";
+    }
+  };
+};
+
+template <typename T> class WeightClipper {
+
+public:
+  explicit WeightClipper(int x_size, int d_size);
+  WeightClipper(){};
+
+  /* in-place clipping of weights */
+  void apply(T *weights, const WeightClipParameter &wclpar);
+
+private:
+  void clip(T *weights, T clip_value);
+  std::vector<T> amax_values_;
+
+  int x_size_ = 0;
+  int d_size_ = 0;
+  int size_ = 0;
+};
+
+} // namespace RPU

--- a/src/rpucuda/weight_modifier.cpp
+++ b/src/rpucuda/weight_modifier.cpp
@@ -41,7 +41,6 @@ void WeightModifier<T>::apply(
   if (new_weights != weights) {
     RPU::math::copy<T>(size_, weights, 1, new_weights, 1);
   }
-  enable_during_test_ = wmpar.enable_during_test;
 
   T amax = wmpar.assumed_wmax; // assumed max
   if (wmpar.rel_to_actual_wmax && wmpar.type != WeightModifierType::Copy) {


### PR DESCRIPTION
## Related issues
#20 

## Description

More advanced hardware-aware training for analog inference with the `InferenceTile`.

## Details

- different types of weight noise can be added per mini-batch during training, that is fixed during forward/backward. Updates are done on a reference weight matrix.
- connection drop
- clipping weights    
