### PR TITLE
Add AnalogSequential module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Added a new `InferenceTile` that supports basic hardware-aware training
   and inference using a statistical noise model that was fitted by real PCM
   devices. (\#25)
+* Added a new `AnalogSequential` layer that can be used in place of `Sequential`
+  for easier operation on children analog layers. (\#34)
 
 ### Changed
 
@@ -40,6 +42,9 @@ The format is based on [Keep a Changelog], and this project adheres to
   package description). (\#13) 
 * The build system can now detect and use `openblas` directly when using the
   conda-installable version. (\#22)
+* When using analog layers as children of another module, the tiles are now
+  correctly moved to CUDA if using `AnalogSequential` (or by the optimizer if
+  using regular torch container modules). (\#34)
 
 ## [0.1.0] - 2020/09/17
 

--- a/examples/4_lenet5_training.py
+++ b/examples/4_lenet5_training.py
@@ -31,8 +31,7 @@ from torch import nn
 from torchvision import datasets, transforms
 
 # Imports from aihwkit.
-from aihwkit.nn.modules.conv import AnalogConv2d
-from aihwkit.nn.modules.linear import AnalogLinear
+from aihwkit.nn import AnalogConv2d, AnalogLinear, AnalogSequential
 from aihwkit.optim.analog_sgd import AnalogSGD
 from aihwkit.simulator.configs import SingleRPUConfig, FloatingPointRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice, FloatingPointDevice
@@ -78,7 +77,7 @@ def load_images():
     return train_data, validation_data
 
 
-class LeNet5(nn.Module):
+class LeNet5(AnalogSequential):
     """LeNet5 inspired analog model."""
 
     def __init__(self):
@@ -278,8 +277,7 @@ def main():
     # Prepare the model.
     model = LeNet5()
     if USE_CUDA:
-        [m.cuda() for m in model.modules()]
-    model.to(DEVICE)
+        model.cuda()
     print(model)
 
     print(f'\n{datetime.now().time().replace(microsecond=0)} --- '

--- a/examples/5_simple_layer_hardware_aware.py
+++ b/examples/5_simple_layer_hardware_aware.py
@@ -85,7 +85,7 @@ print('Correct value:\t {}'.format(y.detach().cpu().numpy().flatten()))
 print('Prediction after training:\t {}'.format(pred_before.detach().cpu().numpy().flatten()))
 
 for t_inference in [0., 1., 20., 1000., 1e5]:
-    drift_analog_weights(model, t_inference)
+    model.drift_analog_weights(t_inference)
     pred_drift = model(x)
     print('Prediction after drift (t={}, correction={:1.3f}):\t {}'.format(
         t_inference, model.analog_tile.alpha.cpu().numpy(),

--- a/src/aihwkit/nn/__init__.py
+++ b/src/aihwkit/nn/__init__.py
@@ -12,5 +12,6 @@
 
 """Neural network modules."""
 
+from aihwkit.nn.modules.container import AnalogSequential
 from aihwkit.nn.modules.conv import AnalogConv2d
 from aihwkit.nn.modules.linear import AnalogLinear

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -35,6 +35,7 @@ class AnalogSequential(Sequential):
         layers. If using regular containers, please be aware that operations
         need to be applied manually to the children analog layers when needed.
     """
+    # pylint: disable=abstract-method
 
     def _apply_to_analog(self, fn: Callable) -> 'AnalogSequential':
         """Apply a function to all the analog layers in this module.

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Analog Modules that contain children Modules.."""
+
+from typing import Callable, Optional, Union
+
+from torch import device as torch_device
+from torch.nn import Sequential
+
+from aihwkit.nn.modules.base import AnalogModuleBase
+
+
+class AnalogSequential(Sequential):
+    """An analog-aware sequential container.
+
+    Specialization of torch ``nn.Sequential`` with extra functionality for
+    handling analog layers:
+    * correct handling of ``.cuda()`` for children modules.
+    * apply analog-specific functions to all its children (drift and program
+      weights).
+
+    Note:
+        This class is recommended to be used in place of ``nn.Sequential`` in
+        order to correctly propagate the actions to all the children analog
+        layers. If using regular containers, please be aware that operations
+        need to be applied manually to the children analog layers when needed.
+    """
+
+    def _apply_to_analog(self, fn: Callable) -> 'AnalogSequential':
+        """Apply a function to all the analog layers in this module.
+
+        Args:
+            fn: function to be applied.
+        """
+        # pylint: disable=invalid-name
+        for module in self.modules():
+            if isinstance(module, AnalogModuleBase):
+                fn(module)
+
+        return self
+
+    def cuda(
+            self,
+            device: Optional[Union[torch_device, str, int]] = None
+    ) -> 'AnalogSequential':
+        super().cuda(device)
+
+        self._apply_to_analog(lambda m: m.cuda())
+
+        return self
+
+    def drift_analog_weights(self, t_inference: float = 0.0) -> None:
+        """(Program) and drift all analog inference layers of a given model.
+
+        Args:
+            t_inference: assumed time of inference (in sec
+        """
+        if self.training:
+            raise RuntimeError('drift_analog_weights can only be applied in '
+                               'evaluation mode')
+
+        self._apply_to_analog(lambda m: m.drift_analog_weights(t_inference))
+
+    def program_analog_weights(self) -> None:
+        """Program all analog inference layers of a given model."""
+        if self.training:
+            raise RuntimeError('program_analog_weights can only be applied in '
+                               'evaluation mode')
+
+        self._apply_to_analog(lambda m: m.program_weights())

--- a/tests/test_inference_tiles.py
+++ b/tests/test_inference_tiles.py
@@ -17,7 +17,6 @@ from torch import Tensor
 from torch.nn.functional import mse_loss
 
 from aihwkit.nn import AnalogLinear
-from aihwkit.nn.modules.base import drift_analog_weights
 from aihwkit.optim.analog_sgd import AnalogSGD
 from aihwkit.simulator.configs.utils import (
     OutputWeightNoiseType, WeightClipType, WeightModifierType
@@ -81,8 +80,9 @@ class InferenceTileTest(ParametrizedTestCase):
         pred_before = model(x)
 
         pred_last = pred_before
+        model.eval()
         for t_inference in [0., 1., 20., 1000., 1e5]:
-            drift_analog_weights(model, t_inference)
+            model.drift_analog_weights(t_inference)
             pred_drift = model(x)
             self.assertNotAlmostEqualTensor(pred_last, pred_drift)
             pred_last = pred_drift

--- a/tests/test_layers_lineal.py
+++ b/tests/test_layers_lineal.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Tests for layer abstractions."""
+"""Tests for linear layer."""
 
 from torch import Tensor, manual_seed
 from torch.nn import Sequential, Linear as torchLinear


### PR DESCRIPTION


## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Add a new `AnalogSequential` module as the counterpart of regular `nn.Sequential` with analog-specific functionality, in order to allow easy operation on functions that need to be applied to the analog children of a Module.

The main benefit is that it allows to perform actions on just the `Analog` layers contained on it - this way, now `.cuda()` can be handled correctly (by running the `super()` normally, and after it finishes invoking it specifically and only on the analog layers), and the same for `drift_analog_weights` and `program_analog_weights`. As the number of analog-specific operations and functions grow, hopefully this can be used as the main point of entry, delegating into `._apply_to_analog`.

## Details

Using this class is not meant to be mandatory, and actually one of the goals is to keep fully compatibility with `Sequential` - it is mostly a convenience for avoiding to apply functions to the analog layers directly. The documentation has been updated to reflect the manual tweaks needed if not using the new class.
