### PR TITLE
Use dataclass fields in InferenceRPUConfig

### DIFF
--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -434,20 +434,17 @@ def tile_parameters_to_bindings(params: Any) -> Any:
     """Convert a tile dataclass parameter into a bindings class."""
     field_map = {'forward': 'forward_io',
                  'backward': 'backward_io'}
+    excuded_fields = ('device', 'noise_model', 'drift_compensation',
+                      'clip', 'modifier')
 
-    result = params['bindings_class']() if isinstance(params, dict) \
-        else params.bindings_class()
-
-    params_dic = params if isinstance(params, dict) else params.__dict__
-
-    for field, value in params_dic.items():
+    result = params.bindings_class()
+    for field, value in params.__dict__.items():
         # Get the mapped field name, if needed.
         field = field_map.get(field, field)
 
         # Convert enums to the bindings enums.
-        if field in ['bindings_class', 'device']:
-            # Exclude `device`, as it is a special field that is not
-            # present in the bindings.
+        if field in excuded_fields:
+            # Exclude special fields that are not present in the bindings.
             continue
 
         if isinstance(value, Enum):


### PR DESCRIPTION
## Related issues

Follow-up to #25

## Description

Revise `InferenceRPUConfig` so the fields are modeled as attributes in
the same way as the rest of `RPUConfigs`. The difference is that those
fields are not present in the constructor (via the `init=False flag`):
it is not meant to make them fully read-only, but at least provide
some assurances about the right field usage while reducing some
complexity and keeping the configs a bit more homogeneous.

## Details

<!-- A more elaborate description of the changes, if needed. -->
