### PR TITLE
Remove the backward IO parameter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ The format is based on [Keep a Changelog], and this project adheres to
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
+
+## [UNRELEASED]
+
+### Removed
+
+* The `BackwardIOParameters` specialization has been removed, as bound
+  management is now automatically ignored for the backward pass. Please use the
+  more general `IOParameters` instead. (\#45)
+
+
 ## [0.2.0] - 2020/10/20
 
 ### Added

--- a/examples/8_simple_layer_with_tiki_taka.py
+++ b/examples/8_simple_layer_with_tiki_taka.py
@@ -54,7 +54,10 @@ rpu_config = UnitCellRPUConfig(
 )
 
 # Make more adjustments (can be made here or above).
-rpu_config.forward.inp_res = 1/64.  # 6 bit DAC
+rpu_config.forward.inp_res = 1/64.   # 6 bit DAC
+
+# same backward pass settings as forward
+rpu_config.backward = rpu_config.forward
 
 # Same forward/update for transfer-read as for actual SGD.
 rpu_config.device.transfer_forward = rpu_config.forward

--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -21,7 +21,7 @@ from aihwkit.simulator.configs.devices import (
 )
 
 from aihwkit.simulator.configs.utils import (
-    BackwardIOParameters, IOParameters, UpdateParameters, PulseType,
+    IOParameters, UpdateParameters, PulseType,
     WeightClipParameter, WeightModifierParameter,
     tile_parameters_to_bindings
 )
@@ -60,8 +60,7 @@ class SingleRPUConfig:
     forward: IOParameters = field(default_factory=IOParameters)
     """Input-output parameter setting for the forward direction."""
 
-    backward: BackwardIOParameters = field(
-        default_factory=BackwardIOParameters)
+    backward: IOParameters = field(default_factory=IOParameters)
     """Input-output parameter setting for the backward direction."""
 
     update: UpdateParameters = field(default_factory=UpdateParameters)
@@ -92,8 +91,7 @@ class UnitCellRPUConfig:
     forward: IOParameters = field(default_factory=IOParameters)
     """Input-output parameter setting for the forward direction."""
 
-    backward: BackwardIOParameters = field(
-        default_factory=BackwardIOParameters)
+    backward: IOParameters = field(default_factory=IOParameters)
     """Input-output parameter setting for the backward direction."""
 
     update: UpdateParameters = field(default_factory=UpdateParameters)
@@ -149,8 +147,8 @@ class InferenceRPUConfig:
                                 init=False)
     """Parameters that modify the behavior of the pulsed device: ideal device."""
 
-    backward: BackwardIOParameters = field(
-        default_factory=lambda: BackwardIOParameters(is_perfect=True),
+    backward: IOParameters = field(
+        default_factory=lambda: IOParameters(is_perfect=True),
         init=False
     )
     """Input-output parameter setting for the backward direction: perfect."""

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -28,6 +28,10 @@ class BoundManagementType(Enum):
 
     In the case ``Iterative`` the MAC is iteratively recomputed with
     inputs iteratively halved, when the output bound was hit.
+
+    Caution:
+        Bound management is **only** available for the forward pass. It
+        will be ignored when used for the backward pass.
     """
 
     NONE = 'None'
@@ -147,7 +151,12 @@ class IOParameters:
     bm_test_negative_bound: bool = True
 
     bound_management: BoundManagementType = BoundManagementType.ITERATIVE
-    """Type of bound management, see :class:`BoundManagementType`."""
+    """Type of bound management, see :class:`BoundManagementType`.
+
+    Caution:
+        Bound management is **only** available for the forward pass. It
+        will be ignored when used for the backward pass.
+    """
 
     inp_bound: float = 1.0
     """Input bound and ranges for the digital-to-analog converter (DAC)."""
@@ -226,25 +235,11 @@ class IOParameters:
     """Type as specified in :class:`OutputWeightNoiseType`.
 
     Note:
-
-     This noise us applied each time anew as it is referred to
-     the output. It will not change the conductance values of
-     the weight matrix. For the latter one can apply
-     :meth:`diffuse_weights`.
+        This noise us applied each time anew as it is referred to
+        the output. It will not change the conductance values of
+        the weight matrix. For the latter one can apply
+        :meth:`diffuse_weights`.
     """
-
-
-@dataclass
-class BackwardIOParameters(IOParameters):
-    """Parameters that modify the backward IO behavior.
-
-    This class contains the same parameters as
-    ``AnalogTileInputOutputParameters``, specializing the default value of
-    ``bound_management`` (as backward does not support bound management).
-    """
-
-    bound_management: BoundManagementType = BoundManagementType.NONE
-    """Type of noise management, see :class:`NoiseManagementType`."""
 
 
 @dataclass
@@ -278,10 +273,9 @@ class UpdateParameters:
     """Switching between different pulse types. See :class:`PulseTypeMap` for details.
 
     Important:
-
-       Pulsing can also be turned off in which case
-       the update is done as if in floating point and all
-       other update related parameter are ignored.
+        Pulsing can also be turned off in which case
+        the update is done as if in floating point and all
+        other update related parameter are ignored.
    """
 
     res: float = 0
@@ -326,7 +320,6 @@ class WeightModifierParameter:
     ``MultNormal`` and ``DiscretizeAddNormal``.
 
     Note:
-
         If the parameter ``rel_to_actual_wmax`` is set then the
         ``std_dev`` is computed in relative terms to the abs max of the
         given weight matrix, otherwise it in relative terms to the
@@ -368,7 +361,7 @@ class WeightModifierParameter:
     """Whether to use the last modified weight matrix during testing.
 
     Caution:
-        This will NOT remove drop connect or any other noise
+        This will **not** remove drop connect or any other noise
         during evaluation, and thus should only used with care.
     """
 

--- a/src/rpucuda/rpu_pulsed_meta_parameter.cpp
+++ b/src/rpucuda/rpu_pulsed_meta_parameter.cpp
@@ -105,7 +105,7 @@ template <typename T> void IOMetaParameter<T>::initializeForBackward() {
 
     if (this->bound_management != BoundManagementType::None) {
       this->bound_management = BoundManagementType::None;
-      RPU_FATAL("Backward does not support bound management!");
+      // keep silent.
     }
   }
 }

--- a/tests/test_bindings_tiles.py
+++ b/tests/test_bindings_tiles.py
@@ -24,7 +24,7 @@ from aihwkit.simulator.rpu_base import tiles, cuda
 
 from aihwkit.simulator.configs import FloatingPointRPUConfig, SingleRPUConfig
 from aihwkit.simulator.configs.devices import FloatingPointDevice, ConstantStepDevice, IdealDevice
-from aihwkit.simulator.configs.utils import BackwardIOParameters, IOParameters
+from aihwkit.simulator.configs.utils import IOParameters
 
 from .helpers.decorators import parametrize_over_tiles
 from .helpers.testcases import ParametrizedTestCase
@@ -55,7 +55,7 @@ class BindingsTilesTest(ParametrizedTestCase):
         if 'FloatingPoint' not in self.parameter:
             rpu_config = SingleRPUConfig(
                 forward=IOParameters(is_perfect=True),
-                backward=BackwardIOParameters(is_perfect=True),
+                backward=IOParameters(is_perfect=True),
                 device=IdealDevice()
             )
 

--- a/tests/test_bindings_tiles_numpy.py
+++ b/tests/test_bindings_tiles_numpy.py
@@ -22,8 +22,7 @@ from torch import from_numpy
 
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.utils import (
-    BackwardIOParameters, IOParameters,
-    UpdateParameters, PulseType
+    IOParameters, UpdateParameters, PulseType
 )
 from aihwkit.simulator.tiles.numpy import NumpyFloatingPointTile, NumpyAnalogTile
 
@@ -150,7 +149,7 @@ class NumpyAnalogTileTest(NumpyFloatingPointTileTest):
         """Return a tile of the specified dimensions with noisiness turned off."""
         rpu_config = SingleRPUConfig(
             forward=IOParameters(is_perfect=True),
-            backward=BackwardIOParameters(is_perfect=True),
+            backward=IOParameters(is_perfect=True),
             update=UpdateParameters(pulse_type=PulseType('None')),
         )
         python_tile = NumpyAnalogTile(out_size, in_size, rpu_config)

--- a/tests/test_rpu_configurations.py
+++ b/tests/test_rpu_configurations.py
@@ -13,7 +13,7 @@
 """Tests for the high level simulator devices functionality."""
 
 from aihwkit.simulator.configs.utils import (
-    BackwardIOParameters, IOParameters, UpdateParameters
+    IOParameters, UpdateParameters
 )
 
 from .helpers.decorators import parametrize_over_tiles
@@ -101,7 +101,7 @@ class RPUConfigurationsTest(ParametrizedTestCase):
         rpu_config = self.get_rpu_config()
 
         rpu_config.forward = IOParameters(inp_noise=0.321)
-        rpu_config.backward = BackwardIOParameters(inp_noise=0.456)
+        rpu_config.backward = IOParameters(inp_noise=0.456)
         rpu_config.update = UpdateParameters(desired_bl=78)
 
         tile = self.get_tile(11, 22, rpu_config).tile

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,7 @@ from aihwkit.optim.analog_sgd import AnalogSGD
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
 from aihwkit.simulator.configs.utils import (
-    BackwardIOParameters, IOParameters, UpdateParameters
+    IOParameters, UpdateParameters
 )
 
 from .helpers.decorators import parametrize_over_layers
@@ -157,7 +157,7 @@ class SerializationTest(ParametrizedTestCase):
         # Create the device and the array.
         rpu_config = SingleRPUConfig(
             forward=IOParameters(inp_noise=0.321),
-            backward=BackwardIOParameters(inp_noise=0.456),
+            backward=IOParameters(inp_noise=0.456),
             update=UpdateParameters(desired_bl=78),
             device=ConstantStepDevice(w_max=0.987)
         )


### PR DESCRIPTION
## Related issues

None

## Description

One often wants to specify the parameters of the forward and backward in tune, ie if one sets the `inp_res` of the forward, the backward needs to be the same. To facilitate this it would be great if one  could just do 
```
rpu_config.forward.inp_res = 234
rpu_config.backward = rpu_config.forward 
``` 
which would be very expressive and short. However, up to now this is not possible because of the specialization `BackwardIOParameter`

Here I removed this because it is really not needed. The only difference between fwd/bwd is the support for bound management.

## Details
 I now just added a silent change of setting BM to zero in case of backward, instead of an runtime error and added documentation so that users are aware that BM is ignored in case of backward.  
