### PR TITLE
Self-compile googletest during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,5 +90,6 @@ if (BUILD_TEST)
 
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
     set_target_properties(${test_name} PROPERTIES FOLDER tests)
+    add_dependencies(RPU_CPU GTest)
   endforeach()
 endif()

--- a/cmake/dependencies_test.cmake
+++ b/cmake/dependencies_test.cmake
@@ -11,5 +11,19 @@
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
 if(BUILD_TEST)
-  find_package(GTest REQUIRED)
+  include(ExternalProject)
+  ExternalProject_Add(GTest
+    URL               https://github.com/google/googletest/archive/release-1.10.0.zip
+    URL_HASH          MD5=82358affdd7ab94854c8ee73a180fc53
+    CMAKE_ARGS        "-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI\=0"
+    INSTALL_COMMAND   ""
+  )
+
+  ExternalProject_Get_Property(GTest source_dir)
+  ExternalProject_Get_Property(GTest binary_dir)
+  set(GTest_INCLUDE_DIR ${source_dir}/googletest/include)
+  set(GTest_LIBRARY_DIR ${binary_dir}/lib)
+
+  include_directories(SYSTEM ${GTest_INCLUDE_DIR})
+  link_directories(SYSTEM ${GTest_LIBRARY_DIR})
 endif()

--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -35,10 +35,10 @@ C++11 compatible compiler
 `scikit-build`_                  0.11.0+
 `Python 3 development headers`_  3.6+
 BLAS implementation                        `OpenBLAS`_ or `Intel MKL`_
-CUDA                             9.0+      Optional, for GPU-enabled simulator
-`Nvidia CUB`_                    1.8.0     Optional, for GPU-enabled simulator
-`googletest`_                    1.10.0    Optional, for building the C++ tests
 `PyTorch`_                       1.5+      The libtorch library and headers are needed [#f2]_
+CUDA                             9.0+      Optional, for GPU-enabled simulator
+`Nvidia CUB`_                    1.8.0     Optional, for GPU-enabled simulator [#f4]_
+`googletest`_                    1.10.0    Optional, for building the C++ tests [#f4]_
 ===============================  ========  ======
 
 Please refer to your operative system documentation for instructions on how
@@ -111,6 +111,10 @@ of the command will help diagnosing the issue.
 
 .. [#f3] Please note that currently support for conda-based distributions is
    experimental, and further commands might be needed.
+
+.. [#f4] Both ``Nvidia CUB`` and ``googletest`` are downloaded and compiled
+   automatically during the build process. As a result, they do not need to be
+   installed manually.
 
 .. _virtual environment: https://docs.python.org/3/library/venv.html
 


### PR DESCRIPTION
## Related issues

Closes #42 

## Description

Instead of relying on the system-wide `googletest` library, download and compile `googletest` with the right ABI flag during the build process. It uses the same approach we use for CUB (the `ExternalProject` cmake command), although a bit more complex than CUB (as in this case we do compile it).

## Details

After compiling, the way we tell `cmake` to use _our_ compiled version of `googletest` instead of the (potentially installed) system-wide version of `googletest` is not optimal - we just append the local paths to `include_directories` and `link_directories`. It seems to be enough for `cmake` to pick the right one, but we might need to refine it eventually.
