### PR TITLE
Add aihwkit.exceptions module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [UNRELEASED]
 
+### Changed
+
+* The `Exceptions` raised by the library have been revised, making use in some
+  cases of the ones introduced in a new `aihwkit.exceptions` module. (\#49)
+
 ### Removed
 
 * The `BackwardIOParameters` specialization has been removed, as bound

--- a/docs/source/api/aihwkit.exceptions.rst
+++ b/docs/source/api/aihwkit.exceptions.rst
@@ -1,0 +1,7 @@
+aihwkit.exceptions module
+=========================
+
+.. automodule:: aihwkit.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/aihwkit.rst
+++ b/docs/source/api/aihwkit.rst
@@ -12,6 +12,7 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   aihwkit.exceptions
    aihwkit.simulator
    aihwkit.nn
    aihwkit.optim

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -5,6 +5,7 @@ API Reference
    :recursive:
 
    aihwkit
+   aihwkit.exceptions
    aihwkit.simulator
    aihwkit.simulator.configs
    aihwkit.simulator.noise_models

--- a/src/aihwkit/exceptions.py
+++ b/src/aihwkit/exceptions.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Custom Exceptions for aihwkit."""
+
+
+class AihwkitException(Exception):
+    """Base class for exceptions related to aihwkit."""
+
+
+class ModuleError(AihwkitException):
+    """Exceptions related to analog neural network modules."""
+
+
+class TileError(AihwkitException):
+    """Exceptions related to analog tiles."""
+
+
+class CudaError(AihwkitException):
+    """Exceptions related to CUDA."""

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -18,6 +18,7 @@ from torch import Tensor
 from torch import device as torch_device
 from torch.nn import Module
 
+from aihwkit.exceptions import ModuleError
 from aihwkit.simulator.configs import (
     FloatingPointRPUConfig, SingleRPUConfig, UnitCellRPUConfig, InferenceRPUConfig
 )
@@ -236,8 +237,8 @@ class AnalogModuleBase(Module):
             t_inference: assumed time of inference (in sec)
         """
         if self.training:
-            raise RuntimeError('drift_analog_weights can only be applied in '
-                               'evaluation mode')
+            raise ModuleError('drift_analog_weights can only be applied in '
+                              'evaluation mode')
 
         if isinstance(self.analog_tile, InferenceTile):
             self.analog_tile.drift_weights(t_inference)
@@ -245,8 +246,8 @@ class AnalogModuleBase(Module):
     def program_analog_weights(self) -> None:
         """Program the analog weights."""
         if self.training:
-            raise RuntimeError('program_analog_weights can only be applied in '
-                               'evaluation mode')
+            raise ModuleError('program_analog_weights can only be applied in '
+                              'evaluation mode')
 
         if isinstance(self.analog_tile, InferenceTile):
             self.analog_tile.program_weights()

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -17,6 +17,7 @@ from typing import Callable, Optional, Union
 from torch import device as torch_device
 from torch.nn import Sequential
 
+from aihwkit.exceptions import ModuleError
 from aihwkit.nn.modules.base import AnalogModuleBase
 
 
@@ -67,15 +68,15 @@ class AnalogSequential(Sequential):
             t_inference: assumed time of inference (in sec
         """
         if self.training:
-            raise RuntimeError('drift_analog_weights can only be applied in '
-                               'evaluation mode')
+            raise ModuleError('drift_analog_weights can only be applied in '
+                              'evaluation mode')
 
         self._apply_to_analog(lambda m: m.drift_analog_weights(t_inference))
 
     def program_analog_weights(self) -> None:
         """Program all analog inference layers of a given model."""
         if self.training:
-            raise RuntimeError('program_analog_weights can only be applied in '
-                               'evaluation mode')
+            raise ModuleError('program_analog_weights can only be applied in '
+                              'evaluation mode')
 
         self._apply_to_analog(lambda m: m.program_weights())

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -88,9 +88,9 @@ class AnalogConv2d(Conv2d, AnalogModuleBase):
     ):
         # pylint: disable=too-many-arguments
         if groups != 1:
-            raise RuntimeError('Only one group is supported')
+            raise ValueError('Only one group is supported')
         if padding_mode != 'zeros':
-            raise RuntimeError('Only "zeros" padding mode is supported')
+            raise ValueError('Only "zeros" padding mode is supported')
 
         kernel_size = _pair(kernel_size)
         self.in_features = (in_channels // groups) * kernel_size[0] * kernel_size[1]  # type: ignore

--- a/src/aihwkit/simulator/tiles/analog.py
+++ b/src/aihwkit/simulator/tiles/analog.py
@@ -19,6 +19,7 @@ from torch import device as torch_device
 from torch.cuda import current_device, current_stream
 from torch.cuda import device as cuda_device
 
+from aihwkit.exceptions import CudaError
 from aihwkit.simulator.configs import (InferenceRPUConfig, SingleRPUConfig, UnitCellRPUConfig)
 from aihwkit.simulator.configs.devices import ConstantStepDevice
 from aihwkit.simulator.tiles.base import BaseTile
@@ -199,7 +200,7 @@ class AnalogTile(BaseTile):
             device: CUDA device
         """
         if not cuda.is_compiled():
-            raise RuntimeError('aihwkit has not been compiled with CUDA support')
+            raise CudaError('aihwkit has not been compiled with CUDA support')
 
         with cuda_device(device):
             tile = CudaAnalogTile(self)
@@ -243,7 +244,7 @@ class CudaAnalogTile(AnalogTile):
 
     def __init__(self, source_tile: AnalogTile):
         if not cuda.is_compiled():
-            raise RuntimeError('aihwkit has not been compiled with CUDA support')
+            raise CudaError('aihwkit has not been compiled with CUDA support')
 
         # Create a new instance of the rpu config.
         new_rpu_config = deepcopy(source_tile.rpu_config)
@@ -262,6 +263,6 @@ class CudaAnalogTile(AnalogTile):
             device: Optional[Union[torch_device, str, int]] = None
     ) -> 'CudaAnalogTile':
         if self.stream != current_stream(device):
-            raise ValueError("Cannot switch CUDA devices of existing Cuda tiles")
+            raise CudaError("Cannot switch CUDA devices of existing Cuda tiles")
 
         return self

--- a/src/aihwkit/simulator/tiles/floating_point.py
+++ b/src/aihwkit/simulator/tiles/floating_point.py
@@ -20,6 +20,7 @@ from torch import device as torch_device
 from torch.cuda import current_device, current_stream
 from torch.cuda import device as cuda_device
 
+from aihwkit.exceptions import CudaError
 from aihwkit.simulator.configs import (
     FloatingPointRPUConfig
 )
@@ -119,7 +120,7 @@ class FloatingPointTile(BaseTile):
         """Return a copy of this tile in CUDA memory."""
 
         if not cuda.is_compiled():
-            raise RuntimeError('aihwkit has not been compiled with CUDA support')
+            raise CudaError('aihwkit has not been compiled with CUDA support')
 
         with cuda_device(device):
             tile = CudaFloatingPointTile(self)
@@ -162,7 +163,7 @@ class CudaFloatingPointTile(FloatingPointTile):
 
     def __init__(self, source_tile: FloatingPointTile):
         if not cuda.is_compiled():
-            raise RuntimeError('aihwkit has not been compiled with CUDA support')
+            raise CudaError('aihwkit has not been compiled with CUDA support')
 
         # Create a new instance of the rpu config.
         new_rpu_config = deepcopy(source_tile.rpu_config)
@@ -181,6 +182,6 @@ class CudaFloatingPointTile(FloatingPointTile):
             device: Optional[Union[torch_device, str, int]] = None
     ) -> 'CudaFloatingPointTile':
         if self.stream != current_stream(device):
-            raise ValueError("Cannot switch streams of existing Cuda tiles")
+            raise CudaError("Cannot switch streams of existing Cuda tiles")
 
         return self

--- a/src/aihwkit/simulator/tiles/inference.py
+++ b/src/aihwkit/simulator/tiles/inference.py
@@ -21,6 +21,7 @@ from torch.cuda import device as cuda_device
 from torch import device as torch_device
 from torch.autograd import no_grad
 
+from aihwkit.exceptions import CudaError
 from aihwkit.simulator.tiles.base import BaseTile
 from aihwkit.simulator.tiles.analog import AnalogTile
 from aihwkit.simulator.configs import InferenceRPUConfig
@@ -179,7 +180,7 @@ class InferenceTile(AnalogTile):
             device: CUDA device
         """
         if not cuda.is_compiled():
-            raise RuntimeError('aihwkit has not been compiled with CUDA support')
+            raise CudaError('aihwkit has not been compiled with CUDA support')
 
         with cuda_device(device):
             tile = CudaInferenceTile(self)
@@ -211,7 +212,7 @@ class CudaInferenceTile(InferenceTile):
 
     def __init__(self, source_tile: AnalogTile):
         if not cuda.is_compiled():
-            raise RuntimeError('aihwkit has not been compiled with CUDA support')
+            raise CudaError('aihwkit has not been compiled with CUDA support')
 
         # Create a new instance of the rpu config.
         new_rpu_config = deepcopy(source_tile.rpu_config)
@@ -230,6 +231,6 @@ class CudaInferenceTile(InferenceTile):
             device: Optional[Union[torch_device, str, int]] = None
     ) -> 'CudaInferenceTile':
         if self.stream != current_stream(device):
-            raise ValueError("Cannot switch CUDA devices of existing Cuda tiles")
+            raise CudaError("Cannot switch CUDA devices of existing Cuda tiles")
 
         return self


### PR DESCRIPTION
## Related issues

Closes #43

## Description

Add a new `aihwkit.exceptions` module that contains base exceptions to be used by the library. Overall, the intent is to just start the `Exception` hierarchy for future needs, taking the chance to revise the `raise` clauses of the codebase and make them more homogeneous.

## Details

<!-- A more elaborate description of the changes, if needed. -->
