### PR TITLE
Ease importing of AnalogSGD

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ from torch.nn.functional import mse_loss
 
 # Import the aihwkit constructs.
 from aihwkit.nn import AnalogLinear
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 
 x = Tensor([[0.1, 0.2, 0.4, 0.3], [0.2, 0.1, 0.1, 0.3]])
 y = Tensor([[1.0, 0.5], [0.7, 0.3]])

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,7 +69,7 @@ Example
     from torch.nn.functional import mse_loss
 
     from aihwkit.nn import AnalogLinear
-    from aihwkit.optim.analog_sgd import AnalogSGD
+    from aihwkit.optim import AnalogSGD
 
     x = Tensor([[0.1, 0.2, 0.4, 0.3], [0.2, 0.1, 0.1, 0.3]])
     y = Tensor([[1.0, 0.5], [0.7, 0.3]])

--- a/docs/source/using_pytorch.rst
+++ b/docs/source/using_pytorch.rst
@@ -130,7 +130,7 @@ snippet would create an analog-aware stochastic gradient descent optimizer
 with a learning rate of ``0.1``, and set it up for using with the
 analog layers of the model::
 
-    from aihwkit.optim.analog_sgd import AnalogSGD
+    from aihwkit.optim import AnalogSGD
 
     optimizer = AnalogSGD(model.parameters(), lr=0.1)
     optimizer.regroup_param_groups(model)
@@ -157,7 +157,7 @@ in order to perform training::
     from torch.nn.functional import mse_loss
 
     from aihwkit.nn import AnalogLinear
-    from aihwkit.optim.analog_sgd import AnalogSGD
+    from aihwkit.optim import AnalogSGD
 
     x = Tensor([[0.1, 0.2, 0.4, 0.3], [0.2, 0.1, 0.1, 0.3]])
     y = Tensor([[1.0, 0.5], [0.7, 0.3]])

--- a/examples/1_simple_layer.py
+++ b/examples/1_simple_layer.py
@@ -22,7 +22,7 @@ from torch.nn.functional import mse_loss
 
 # Imports from aihwkit.
 from aihwkit.nn import AnalogLinear
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
 from aihwkit.simulator.rpu_base import cuda

--- a/examples/2_multiple_layer.py
+++ b/examples/2_multiple_layer.py
@@ -23,7 +23,7 @@ from torch.nn import Sequential
 
 # Imports from aihwkit.
 from aihwkit.nn import AnalogLinear
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
 

--- a/examples/3_mnist_training.py
+++ b/examples/3_mnist_training.py
@@ -29,7 +29,7 @@ from torchvision import datasets, transforms
 
 # Imports from aihwkit.
 from aihwkit.nn import AnalogLinear
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
 

--- a/examples/4_lenet5_training.py
+++ b/examples/4_lenet5_training.py
@@ -32,7 +32,7 @@ from torchvision import datasets, transforms
 
 # Imports from aihwkit.
 from aihwkit.nn import AnalogConv2d, AnalogLinear, AnalogSequential
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import SingleRPUConfig, FloatingPointRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice, FloatingPointDevice
 

--- a/examples/5_simple_layer_hardware_aware.py
+++ b/examples/5_simple_layer_hardware_aware.py
@@ -22,7 +22,7 @@ from torch.nn.functional import mse_loss
 
 # Imports from aihwkit.
 from aihwkit.nn import AnalogLinear
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import InferenceRPUConfig
 from aihwkit.simulator.configs.utils import (
     OutputWeightNoiseType, WeightClipType, WeightModifierType)

--- a/examples/6_lenet5_hardware_aware.py
+++ b/examples/6_lenet5_hardware_aware.py
@@ -29,7 +29,7 @@ from torchvision import datasets, transforms
 
 # Imports from aihwkit.
 from aihwkit.nn import AnalogConv2d, AnalogLinear, AnalogSequential
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import InferenceRPUConfig
 from aihwkit.simulator.configs.utils import OutputWeightNoiseType
 from aihwkit.simulator.noise_models import PCMLikeNoiseModel

--- a/examples/7_simple_layer_with_other_devices.py
+++ b/examples/7_simple_layer_with_other_devices.py
@@ -22,7 +22,7 @@ from torch.nn.functional import mse_loss
 
 # Imports from aihwkit.
 from aihwkit.nn import AnalogLinear
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import UnitCellRPUConfig
 from aihwkit.simulator.configs.devices import (
     ConstantStepDevice,

--- a/examples/8_simple_layer_with_tiki_taka.py
+++ b/examples/8_simple_layer_with_tiki_taka.py
@@ -22,7 +22,7 @@ from torch.nn.functional import mse_loss
 
 # Imports from aihwkit.
 from aihwkit.nn import AnalogLinear
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import UnitCellRPUConfig
 from aihwkit.simulator.configs.devices import (
     TransferCompoundDevice,

--- a/src/aihwkit/nn/__init__.py
+++ b/src/aihwkit/nn/__init__.py
@@ -12,6 +12,8 @@
 
 """Neural network modules."""
 
+# Convenience imports for easier access to the classes.
+
 from aihwkit.nn.modules.container import AnalogSequential
 from aihwkit.nn.modules.conv import AnalogConv2d
 from aihwkit.nn.modules.linear import AnalogLinear

--- a/src/aihwkit/optim/__init__.py
+++ b/src/aihwkit/optim/__init__.py
@@ -11,3 +11,7 @@
 # that they have been altered from the originals.
 
 """Analog Optimizers."""
+
+# Convenience imports for easier access to the classes.
+
+from aihwkit.optim.analog_sgd import AnalogSGD

--- a/src/aihwkit/simulator/tiles/__init__.py
+++ b/src/aihwkit/simulator/tiles/__init__.py
@@ -12,6 +12,8 @@
 
 """High level analog tiles."""
 
+# Convenience imports for easier access to the classes.
+
 from aihwkit.simulator.tiles.base import BaseTile
 from aihwkit.simulator.tiles.floating_point import FloatingPointTile, CudaFloatingPointTile
 from aihwkit.simulator.tiles.analog import AnalogTile, CudaAnalogTile

--- a/tests/test_inference_tiles.py
+++ b/tests/test_inference_tiles.py
@@ -17,7 +17,7 @@ from torch import Tensor
 from torch.nn.functional import mse_loss
 
 from aihwkit.nn import AnalogLinear
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs.utils import (
     OutputWeightNoiseType, WeightClipType, WeightModifierType
 )

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -16,7 +16,7 @@ from unittest import SkipTest
 
 from torch import Tensor
 
-from aihwkit.nn.modules.container import AnalogSequential
+from aihwkit.nn import AnalogSequential
 from aihwkit.simulator.tiles import AnalogTile, CudaAnalogTile
 from aihwkit.simulator.rpu_base import cuda
 

--- a/tests/test_layers_convolution.py
+++ b/tests/test_layers_convolution.py
@@ -16,7 +16,7 @@ from torch import randn
 from torch.nn import Conv2d as torch_Conv2d, Sequential
 from torch.nn.functional import mse_loss
 
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 
 from .helpers.decorators import parametrize_over_layers
 from .helpers.layers import Conv2d, Conv2dCuda

--- a/tests/test_layers_lineal.py
+++ b/tests/test_layers_lineal.py
@@ -16,7 +16,7 @@ from torch import Tensor, manual_seed
 from torch.nn import Sequential, Linear as torchLinear
 from torch.nn.functional import mse_loss
 
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.optim import AnalogSGD
 
 from .helpers.decorators import parametrize_over_layers
 from .helpers.layers import Linear, LinearCuda

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,8 +19,8 @@ from numpy.testing import assert_array_almost_equal, assert_raises
 from torch import Tensor, save, load
 from torch.nn.functional import mse_loss
 
-from aihwkit.nn.modules.conv import AnalogConv2d
-from aihwkit.optim.analog_sgd import AnalogSGD
+from aihwkit.nn import AnalogConv2d
+from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
 from aihwkit.simulator.configs.utils import (


### PR DESCRIPTION
## Related issues

#48 (quite tangentially though!)

## Description

Allow importing the `AnalogSGD` optimizer as:

```
from aihwkit.optim import AnalogSGD
```

in the same way we provide convenience imports in other modules, and adding some comments and updating the examples/documentation in the process.

## Details

<!-- A more elaborate description of the changes, if needed. -->
