### PR TITLE
Provide pointer to repo in install section

### DIFF
--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -31,7 +31,7 @@ Dependency                       Version   Notes
 ===============================  ========  ======
 C++11 compatible compiler
 `cmake`_                         3.18+
-`pybind11`_                      2.6.0+    Version 2.6.0 can be installed using ``pip``(recommended)
+`pybind11`_                      2.6.0+    Version 2.6.0 can be installed using ``pip`` (recommended)
 `scikit-build`_                  0.11.0+
 `Python 3 development headers`_  3.6+
 BLAS implementation                        `OpenBLAS`_ or `Intel MKL`_

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -33,13 +33,20 @@ creating an analog layer and predicting the output::
     model = AnalogLinear(3, 2)
     model(Tensor([[0.1, 0.2], [0.3, 0.4]]))
 
+If you encounter any issues during the installation or executing the snippet,
+please refer to the :doc:`advanced_install` for more details and don't
+hesitate on using the `issue tracker`_ for additional support.
+
+Next steps
+----------
+
 You can read more about the Pytorch layers in the :doc:`using_pytorch`
 section, and about the internal analog tiles in the :doc:`using_simulator`
 section.
 
-.. _OpenBLAS: https://www.openblas.net
-.. _CUDA Toolkit: https://developer.nvidia.com/accelerated-computing-toolkit
-
-
 .. [#f1] Note that GPU support is not available in OSX, as it depends on a
    platform that has official CUDA support.
+
+.. _OpenBLAS: https://www.openblas.net
+.. _CUDA Toolkit: https://developer.nvidia.com/accelerated-computing-toolkit
+.. _issue tracker: https://github.com/IBM/aihwkit/issues


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Revise the `install.rst` section with further pointers to the advanced section (in cases where the user is forced to compile due to the pip package not available) and with a clear path to the repository issues (thanks Cody for the suggestion!).

## Details

<!-- A more elaborate description of the changes, if needed. -->
