### PR TITLE
Rename unit cell devices in simulator.configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Changed
 
+* The unit cell items in `aihwkit.simulator.configs` have been renamed, removing
+  their `Device` suffix, for having a more consistent naming scheme. (\#57)
 * The `Exceptions` raised by the library have been revised, making use in some
   cases of the ones introduced in a new `aihwkit.exceptions` module. (\#49)
-
 * The `pybind11` version required has been bumped to 2.6.0, which can be
   installed from `pip` and makes system-wide installation no longer required.
   Please update your `pybind11` accordingly for compiling the library. (\#44)

--- a/docs/source/pcm_inference.rst
+++ b/docs/source/pcm_inference.rst
@@ -217,7 +217,7 @@ inference features, one has to build an model using our
     # specify additional options of the non-idealities in forward to your liking
     rpu_config.forward.inp_res = 1/64.  # 6-bit DAC discretization.
     rpu_config.forward.out_res = 1/256. # 8-bit ADC discretization.
-    rpu_config.forward.w_noise_type = OutputWeightNoiseType.ADDITIVE_CONSTANT
+    rpu_config.forward.w_noise_type = WeightNoiseType.ADDITIVE_CONSTANT
     rpu_config.forward.w_noise = 0.02   # Some short-term w-noise.
     rpu_config.forward.out_noise = 0.02 # Some output noise.
 

--- a/docs/source/using_simulator.rst
+++ b/docs/source/using_simulator.rst
@@ -116,8 +116,8 @@ Unit cell devices
 ====================================================================  ========
 Resistive device class                                                Description
 ====================================================================  ========
-:class:`~aihwkit.simulator.configs.devices.VectorUnitCellDevice`      abstract resistive device that combines multiple pulsed resistive devices in a single 'unit cell'.
-:class:`~aihwkit.simulator.configs.devices.DifferenceUnitCellDevice`  abstract device model takes an arbitrary device per crosspoint and implements an explicit plus-minus device pair.
+:class:`~aihwkit.simulator.configs.devices.VectorUnitCell`            abstract resistive device that combines multiple pulsed resistive devices in a single 'unit cell'.
+:class:`~aihwkit.simulator.configs.devices.DifferenceUnitCell`        abstract device model takes an arbitrary device per crosspoint and implements an explicit plus-minus device pair.
 ====================================================================  ========
 
 Compound devices
@@ -126,7 +126,7 @@ Compound devices
 ====================================================================  ========
 Resistive device class                                                Description
 ====================================================================  ========
-:class:`~aihwkit.simulator.configs.devices.TransferCompoundDevice`    abstract device model that takes 2 or more devices per crosspoint and implements a 'transfer' based learning rule such as Tiki-Taka (see `Gokmen & Haensch 2020`_).
+:class:`~aihwkit.simulator.configs.devices.TransferCompound`          abstract device model that takes 2 or more devices per crosspoint and implements a 'transfer' based learning rule such as Tiki-Taka (see `Gokmen & Haensch 2020`_).
 ====================================================================  ========
 
 RPU Configurations
@@ -221,7 +221,7 @@ pulse update behavior, one could do (see also `Example 7`_)::
     from aihwkit.simulator.configs import UnitCellRPUConfig
     from aihwkit.simulator.configs.devices import (
         ConstantStepDevice,
-        VectorUnitCellDevice,
+        VectorUnitCell,
         LinearStepDevice,
         SoftBoundsDevice
     )
@@ -231,7 +231,7 @@ pulse update behavior, one could do (see also `Example 7`_)::
 
     rpu_config = UnitCellRPUConfig()
 
-    rpu_config.device = VectorUnitCellDevice(
+    rpu_config.device = VectorUnitCell(
         unit_cell_devices=[
             ConstantStepDevice(),
             LinearStepDevice(w_max_dtod=0.4),
@@ -283,13 +283,13 @@ use the following tile configuration for that (see also `Example 8`_)::
     # Imports from aihwkit.
     from aihwkit.simulator.configs import UnitCellRPUConfig
     from aihwkit.simulator.configs.devices import (
-        TransferCompoundDevice,
+        TransferCompound,
         SoftBoundsDevice
     )
 
     # The Tiki-taka learning rule can be implemented using the transfer device.
     rpu_config = UnitCellRPUConfig(
-        device=TransferCompoundDevice(
+        device=TransferCompound(
 
             # devices that compose the Tiki-taka compound
             unit_cell_devices=[

--- a/examples/5_simple_layer_hardware_aware.py
+++ b/examples/5_simple_layer_hardware_aware.py
@@ -25,7 +25,7 @@ from aihwkit.nn import AnalogLinear
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import InferenceRPUConfig
 from aihwkit.simulator.configs.utils import (
-    OutputWeightNoiseType, WeightClipType, WeightModifierType)
+    WeightNoiseType, WeightClipType, WeightModifierType)
 from aihwkit.simulator.noise_models import PCMLikeNoiseModel, GlobalDriftCompensation
 from aihwkit.simulator.rpu_base import cuda
 
@@ -36,7 +36,7 @@ y = Tensor([[1.0, 0.5], [0.7, 0.3]])
 # Define a single-layer network, using inference/hardware-aware training tile
 rpu_config = InferenceRPUConfig()
 rpu_config.forward.out_res = -1.  # Turn off (output) ADC discretization.
-rpu_config.forward.w_noise_type = OutputWeightNoiseType.ADDITIVE_CONSTANT
+rpu_config.forward.w_noise_type = WeightNoiseType.ADDITIVE_CONSTANT
 rpu_config.forward.w_noise = 0.02  # Short-term w-noise.
 
 rpu_config.clip.type = WeightClipType.FIXED_VALUE

--- a/examples/6_lenet5_hardware_aware.py
+++ b/examples/6_lenet5_hardware_aware.py
@@ -31,7 +31,7 @@ from torchvision import datasets, transforms
 from aihwkit.nn import AnalogConv2d, AnalogLinear, AnalogSequential
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import InferenceRPUConfig
-from aihwkit.simulator.configs.utils import OutputWeightNoiseType
+from aihwkit.simulator.configs.utils import WeightNoiseType
 from aihwkit.simulator.noise_models import PCMLikeNoiseModel
 
 # Check device
@@ -58,7 +58,7 @@ N_CLASSES = 10
 # the inference/training pass
 RPU_CONFIG = InferenceRPUConfig()
 RPU_CONFIG.forward.out_res = -1.  # Turn off (output) ADC discretization.
-RPU_CONFIG.forward.w_noise_type = OutputWeightNoiseType.ADDITIVE_CONSTANT
+RPU_CONFIG.forward.w_noise_type = WeightNoiseType.ADDITIVE_CONSTANT
 RPU_CONFIG.forward.w_noise = 0.02
 RPU_CONFIG.noise_model = PCMLikeNoiseModel(g_max=25.0)
 

--- a/examples/7_simple_layer_with_other_devices.py
+++ b/examples/7_simple_layer_with_other_devices.py
@@ -26,7 +26,7 @@ from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import UnitCellRPUConfig
 from aihwkit.simulator.configs.devices import (
     ConstantStepDevice,
-    VectorUnitCellDevice,
+    VectorUnitCell,
     LinearStepDevice,
     SoftBoundsDevice)
 from aihwkit.simulator.rpu_base import cuda
@@ -40,7 +40,7 @@ y = Tensor([[1.0, 0.5], [0.7, 0.3]])
 
 rpu_config = UnitCellRPUConfig()
 # 3 arbitrary devices per cross-point.
-rpu_config.device = VectorUnitCellDevice(
+rpu_config.device = VectorUnitCell(
     unit_cell_devices=[
         ConstantStepDevice(),
         LinearStepDevice(w_max_dtod=0.4),

--- a/examples/8_simple_layer_with_tiki_taka.py
+++ b/examples/8_simple_layer_with_tiki_taka.py
@@ -25,7 +25,7 @@ from aihwkit.nn import AnalogLinear
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import UnitCellRPUConfig
 from aihwkit.simulator.configs.devices import (
-    TransferCompoundDevice,
+    TransferCompound,
     SoftBoundsDevice)
 from aihwkit.simulator.rpu_base import cuda
 
@@ -35,7 +35,7 @@ y = Tensor([[1.0, 0.5], [0.7, 0.3]])
 
 # The Tiki-taka learning rule can be implemented using the transfer device.
 rpu_config = UnitCellRPUConfig(
-    device=TransferCompoundDevice(
+    device=TransferCompound(
 
         # Devices that compose the Tiki-taka compound.
         unit_cell_devices=[

--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -17,7 +17,7 @@ from typing import ClassVar, Type
 
 from aihwkit.simulator.configs.devices import (
     FloatingPointDevice, ConstantStepDevice, PulsedDevice,
-    UnitCellDevice, IdealDevice
+    UnitCell, IdealDevice
 )
 
 from aihwkit.simulator.configs.utils import (
@@ -85,7 +85,7 @@ class UnitCellRPUConfig:
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 
-    device: UnitCellDevice = field(default_factory=UnitCellDevice)
+    device: UnitCell = field(default_factory=UnitCell)
     """Parameters that modify the behavior of the pulsed device."""
 
     forward: IOParameters = field(default_factory=IOParameters)

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -211,7 +211,7 @@ class PulsedDevice:
 
 
 @dataclass
-class UnitCellDevice:
+class UnitCell:
     """Parameters that modify the behaviour of a unit cell."""
 
     bindings_class: ClassVar[Type] = devices.VectorResistiveDeviceParameter
@@ -492,7 +492,7 @@ class ExpStepDevice(PulsedDevice):
 ###############################################################################
 
 @dataclass
-class VectorUnitCellDevice(UnitCellDevice):
+class VectorUnitCell(UnitCell):
     """Abstract resistive device that combines multiple pulsed resistive
     devices in a single 'unit cell'.
 
@@ -523,7 +523,7 @@ class VectorUnitCellDevice(UnitCellDevice):
 
 
 @dataclass
-class DifferenceUnitCellDevice(UnitCellDevice):
+class DifferenceUnitCell(UnitCell):
     """Abstract device model takes an arbitrary device per crosspoint and
     implements an explicit plus-minus device pair.
 
@@ -556,7 +556,7 @@ class DifferenceUnitCellDevice(UnitCellDevice):
 
 
 @dataclass
-class TransferCompoundDevice(UnitCellDevice):
+class TransferCompound(UnitCell):
     r"""Abstract device model that takes 2 or more devices and
     implements a 'transfer' based learning rule.
 

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -62,7 +62,7 @@ class NoiseManagementType(Enum):
     r"""A constant value (given by parameter ``nm_thres``)."""
 
 
-class OutputWeightNoiseType(Enum):
+class WeightNoiseType(Enum):
     r"""Output weight noise type.
 
     The weight noise is applied for each MAC computation, while not
@@ -231,7 +231,7 @@ class IOParameters:
     r"""Scale of output referred weight noise (:math:`\sigma_w`) for a given
     ``w_noise_type``."""
 
-    w_noise_type: OutputWeightNoiseType = OutputWeightNoiseType.NONE
+    w_noise_type: WeightNoiseType = WeightNoiseType.NONE
     """Type as specified in :class:`OutputWeightNoiseType`.
 
     Note:

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -391,7 +391,7 @@ void declare_rpu_devices(py::module &m) {
       .value("Constant", RPU::NoiseManagementType::Constant)
       .value("Max", RPU::NoiseManagementType::Max);
 
-  py::enum_<RPU::OutputWeightNoiseType>(m, "OutputWeightNoiseType")
+  py::enum_<RPU::OutputWeightNoiseType>(m, "WeightNoiseType")
       .value("None", RPU::OutputWeightNoiseType::None)
       .value("AdditiveConstant", RPU::OutputWeightNoiseType::AdditiveConstant);
 

--- a/tests/helpers/tiles.py
+++ b/tests/helpers/tiles.py
@@ -22,9 +22,9 @@ from aihwkit.simulator.configs.devices import (
     ExpStepDevice,
     SoftBoundsDevice,
     IOParameters,
-    DifferenceUnitCellDevice,
-    VectorUnitCellDevice,
-    TransferCompoundDevice
+    DifferenceUnitCell,
+    VectorUnitCell,
+    TransferCompound
 )
 from aihwkit.simulator.configs import (
     FloatingPointRPUConfig,
@@ -119,7 +119,7 @@ class Vector:
     use_cuda = False
 
     def get_rpu_config(self):
-        return UnitCellRPUConfig(device=VectorUnitCellDevice(
+        return UnitCellRPUConfig(device=VectorUnitCell(
             unit_cell_devices=[
                 ConstantStepDevice(w_max_dtod=0, w_min_dtod=0),
                 ConstantStepDevice(w_max_dtod=0, w_min_dtod=0)
@@ -138,7 +138,7 @@ class Difference:
     use_cuda = False
 
     def get_rpu_config(self):
-        return UnitCellRPUConfig(device=DifferenceUnitCellDevice(
+        return UnitCellRPUConfig(device=DifferenceUnitCell(
             unit_cell_devices=[
                 ConstantStepDevice(w_max_dtod=0, w_min_dtod=0)
             ]))
@@ -156,7 +156,7 @@ class Transfer:
     use_cuda = False
 
     def get_rpu_config(self):
-        return UnitCellRPUConfig(device=TransferCompoundDevice(
+        return UnitCellRPUConfig(device=TransferCompound(
             unit_cell_devices=[
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0),
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0)
@@ -267,7 +267,7 @@ class VectorCuda:
     use_cuda = True
 
     def get_rpu_config(self):
-        return UnitCellRPUConfig(device=VectorUnitCellDevice(
+        return UnitCellRPUConfig(device=VectorUnitCell(
             unit_cell_devices=[
                 ConstantStepDevice(w_max_dtod=0, w_min_dtod=0),
                 ConstantStepDevice(w_max_dtod=0, w_min_dtod=0)
@@ -286,7 +286,7 @@ class DifferenceCuda:
     use_cuda = True
 
     def get_rpu_config(self):
-        return UnitCellRPUConfig(device=DifferenceUnitCellDevice(
+        return UnitCellRPUConfig(device=DifferenceUnitCell(
             unit_cell_devices=[
                 ConstantStepDevice(w_max_dtod=0, w_min_dtod=0)
             ]))
@@ -304,7 +304,7 @@ class TransferCuda:
     use_cuda = True
 
     def get_rpu_config(self):
-        return UnitCellRPUConfig(device=TransferCompoundDevice(
+        return UnitCellRPUConfig(device=TransferCompound(
             unit_cell_devices=[
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0),
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0)

--- a/tests/test_inference_tiles.py
+++ b/tests/test_inference_tiles.py
@@ -19,7 +19,7 @@ from torch.nn.functional import mse_loss
 from aihwkit.nn import AnalogLinear
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs.utils import (
-    OutputWeightNoiseType, WeightClipType, WeightModifierType
+    WeightNoiseType, WeightClipType, WeightModifierType
 )
 from aihwkit.simulator.noise_models import PCMLikeNoiseModel
 
@@ -44,7 +44,7 @@ class InferenceTileTest(ParametrizedTestCase):
         # Define a single-layer network, using a constant step device type.
         rpu_config = self.get_rpu_config()
         rpu_config.forward.out_res = -1.  # Turn off (output) ADC discretization.
-        rpu_config.forward.w_noise_type = OutputWeightNoiseType.ADDITIVE_CONSTANT
+        rpu_config.forward.w_noise_type = WeightNoiseType.ADDITIVE_CONSTANT
         rpu_config.forward.w_noise = 0.02
         rpu_config.noise_model = PCMLikeNoiseModel(g_max=25.0)
 


### PR DESCRIPTION
## Related issues

#6 (final tweaks)

## Description

Rename several configuration items that were meant to be renamed in previous iterations:
    
* `DifferenceUnitCellDevice` to `DifferenceUnitCell`
* `TransferCompoundDevice` to `TransferCompound`
* `UnitCellDevice` to `UnitCell`
* `VectorUnitCellDevice` to `VectorUnitCell`
* `OutputWeightNoiseType` to `WeightNoiseType`

<!-- A short description of the changes included in the pull request. -->

## Details


