### PR TITLE
Pretty print the RPUConfigs

### DIFF
--- a/examples/8_simple_layer_with_tiki_taka.py
+++ b/examples/8_simple_layer_with_tiki_taka.py
@@ -64,8 +64,17 @@ rpu_config.device.transfer_forward = rpu_config.forward
 # SGD update/transfer-update will be done with stochastic pulsing.
 rpu_config.device.transfer_update = rpu_config.update
 
+# print the config (default values are omitted)
+print('\nPretty-print of non-default settings:\n')
+print(rpu_config)
+
+print('\nInfo about all settings:\n')
+print(repr(rpu_config))
+
 model = AnalogLinear(4, 2, bias=True, rpu_config=rpu_config)
 
+# a more detailed printout of the instantiated
+print('\nInfo about the instantiated C++ tile:\n')
 print(model.analog_tile.tile)
 
 # Move the model and tensors to cuda if it is available.

--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -19,11 +19,12 @@ from aihwkit.simulator.configs.devices import (
     FloatingPointDevice, ConstantStepDevice, PulsedDevice,
     UnitCell, IdealDevice
 )
-
+from aihwkit.simulator.configs.helpers import (
+    _PrintableMixin, tile_parameters_to_bindings
+)
 from aihwkit.simulator.configs.utils import (
     IOParameters, UpdateParameters, PulseType,
-    WeightClipParameter, WeightModifierParameter,
-    tile_parameters_to_bindings
+    WeightClipParameter, WeightModifierParameter
 )
 from aihwkit.simulator.rpu_base import devices
 from aihwkit.simulator.noise_models import (
@@ -33,7 +34,7 @@ from aihwkit.simulator.noise_models import (
 
 
 @dataclass
-class FloatingPointRPUConfig:
+class FloatingPointRPUConfig(_PrintableMixin):
     """Configuration for a floating point resistive processing unit."""
 
     device: FloatingPointDevice = field(default_factory=FloatingPointDevice)
@@ -49,7 +50,7 @@ class FloatingPointRPUConfig:
 
 
 @dataclass
-class SingleRPUConfig:
+class SingleRPUConfig(_PrintableMixin):
     """Configuration for an analog (pulsed device) resistive processing unit."""
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
@@ -80,7 +81,7 @@ class SingleRPUConfig:
 
 
 @dataclass
-class UnitCellRPUConfig:
+class UnitCellRPUConfig(_PrintableMixin):
     """Configuration for an analog (unit cell) resistive processing unit."""
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
@@ -111,7 +112,7 @@ class UnitCellRPUConfig:
 
 
 @dataclass
-class InferenceRPUConfig:
+class InferenceRPUConfig(_PrintableMixin):
     """Configuration for an analog tile that is used only for inference.
 
     Training is done in *hardware-aware* manner, thus using only the

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -19,13 +19,16 @@ from typing import ClassVar, List, Type
 
 from aihwkit.simulator.rpu_base import devices
 
+from aihwkit.simulator.configs.helpers import (
+    _PrintableMixin, parameters_to_bindings
+)
 from aihwkit.simulator.configs.utils import (
-    IOParameters, UpdateParameters, parameters_to_bindings
+    IOParameters, UpdateParameters
 )
 
 
 @dataclass
-class FloatingPointDevice:
+class FloatingPointDevice(_PrintableMixin):
     """Floating point reference.
 
     Implements ideal devices forward/backward/update behavior.
@@ -45,7 +48,7 @@ class FloatingPointDevice:
 
 
 @dataclass
-class PulsedDevice:
+class PulsedDevice(_PrintableMixin):
     r"""Pulsed update resistive devices.
 
     Device are used as part of an
@@ -211,7 +214,7 @@ class PulsedDevice:
 
 
 @dataclass
-class UnitCell:
+class UnitCell(_PrintableMixin):
     """Parameters that modify the behaviour of a unit cell."""
 
     bindings_class: ClassVar[Type] = devices.VectorResistiveDeviceParameter
@@ -229,7 +232,7 @@ class UnitCell:
 ###############################################################################
 
 @dataclass
-class IdealDevice:
+class IdealDevice(_PrintableMixin):
     """Ideal update behavior (using floating point), but forward/backward
     might be non-ideal.
 
@@ -590,7 +593,8 @@ class TransferCompound(UnitCell):
     Weightening factor g**(n-1) W[0] + g**(n-2) W[1] + .. + g**0 W[n-1]
     """
 
-    gamma_vec: List[float] = field(default_factory=list)
+    gamma_vec: List[float] = field(default_factory=list,
+                                   metadata={'hide_if_empty': True})
     """
     User-defined weightening can be given as a list if weights in
     which case the default weightening scheme with ``gamma`` is not
@@ -616,7 +620,8 @@ class TransferCompound(UnitCell):
     applied to itself) to zero.
     """
 
-    transfer_every_vec: List[float] = field(default_factory=list)
+    transfer_every_vec: List[float] = field(default_factory=list,
+                                            metadata={'hide_if_empty': True})
     """A list of :math:`n` entries, to explicitly set the transfer
     cycles lengths. In this case, the above defaults are ignored.
     """
@@ -655,7 +660,8 @@ class TransferCompound(UnitCell):
       applied internally.
     """
 
-    transfer_lr_vec: List[float] = field(default_factory=list)
+    transfer_lr_vec: List[float] = field(default_factory=list,
+                                         metadata={'hide_if_empty': True})
     """Transfer LR for each individual transfer in the device chain
     can be given.
     """

--- a/src/aihwkit/simulator/configs/helpers.py
+++ b/src/aihwkit/simulator/configs/helpers.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utilities for resistive processing units configurations."""
+
+from dataclasses import Field, is_dataclass, fields
+from enum import Enum
+from textwrap import indent
+from typing import Any, List
+from aihwkit.simulator.rpu_base import devices, tiles
+
+
+def parameters_to_bindings(params: Any) -> Any:
+    """Convert a dataclass parameter into a bindings class."""
+    result = params.bindings_class()
+    for field, value in params.__dict__.items():
+        # Convert enums to the bindings enums.
+        if field == 'unit_cell_devices':
+            # Exclude `unit_cell_devices`, as it is a special field that is not
+            # present in the bindings.
+            continue
+
+        if isinstance(value, Enum):
+            if hasattr(tiles, value.__class__.__name__):
+                enum_class = getattr(tiles, value.__class__.__name__)
+            else:
+                enum_class = getattr(devices, value.__class__.__name__)
+            enum_value = getattr(enum_class, value.value)
+            setattr(result, field, enum_value)
+        elif is_dataclass(value):
+            setattr(result, field, parameters_to_bindings(value))
+        else:
+            setattr(result, field, value)
+
+    return result
+
+
+def tile_parameters_to_bindings(params: Any) -> Any:
+    """Convert a tile dataclass parameter into a bindings class."""
+    field_map = {'forward': 'forward_io',
+                 'backward': 'backward_io'}
+    excuded_fields = ('device', 'noise_model', 'drift_compensation',
+                      'clip', 'modifier')
+
+    result = params.bindings_class()
+    for field, value in params.__dict__.items():
+        # Get the mapped field name, if needed.
+        field = field_map.get(field, field)
+
+        # Convert enums to the bindings enums.
+        if field in excuded_fields:
+            # Exclude special fields that are not present in the bindings.
+            continue
+
+        if isinstance(value, Enum):
+            enum_class = getattr(devices, value.__class__.__name__)
+            enum_value = getattr(enum_class, value.value)
+            setattr(result, field, enum_value)
+        elif is_dataclass(value):
+            setattr(result, field, parameters_to_bindings(value))
+        else:
+            setattr(result, field, value)
+
+    return result
+
+
+class _PrintableMixin:
+    """Helper class for pretty-printing of config dataclasses."""
+    # pylint: disable=too-few-public-methods
+
+    def __str__(self) -> str:
+        """Return a pretty-print representation."""
+
+        def lines_list_to_str(
+                lines_list: List[str],
+                prefix: str = '',
+                suffix: str = '',
+                indent_: int = 0,
+                force_multiline: bool = False
+        ) -> str:
+            """Convert a list of lines into a string.
+
+            Args:
+                lines_list: the list of lines to be converted.
+                prefix: an optional prefix to be appended at the beginning of
+                    the string.
+                suffix: an optional suffix to be appended at the end of the string.
+                indent_: the optional number of spaces to indent the code.
+                force_multiline: force the output to be multiline.
+
+            Returns:
+                The lines collapsed into a single string (potentially with line
+                breaks).
+            """
+            if force_multiline or len(lines_list) > 3 or any(
+                    '\n' in line for line in lines_list):
+                # Return a multi-line string.
+                lines_str = indent(',\n'.join(lines_list), ' '*indent_)
+                prefix = '{}\n'.format(prefix) if prefix else prefix
+                suffix = '\n{}'.format(suffix) if suffix else suffix
+            else:
+                # Return an inline string.
+                lines_str = ', '.join(lines_list)
+
+            return '{}{}{}'.format(prefix, lines_str, suffix)
+
+        def field_to_str(field_value: Any) -> str:
+            """Return a string representation of the value of a field.
+
+            Args:
+                field_value: the object that contains a field value.
+
+            Returns:
+                The string representation of the field (potentially with line
+                breaks).
+            """
+            field_lines = []
+            force_multiline = False
+
+            # Handle special cases.
+            if isinstance(field_value, list) and len(value) > 0:
+                # For non-emtpy lists, always use multiline, with one item per line.
+                for item in field_value:
+                    field_lines.append(indent('{}'.format(str(item)), ' '*4))
+                force_multiline = True
+            else:
+                field_lines.append(str(field_value))
+
+            prefix = '[' if force_multiline else ''
+            suffix = ']' if force_multiline else ''
+            return lines_list_to_str(
+                field_lines, prefix, suffix, force_multiline=force_multiline)
+
+        def is_skippable(field: Field, value: Any) -> bool:
+            """Return whether a field should be skipped."""
+            if value == field.default:
+                # Skip fields with the default value.
+                return True
+            if isinstance(value, list) and len(value) == 0:
+                # For empty lists, skip based on the field metadata.
+                if field.metadata.get('hide_if_empty', False):
+                    return True
+
+            return False
+
+        # Main loop.
+
+        # Build the list of lines.
+        fields_lines = []
+        for field in fields(self):
+            value = getattr(self, field.name)
+
+            # Exclude fields.
+            if is_skippable(field, value):
+                continue
+
+            # Convert the value into a string, falling back to repr if needed.
+            try:
+                value_str = field_to_str(value)
+            except Exception:  # pylint: disable=broad-except
+                value_str = str(value)
+
+            fields_lines.append('{}={}'.format(field.name, value_str))
+
+        # Convert the full object to str.
+        output = lines_list_to_str(
+            fields_lines, '{}('.format(self.__class__.__name__), ')', 4)
+
+        return output

--- a/src/aihwkit/simulator/noise_models.py
+++ b/src/aihwkit/simulator/noise_models.py
@@ -89,6 +89,11 @@ class SinglePairConductanceConverter(BaseConductanceConverter):
         if self.g_min > self.g_max:
             raise ValueError('g_min should be smaller than g_max')
 
+    def __str__(self) -> str:
+        return '{}(g_max={:1.2f}, g_min={:1.2f})'.format(
+            self.__class__.__name__, self.g_max, self.g_min
+        )
+
     @no_grad()
     def convert_to_conductances(self, weights: Tensor) -> Tuple[List[Tensor], Dict]:
         abs_max = torch_abs(weights).max()
@@ -286,6 +291,12 @@ class PCMLikeNoiseModel(BaseNoiseModel):
         self.t_0 = t_0
         self.t_read = t_read
 
+    def __str__(self) -> str:
+        return ('{}(prog_coeff={}, g_converter={}, g_max={:1.2f}, t_read={}, '
+                't_0={:1.2f})').format(
+                    self.__class__.__name__, self.prog_coeff, self.g_converter,
+                    self.g_max, self.t_read, self.t_0)
+
     @no_grad()
     def apply_programming_noise_to_conductance(self, g_target: Tensor) -> Tensor:
         """Apply programming noise to a target conductance Tensor.
@@ -409,3 +420,6 @@ class GlobalDriftCompensation(BaseDriftCompensation):
         Uses a single all one vector.
         """
         return ones((1, in_size))
+
+    def __str__(self) -> str:
+        return '{}()'.format(self.__class__.__name__)

--- a/src/aihwkit/simulator/tiles/inference.py
+++ b/src/aihwkit/simulator/tiles/inference.py
@@ -26,8 +26,9 @@ from aihwkit.simulator.tiles.base import BaseTile
 from aihwkit.simulator.tiles.analog import AnalogTile
 from aihwkit.simulator.configs import InferenceRPUConfig
 from aihwkit.simulator.configs.utils import (
-    WeightClipType, WeightModifierType, parameters_to_bindings
+    WeightClipType, WeightModifierType
 )
+from aihwkit.simulator.configs.helpers import parameters_to_bindings
 from aihwkit.simulator.rpu_base import tiles, cuda
 
 

--- a/tests/helpers/tiles.py
+++ b/tests/helpers/tiles.py
@@ -161,7 +161,10 @@ class Transfer:
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0),
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0)
             ],
-            transfer_forward=IOParameters(is_perfect=True)
+            transfer_forward=IOParameters(is_perfect=True),
+            transfer_every=1,
+            gamma=0.1
+
         ))
 
     def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
@@ -309,7 +312,9 @@ class TransferCuda:
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0),
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0)
             ],
-            transfer_forward=IOParameters(is_perfect=True)
+            transfer_forward=IOParameters(is_perfect=True),
+            transfer_every=1,
+            gamma=0.1
         ))
 
     def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):


### PR DESCRIPTION
## Related issues

None

## Description

Printing of the `rpu_configs` to the terminal was very unreadable. In particular, all values where printed in one line, even those little use options. 

Here we changed the behavior how to print `RPUConfigs`, to exclude the default values and only print those that change from the  defaults in a nice manner. For instance, a complicated config might print like:

```
UnitCellRPUConfig(
    device=TransferCompound(
        unit_cell_devices=[
            SoftBoundsDevice(w_max=0.3, w_min=-0.3),
            SoftBoundsDevice()
        ],
        transfer_every=2,
        transfer_forward=IOParameters(inp_res=0.015625),
        transfer_update=UpdateParameters()
    ),
    forward=IOParameters(inp_res=0.015625),
    backward=IOParameters(inp_res=0.015625),
    update=UpdateParameters()
)

```  
Note that printing all available settings (the old printing behaviour) can still be achieved by `repr(rpu_config)`.  

## Details

Use a Mixin class approach to the data classes overriding the `__str__` method. 
