### PR TITLE
Docstring and style tweaks for ReferenceUnitCell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,15 @@ The format is based on [Keep a Changelog], and this project adheres to
 ## [UNRELEASED]
 
 ### Added
-* Pretty print the `rpu_config` in a readable manner (excluding all the default
-  settings). (\#60)
-* `ReferenceUnitCell`  is introduced, which has two devices, where one is fixed and
-  the other updated and the effective weight is computed a difference
-  betweem the two. (\#61)
-* `VectorUnitCell` accepts now arbitrariy weighting schemes that can
-  be user-defined by using a new `gamma_vec` property that spcified
-  how to combine the unit cell devices to form the
-  effective weight. (\#61)
+
+* The `rpu_config` is now pretty-printed in a readable manner (excluding the
+  default settings and other readability tweak). (\#60)
+* Added a new `ReferenceUnitCell` which has two devices, where one is fixed and
+  the other updated and the effective weight is computed a difference between
+  the two. (\#61)
+* `VectorUnitCell` accepts now arbitrary weighting schemes that can be
+  user-defined by using a new `gamma_vec` property that specifies how to combine
+  the unit cell devices to form the effective weight. (\#61)
 
 ### Changed
 
@@ -36,15 +36,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 * The `pybind11` version required has been bumped to 2.6.0, which can be
   installed from `pip` and makes system-wide installation no longer required.
   Please update your `pybind11` accordingly for compiling the library. (\#44)
-* `VectorUnitCell` properties renamed and extended with an update policy specifying
-  how to select the hidden devices. (#61)
+* Some `VectorUnitCell` properties have been renamed and extended with an update
+  policy specifying how to select the hidden devices. (\#61)
 
 ### Removed
 
 * The `BackwardIOParameters` specialization has been removed, as bound
   management is now automatically ignored for the backward pass. Please use the
   more general `IOParameters` instead. (\#45)
-
 
 ## [0.2.0] - 2020/10/20
 

--- a/examples/7_simple_layer_with_other_devices.py
+++ b/examples/7_simple_layer_with_other_devices.py
@@ -24,8 +24,7 @@ from torch.nn.functional import mse_loss
 from aihwkit.nn import AnalogLinear
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import UnitCellRPUConfig
-from aihwkit.simulator.configs.utils import (
-    VectorUnitCellUpdatePolicy)
+from aihwkit.simulator.configs.utils import VectorUnitCellUpdatePolicy
 from aihwkit.simulator.configs.devices import (
     ConstantStepDevice,
     VectorUnitCell,

--- a/src/aihwkit/exceptions.py
+++ b/src/aihwkit/exceptions.py
@@ -30,4 +30,4 @@ class CudaError(AihwkitException):
 
 
 class ConfigError(AihwkitException):
-    """Exception during tile configuration. """
+    """Exception related to tile configuration. """

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -546,7 +546,7 @@ class VectorUnitCell(UnitCell):
 
     first_update_idx: int = 0
     """Device that receives the first mini-batch.
-    
+
     Useful only for ``VectorUnitCellUpdatePolicy.SINGLE_FIXED``.
     """
 
@@ -564,12 +564,12 @@ class VectorUnitCell(UnitCell):
         vector_parameters = parameters_to_bindings(self)
 
         if not isinstance(self.unit_cell_devices, list):
-            raise ValueError("Expect a list of devices as unit cell device!")
+            raise ConfigError("unit_cell_devices should be a list of devices")
 
         for param in self.unit_cell_devices:
             device_parameters = param.as_bindings()
             if not vector_parameters.append_parameter(device_parameters):
-                raise ConfigError("Could not add unit cell device parameter. ")
+                raise ConfigError("Could not add unit cell device parameter")
 
         return vector_parameters
 
@@ -625,7 +625,7 @@ class ReferenceUnitCell(UnitCell):
         vector_parameters = parameters_to_bindings(self)
 
         if not isinstance(self.unit_cell_devices, list):
-            raise ValueError("Expect a list of devices as unit cell device!")
+            raise ConfigError("unit_cell_devices should be a list of devices")
 
         if len(self.unit_cell_devices) > 2:
             self.unit_cell_devices = self.unit_cell_devices[:2]
@@ -633,12 +633,12 @@ class ReferenceUnitCell(UnitCell):
             self.unit_cell_devices = [self.unit_cell_devices[0],
                                       deepcopy(self.unit_cell_devices[0])]
         elif len(self.unit_cell_devices) != 2:
-            raise ValueError("ReferenceUnitCell expects two unit_cell_devices!")
+            raise ConfigError("ReferenceUnitCell expects two unit_cell_devices")
 
         for param in self.unit_cell_devices:
             device_parameters = param.as_bindings()
             if not vector_parameters.append_parameter(device_parameters):
-                raise ConfigError("Could not add unit cell device parameter. ")
+                raise ConfigError("Could not add unit cell device parameter")
 
         return vector_parameters
 
@@ -668,17 +668,17 @@ class DifferenceUnitCell(UnitCell):
         """Return a representation of this instance as a simulator bindings object."""
 
         if not isinstance(self.unit_cell_devices, list):
-            raise ValueError("Expect a list of devices as unit cell device!")
+            raise ConfigError("unit_cell_devices should be a list of devices")
 
         difference_parameters = parameters_to_bindings(self)
         device_parameters = self.unit_cell_devices[0].as_bindings()
 
         # need to be exactly 2 and same parameters
         if not difference_parameters.append_parameter(device_parameters):
-            raise ConfigError("Could not add unit cell device parameter. ")
+            raise ConfigError("Could not add unit cell device parameter")
 
         if not difference_parameters.append_parameter(device_parameters):
-            raise ConfigError("Could not add unit cell device parameter. ")
+            raise ConfigError("Could not add unit cell device parameter")
 
         return difference_parameters
 
@@ -813,7 +813,7 @@ class TransferCompound(UnitCell):
         """Return a representation of this instance as a simulator bindings object."""
 
         if not isinstance(self.unit_cell_devices, list):
-            raise ValueError("Expect a list of devices as unit cell device!")
+            raise ConfigError("unit_cell_devices should be a list of devices")
 
         n_devices = len(self.unit_cell_devices)
 
@@ -823,10 +823,10 @@ class TransferCompound(UnitCell):
         param_slow = self.unit_cell_devices[1].as_bindings()
 
         if not transfer_parameters.append_parameter(param_fast):
-            raise ConfigError("Could not add unit cell device parameter. ")
+            raise ConfigError("Could not add unit cell device parameter")
 
         for _ in range(n_devices - 1):
             if not transfer_parameters.append_parameter(param_slow):
-                raise ConfigError("Could not add unit cell device parameter. ")
+                raise ConfigError("Could not add unit cell device parameter")
 
         return transfer_parameters

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -252,10 +252,10 @@ class UnitCell(_PrintableMixin):
         """Return whether device has decay enabled."""
         return any(dev.requires_decay() for dev in self.unit_cell_devices)
 
+
 ###############################################################################
 # Specific devices based on ``pulsed``.
 ###############################################################################
-
 
 @dataclass
 class IdealDevice(_PrintableMixin):
@@ -542,23 +542,21 @@ class VectorUnitCell(UnitCell):
 
     update_policy: VectorUnitCellUpdatePolicy = VectorUnitCellUpdatePolicy.ALL
     """The update policy of which if the devices will be receiving the
-    update of a mini-batch.
-
-    """
+    update of a mini-batch."""
 
     first_update_idx: int = 0
-    """Device that receives the first mini-batch. Useful only for
-    ``VectorUnitCellUpdatePolicy.SINGLE_FIXED``.
+    """Device that receives the first mini-batch.
+    
+    Useful only for ``VectorUnitCellUpdatePolicy.SINGLE_FIXED``.
     """
 
     gamma_vec: List[float] = field(default_factory=list, metadata={'hide_if': []})
 
-    """ Weighting of the unit cell devices to reduce to final weight.
+    """Weighting of the unit cell devices to reduce to final weight.
 
     User-defined weightening can be given as a list if factors. If not
     given, each device index of the unit cell is weighted by equal
-    amounts (:math:`1/n`)
-
+    amounts (:math:`1/n`).
     """
 
     def as_bindings(self) -> devices.VectorResistiveDeviceParameter:
@@ -586,19 +584,19 @@ class ReferenceUnitCell(UnitCell):
     the two.
 
     Note:
-      Exactly 2 devices are used, if more are given the are
-      discarded, if less, the same device will be used twice.
+        Exactly 2 devices are used, if more are given the are
+        discarded, if less, the same device will be used twice.
 
     Note:
-      The reference device weights will all zero on default. To set
-      the reference device with a particular value one can select the
-      device update index::
+        The reference device weights will all zero on default. To set
+        the reference device with a particular value one can select the
+        device update index::
 
-        analog_tile.set_hidden_update_index(1)
-        analog_tile.set_weights(W)
-        analog_tile.set_hidden_update_index(0) # set back to 0 for the following updates
-
+            analog_tile.set_hidden_update_index(1)
+            analog_tile.set_weights(W)
+            analog_tile.set_hidden_update_index(0) # set back to 0 for the following updates
     """
+
     bindings_class: ClassVar[Type] = devices.VectorResistiveDeviceParameter
 
     update_policy: VectorUnitCellUpdatePolicy = VectorUnitCellUpdatePolicy.SINGLE_FIXED
@@ -606,23 +604,20 @@ class ReferenceUnitCell(UnitCell):
     update of a mini-batch.
 
     Caution:
-       Should be kept to SINGLE_FIXED for this device.
-
+        This parameter should be kept to SINGLE_FIXED for this device.
     """
 
     first_update_idx: int = 0
-    """Device that receives the update.
-    """
+    """Device that receives the update."""
 
     gamma_vec: List[float] = field(default_factory=lambda: [1., -1.],
                                    metadata={'hide_if': [1., -1.]})
     """Weighting of the unit cell devices to reduce to final weight.
 
     Note:
-       While user-defined weighting can be given it is suggested to
-       keep it to the default ``[1, -1]`` to implement the reference
-       device subtraction.
-
+        While user-defined weighting can be given it is suggested to
+        keep it to the default ``[1, -1]`` to implement the reference
+        device subtraction.
     """
 
     def as_bindings(self) -> devices.VectorResistiveDeviceParameter:
@@ -663,8 +658,8 @@ class DifferenceUnitCell(UnitCell):
     (however, device-to-device variation is still present).
 
     Caution:
-       Reset needs to be added `manually` by calling the
-       reset_columns method of a tile.
+        Reset needs to be added `manually` by calling the
+        reset_columns method of a tile.
     """
 
     bindings_class: ClassVar[Type] = devices.DifferenceResistiveDeviceParameter
@@ -786,8 +781,8 @@ class TransferCompound(UnitCell):
     learning rate of the SGD.
 
     Note:
-      LR is always a positive number, sign will be correctly
-      applied internally.
+        LR is always a positive number, sign will be correctly
+        applied internally.
     """
 
     transfer_lr_vec: List[float] = field(default_factory=list,

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -142,10 +142,10 @@ class WeightClipType(Enum):
 
 
 class VectorUnitCellUpdatePolicy(Enum):
-    """ Vector unit cell update policy."""
+    """Vector unit cell update policy."""
 
     ALL = 'All'
-    """ All devices updated simultaneously """
+    """All devices updated simultaneously."""
 
     SINGLE_FIXED = 'SingleFixed'
     """Device index is not changed. Can be set initially and/or updated on
@@ -213,11 +213,11 @@ class IOParameters(_PrintableMixin):
     `AbsMax`:
 
     .. math::
-       :nowrap:
+        :nowrap:
 
-       \begin{equation*} \alpha=\begin{cases}\max_i|x_i|, &
-       \text{if} \max_i|x_i|<\theta \\ \theta, &
-       \text{otherwise}\end{cases} \end{equation*}
+        \begin{equation*} \alpha=\begin{cases}\max_i|x_i|, &
+        \text{if} \max_i|x_i|<\theta \\ \theta, &
+        \text{otherwise}\end{cases} \end{equation*}
 
     Caution:
         If ``nm_thres`` is set (and type is not ``Constant``), the

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -362,7 +362,6 @@ class BaseTile(Generic[RPUConfigGeneric]):
             Depending on the update and learning policy implemented
             in the tile, updated devices might switch internally as
             well.
-
         """
         return self.tile.get_hidden_update_index()
 
@@ -383,7 +382,6 @@ class BaseTile(Generic[RPUConfigGeneric]):
             Depending on the update and learning policy implemented
             in the tile, updated devices might switch internally as
             well.
-
         """
         self.tile.set_hidden_update_index(index)
 


### PR DESCRIPTION
## Related issues

#61 

## Description

Round of small tweaks to #61:
* revise docstrings, mostly indentation for proper sphinx rendering and other small style tweaks
* update `raise` clauses so all of them raise `ConfigError`, reserving `ValueError` for those that are related to checking arguments of the function directly (subtle distinction - the existing ones were checking `self` attributes, so this way we stick further to the original `ValueError` definition).
* reword changelog slightly for making it a bit more consistent with the rest of the entries


## Details

<!-- A more elaborate description of the changes, if needed. -->
