### PR TITLE
Add SoftBounds device to parametrized tests

### DIFF
--- a/docs/source/using_simulator.rst
+++ b/docs/source/using_simulator.rst
@@ -118,6 +118,7 @@ Resistive device class                                                Descriptio
 ====================================================================  ========
 :class:`~aihwkit.simulator.configs.devices.VectorUnitCell`            abstract resistive device that combines multiple pulsed resistive devices in a single 'unit cell'.
 :class:`~aihwkit.simulator.configs.devices.DifferenceUnitCell`        abstract device model takes an arbitrary device per crosspoint and implements an explicit plus-minus device pair.
+:class:`~aihwkit.simulator.configs.devices.ReferenceUnitCell`         abstract device model takes two arbitrary device per cross-point and implements an device with reference pair.
 ====================================================================  ========
 
 Compound devices

--- a/tests/helpers/tiles.py
+++ b/tests/helpers/tiles.py
@@ -97,6 +97,21 @@ class LinearStep:
         return AnalogTile(out_size, in_size, rpu_config, **kwargs)
 
 
+class SoftBounds:
+    """AnalogTile with SoftBoundsDevice."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = 'max_bound'
+    use_cuda = False
+
+    def get_rpu_config(self):
+        return SingleRPUConfig(device=SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
+        rpu_config = rpu_config or self.get_rpu_config()
+        return AnalogTile(out_size, in_size, rpu_config, **kwargs)
+
+
 class ExpStep:
     """AnalogTile with ExpStepResistiveDevice."""
 

--- a/tests/helpers/tiles.py
+++ b/tests/helpers/tiles.py
@@ -53,7 +53,7 @@ class FloatingPoint:
 
 
 class Ideal:
-    """AnalogTile with IdealResistiveDevice."""
+    """AnalogTile with IdealDevice."""
 
     simulator_tile_class = tiles.AnalogTile
     first_hidden_field = None
@@ -68,7 +68,7 @@ class Ideal:
 
 
 class ConstantStep:
-    """AnalogTile with ConstantStepResistiveDevice."""
+    """AnalogTile with ConstantStepDevice."""
 
     simulator_tile_class = tiles.AnalogTile
     first_hidden_field = 'max_bound'
@@ -83,7 +83,7 @@ class ConstantStep:
 
 
 class LinearStep:
-    """AnalogTile with LinearStepResistiveDevice."""
+    """AnalogTile with LinearStepDevice."""
 
     simulator_tile_class = tiles.AnalogTile
     first_hidden_field = 'max_bound'
@@ -113,7 +113,7 @@ class SoftBounds:
 
 
 class ExpStep:
-    """AnalogTile with ExpStepResistiveDevice."""
+    """AnalogTile with ExpStepDevice."""
 
     simulator_tile_class = tiles.AnalogTile
     first_hidden_field = 'max_bound'
@@ -238,7 +238,7 @@ class FloatingPointCuda:
 
 
 class IdealCuda:
-    """AnalogTile with IdealResistiveDevice."""
+    """AnalogTile with IdealDevice."""
 
     simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
     first_hidden_field = None
@@ -253,7 +253,7 @@ class IdealCuda:
 
 
 class ConstantStepCuda:
-    """AnalogTile with ConstantStepResistiveDevice."""
+    """AnalogTile with ConstantStepDevice."""
 
     simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
     first_hidden_field = 'max_bound'
@@ -268,7 +268,7 @@ class ConstantStepCuda:
 
 
 class LinearStepCuda:
-    """AnalogTile with LinearStepResistiveDevice."""
+    """AnalogTile with LinearStepDevice."""
 
     simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
     first_hidden_field = 'max_bound'
@@ -282,8 +282,23 @@ class LinearStepCuda:
         return AnalogTile(out_size, in_size, rpu_config, **kwargs).cuda()
 
 
+class SoftBoundsCuda:
+    """AnalogTile with SoftBoundsDevice."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = 'max_bound'
+    use_cuda = True
+
+    def get_rpu_config(self):
+        return SingleRPUConfig(device=SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
+        rpu_config = rpu_config or self.get_rpu_config()
+        return AnalogTile(out_size, in_size, rpu_config, **kwargs).cuda()
+
+
 class ExpStepCuda:
-    """AnalogTile with ExpStepResistiveDevice."""
+    """AnalogTile with ExpStepDevice."""
 
     simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
     first_hidden_field = 'max_bound'

--- a/tests/test_simulator_tiles.py
+++ b/tests/test_simulator_tiles.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Tests for the high level simulator devices functionality."""
+
 from unittest import SkipTest
 
 from torch import Tensor, zeros
@@ -24,11 +25,11 @@ from aihwkit.simulator.configs import UnitCellRPUConfig
 from .helpers.decorators import parametrize_over_tiles
 from .helpers.testcases import ParametrizedTestCase
 from .helpers.tiles import (
-    FloatingPoint, Ideal, ConstantStep, LinearStep,
+    FloatingPoint, Ideal, ConstantStep, LinearStep, SoftBounds,
     ExpStep, Vector, Difference, Transfer, Inference,
     FloatingPointCuda, IdealCuda, ConstantStepCuda, LinearStepCuda,
-    ExpStepCuda, VectorCuda, DifferenceCuda, TransferCuda, InferenceCuda,
-    Reference, ReferenceCuda
+    SoftBoundsCuda, ExpStepCuda, VectorCuda, DifferenceCuda, TransferCuda,
+    InferenceCuda, Reference, ReferenceCuda
 )
 
 
@@ -38,6 +39,7 @@ from .helpers.tiles import (
     ConstantStep,
     LinearStep,
     ExpStep,
+    SoftBounds,
     Vector,
     Difference,
     Transfer,
@@ -48,6 +50,7 @@ from .helpers.tiles import (
     ConstantStepCuda,
     LinearStepCuda,
     ExpStepCuda,
+    SoftBoundsCuda,
     VectorCuda,
     DifferenceCuda,
     TransferCuda,


### PR DESCRIPTION
## Related issues

#7

## Description

Add `SoftBounds` (and `SoftBoundsCuda`) to the helpers for the parametrized tests, as it was the device that was missing from the helper.

## Details

In the process, add `ReferenceUnitCell` from #61  to the `using_simulator` sphinx documentation.
