### PR TITLE
Cmake output tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 cmake_minimum_required(VERSION 3.18.0)
 project(aihwkit C CXX)
+set(ignoreMe "${SKBUILD}")
 
 # Project options.
 option(BUILD_TEST "Build C++ test binaries" OFF)
@@ -68,6 +69,7 @@ endif()
 
 set_target_properties(RPU_CPU PROPERTIES CXX_STANDARD 11
                                          POSITION_INDEPENDENT_CODE ON)
+
 
 if (USE_CUDA)
   add_subdirectory(src/rpucuda/cuda)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,6 @@ endif()
 set_target_properties(RPU_CPU PROPERTIES CXX_STANDARD 11
                                          POSITION_INDEPENDENT_CODE ON)
 
-
 if (USE_CUDA)
   add_subdirectory(src/rpucuda/cuda)
   include_directories(SYSTEM src/rpucuda/cuda)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -84,7 +84,8 @@ include_directories(${PYTHON_INCLUDE_DIRS})  # order matters (before pybind)
 # Find pybind11Config.cmake
 execute_process(COMMAND python -c "import pybind11; print(pybind11.get_cmake_dir())"
     OUTPUT_VARIABLE CUSTOM_PYTHON_PYBIND11_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_QUIET ERROR_QUIET)
 set (pybind11_DIR ${CUSTOM_PYTHON_PYBIND11_PATH})
 
 find_package(pybind11 CONFIG REQUIRED)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -85,7 +85,7 @@ include_directories(${PYTHON_INCLUDE_DIRS})  # order matters (before pybind)
 execute_process(COMMAND python -c "import pybind11; print(pybind11.get_cmake_dir())"
     OUTPUT_VARIABLE CUSTOM_PYTHON_PYBIND11_PATH
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_QUIET ERROR_QUIET)
+    ERROR_QUIET)
 set (pybind11_DIR ${CUSTOM_PYTHON_PYBIND11_PATH})
 
 find_package(pybind11 CONFIG REQUIRED)


### PR DESCRIPTION
## Related issues

In case of some pybind configurations the following output errors and warnings were shown, which however do not interfere with the compilation in any way:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: module 'pybind11' has no attribute 'get_cmake_dir'
```
and
```
CMake Warning:
  Manually-specified variables were not used by the project:
    SKBUILD 
```

## Description
This PR silences these messages.
