### PR TITLE
Add clean-doc target, tweak clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,18 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-.PHONY: build_inplace clean clang-tidy clang-format mypy pycodestyle pylint pytest
+.PHONY: build_inplace clean clean-doc clang-format mypy pycodestyle pylint pytest
 
 build_inplace:
 	python setup.py build_ext -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE --inplace
 
 clean:
 	python setup.py clean
-	cd docs && make clean
+	rm -rf _skbuild
 	rm -f src/aihwkit/simulator/rpu_base.*.so
+
+clean-doc:
+	cd docs && make clean
 
 clang-format:
 	clang-format -i src/aihwkit/simulator/rpu_base_src/*.cpp  \


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Split the `clean` make target into `clean-doc`, leaving the main target only for the python and cmake related cleanup.

## Details

As the building (and cleaning) of the documentation is quite infrequent compared to the compilation, this makes the normal operation of `make clean` a bit more convenient (avoiding the need to install sphinx just for the purpose of silencing the error).