### PR TITLE
Enable linting of docstrings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -31,7 +31,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.docparams
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -78,6 +78,9 @@ class AnalogModuleBase(Module):
             bias: whether to use a bias row on the analog tile or not.
             realistic_read_write: whether to enable realistic read/write
                for setting initial weights and read out of weights.
+
+        Returns:
+            An analog tile with the requested parameters.
         """
         # pylint: disable=attribute-defined-outside-init
         # Default to constant step device if not provided.
@@ -222,6 +225,9 @@ class AnalogModuleBase(Module):
         Arguments:
             device (int, optional): if specified, all parameters will be
                 copied to that GPU device
+
+        Returns:
+            This layer with its parameters, buffers and tiles in GPU.
         """
         # pylint: disable=attribute-defined-outside-init
         # Note: this needs to be an in-place function, not a copy
@@ -235,6 +241,9 @@ class AnalogModuleBase(Module):
 
         Args:
             t_inference: assumed time of inference (in sec)
+
+        Raises:
+            ModuleError: if the layer is not in evaluation mode.
         """
         if self.training:
             raise ModuleError('drift_analog_weights can only be applied in '
@@ -244,7 +253,11 @@ class AnalogModuleBase(Module):
             self.analog_tile.drift_weights(t_inference)
 
     def program_analog_weights(self) -> None:
-        """Program the analog weights."""
+        """Program the analog weights.
+
+        Raises:
+            ModuleError: if the layer is not in evaluation mode.
+        """
         if self.training:
             raise ModuleError('program_analog_weights can only be applied in '
                               'evaluation mode')

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -43,6 +43,9 @@ class AnalogSequential(Sequential):
 
         Args:
             fn: function to be applied.
+
+        Returns:
+            This module after the function has been applied.
         """
         for module in self.modules():
             if isinstance(module, AnalogModuleBase):
@@ -64,7 +67,10 @@ class AnalogSequential(Sequential):
         """(Program) and drift all analog inference layers of a given model.
 
         Args:
-            t_inference: assumed time of inference (in sec
+            t_inference: assumed time of inference (in sec)
+
+        Raises:
+            ModuleError: if the layer is not in evaluation mode.
         """
         if self.training:
             raise ModuleError('drift_analog_weights can only be applied in '
@@ -73,7 +79,11 @@ class AnalogSequential(Sequential):
         self._apply_to_analog(lambda m: m.drift_analog_weights(t_inference))
 
     def program_analog_weights(self) -> None:
-        """Program all analog inference layers of a given model."""
+        """Program all analog inference layers of a given model.
+
+        Raises:
+            ModuleError: if the layer is not in evaluation mode.
+        """
         if self.training:
             raise ModuleError('program_analog_weights can only be applied in '
                               'evaluation mode')

--- a/src/aihwkit/optim/analog_sgd.py
+++ b/src/aihwkit/optim/analog_sgd.py
@@ -87,6 +87,9 @@ class AnalogSGD(SGD):
         Arguments:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
+
+        Returns:
+            The loss, if ``closure`` has been passed as a parameter.
         """
         # pylint: disable=too-many-branches
         loss = None

--- a/src/aihwkit/simulator/noise_models.py
+++ b/src/aihwkit/simulator/noise_models.py
@@ -70,7 +70,6 @@ class SinglePairConductanceConverter(BaseConductanceConverter):
     Args:
         g_max: In :math:`\mu S`, the maximal conductance, ie the value
             the absolute max of the weights will be mapped to.
-
         g_min: In :math:`\mu S`, the minimal conductance, ie the value
             the logical zero of the weights will be mapped to.
     """
@@ -263,13 +262,15 @@ class PCMLikeNoiseModel(BaseNoiseModel):
     Args:
         prog_coeff: programming polynomial coeffs in :math:`\mu S`, c(0) + c(1)*gt + c(2)*gt^2)
         g_converter: instantiated class of the conductance converter (defaults to single pair)
+        g_max: In :math:`\mu S`, the maximal conductance, ie the value
+            the absolute max of the weights will be mapped to.
         t_read: parameter of the 1/f fit (in seconds)
         t_0: parameter of the drift fit (first reading time)
 
-        Note:
-            The ``t_inference`` is relative to this time `t0`
-            e.g. t_inference counts from the completion of the programming
-            of a device.
+            Note:
+                The ``t_inference`` is relative to this time `t0`
+                e.g. t_inference counts from the completion of the programming
+                of a device.
     """
 
     def __init__(

--- a/src/aihwkit/simulator/tiles/analog.py
+++ b/src/aihwkit/simulator/tiles/analog.py
@@ -173,6 +173,8 @@ class AnalogTile(BaseTile):
             has an extra column to code the biases. Internally, the
             input :math:`\mathbf{x}` will be automatically expanded by
             an extra dimension which will be set to 1 always.
+        in_trans: Whether to assume an transposed input (batch first).
+        out_trans: Whether to assume an transposed output (batch first).
 
     .. _Gokmen & Vlasov (2016): https://www.frontiersin.org/articles/10.3389/fnins.2016.00333/full
     """
@@ -198,6 +200,12 @@ class AnalogTile(BaseTile):
 
         Args:
             device: CUDA device
+
+        Returns:
+            A copy of this tile in CUDA memory.
+
+        Raises:
+            CudaError: if the library has not been compiled with CUDA.
         """
         if not cuda.is_compiled():
             raise CudaError('aihwkit has not been compiled with CUDA support')

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -159,6 +159,13 @@ class BaseTile(Generic[RPUConfigGeneric]):
                 closed-loop manner.
                 A value of ``1`` means that all columns in principle receive
                 enough pulses to change from ``w_min`` to ``w_max``.
+
+        Returns:
+            None.
+
+        Raises:
+            ValueError: if the tile has bias but ``bias`` has not been
+                specified.
         """
         # Prepare the array expected by the pybind function, appending the
         # biases row if needed.
@@ -231,6 +238,9 @@ class BaseTile(Generic[RPUConfigGeneric]):
 
         Args:
             learning_rate: the desired learning rate.
+
+        Returns:
+            None.
         """
         return self.tile.set_learning_rate(learning_rate)
 
@@ -248,6 +258,9 @@ class BaseTile(Generic[RPUConfigGeneric]):
         Args:
            alpha: additional decay scale (such as LR). The base decay
               rate is set during tile init.
+
+        Returns:
+            None.
         """
         return self.tile.decay_weights(alpha)
 
@@ -255,6 +268,9 @@ class BaseTile(Generic[RPUConfigGeneric]):
         """Diffuses the weights once.
 
         The base diffusion rate is set during tile init.
+
+        Returns:
+            None
         """
         return self.tile.diffuse_weights()
 
@@ -268,12 +284,15 @@ class BaseTile(Generic[RPUConfigGeneric]):
         .. math::
             W_{ij} = \xi*\sigma_\text{reset} + b^\text{reset}_{ij}
 
+        The reset parameters are set during tile init.
+
         Args:
             start_column_idx: a start index of columns (0..x_size-1)
             num_columns: how many consecutive columns to reset (with circular warping)
             reset_prob: individual probability of reset.
 
-        The reset parameter are set during tile init.
+        Returns:
+            None
         """
         return self.tile.reset_columns(start_column_idx, num_columns, reset_prob)
 
@@ -316,6 +335,9 @@ class BaseTile(Generic[RPUConfigGeneric]):
         Args:
             x_input: ``[N, in_size]`` tensor. If ``in_trans`` is set, transposed.
             d_input: ``[N, out_size]`` tensor. If ``out_trans`` is set, transposed.
+
+        Returns:
+            None
         """
         return self.tile.update(x_input, d_input, self.bias,
                                 self.in_trans, self.out_trans)
@@ -392,6 +414,10 @@ class BaseTile(Generic[RPUConfigGeneric]):
         Args:
             indices : torch.tensor with int indices
             image_sizes: [C_in, H_in, W_in, H_out, W_out] sizes
+
+        Raises:
+            ValueError: if ``image_sizes`` does not have valid dimensions.
+            TileError: if the tile uses transposition.
         """
         if len(image_sizes) != 5:
             raise ValueError('image_sizes expects 5 sizes [C_in, H_in, W_in, H_out, W_out]')
@@ -412,6 +438,9 @@ class BaseTile(Generic[RPUConfigGeneric]):
 
         Returns:
             torch.Tensor: ``[N, out_size]`` tensor. If ``out_trans`` is set, transposed.
+
+        Raises:
+            TileError: if the indexed tile has not been initialized.
         """
         if not self.image_sizes:
             raise TileError('self.image_sizes is not initialized. Please use '
@@ -438,6 +467,9 @@ class BaseTile(Generic[RPUConfigGeneric]):
         Args:
             x_input: ``[N, in_size]`` tensor. If ``in_trans`` is set, transposed.
             d_input: ``[N, out_size]`` tensor. If ``out_trans`` is set, transposed.
+
+        Returns:
+            None
         """
         return self.tile.update_indexed(x_input, d_input)
 

--- a/src/aihwkit/simulator/tiles/floating_point.py
+++ b/src/aihwkit/simulator/tiles/floating_point.py
@@ -99,6 +99,8 @@ class FloatingPointTile(BaseTile):
             has an extra column to code the biases. Internally, the
             input :math:`\mathbf{x}` will be automatically expanded by
             an extra dimension which will be set to 1 always.
+        in_trans: Whether to assume an transposed input (batch first).
+        out_trans: Whether to assume an transposed output (batch first).
     """
 
     def __init__(
@@ -117,8 +119,17 @@ class FloatingPointTile(BaseTile):
             self,
             device: Optional[Union[torch_device, str, int]] = None
     ) -> 'BaseTile':
-        """Return a copy of this tile in CUDA memory."""
+        """Return a copy of this tile in CUDA memory.
 
+        Args:
+            device: CUDA device
+
+        Returns:
+            A copy of this tile in CUDA memory.
+
+        Raises:
+            CudaError: if the library has not been compiled with CUDA.
+        """
         if not cuda.is_compiled():
             raise CudaError('aihwkit has not been compiled with CUDA support')
 

--- a/src/aihwkit/simulator/tiles/inference.py
+++ b/src/aihwkit/simulator/tiles/inference.py
@@ -39,7 +39,6 @@ class InferenceTile(AnalogTile):
         out_size: output size
         in_size: input size
         rpu_config: resistive processing unit configuration.
-        noise_model: noise model governing the expected inference noise in a statistical manner
         bias: whether to add a bias column to the tile.
         in_trans: Whether to assume an transposed input (batch first)
         out_trans: Whether to assume an transposed output (batch first)
@@ -179,6 +178,12 @@ class InferenceTile(AnalogTile):
 
         Args:
             device: CUDA device
+
+        Returns:
+            A copy of this tile in CUDA memory.
+
+        Raises:
+            CudaError: if the library has not been compiled with CUDA.
         """
         if not cuda.is_compiled():
             raise CudaError('aihwkit has not been compiled with CUDA support')

--- a/src/aihwkit/simulator/tiles/numpy.py
+++ b/src/aihwkit/simulator/tiles/numpy.py
@@ -99,6 +99,9 @@ class NumpyMixin:
         Args:
             x_input: ``[N, in_size]`` matrix. If ``in_trans`` is set, transposed.
             d_input: ``[N, out_size]`` matrix. If ``out_trans`` is set, transposed.
+
+        Returns:
+            None.
         """
         if self.is_cuda:
             x_tensor = from_numpy(x_input.astype('float32')).cuda()

--- a/tests/helpers/decorators.py
+++ b/tests/helpers/decorators.py
@@ -13,17 +13,20 @@
 """Decorators for aihwkit tests."""
 
 from itertools import product
-from typing import List
+from typing import List, Callable
 
 from parameterized import parameterized_class
 
 
-def parametrize_over_tiles(tiles: List):
+def parametrize_over_tiles(tiles: List) -> Callable:
     """Parametrize a TestCase over different kind of tiles.
 
     Args:
         tiles: list of tile descriptions. The ``TestCase`` will be repeated
             for each of the entries in the list.
+
+    Returns:
+        The decorated TestCase.
     """
 
     def object_to_dict(obj):
@@ -42,7 +45,7 @@ def parametrize_over_tiles(tiles: List):
                                class_name_func=class_name)
 
 
-def parametrize_over_layers(layers: List, tiles: List, biases: List):
+def parametrize_over_layers(layers: List, tiles: List, biases: List) -> Callable:
     """Parametrize a TestCase over different kind of layers.
 
     The ``TestCase`` will be repeated for each combination of
@@ -52,6 +55,9 @@ def parametrize_over_layers(layers: List, tiles: List, biases: List):
         layers: list of layer descriptions.
         tiles: list of tile descriptions.
         biases: list of bias values.
+
+    Returns:
+        The decorated TestCase.
     """
 
     def object_to_dict(layer, tile, bias):


### PR DESCRIPTION
## Related issues

#43 slightly

## Description

As part of keeping the documentation up to date, enable the pylint optional plugin that performs some basic checks for docstrings. This helps us making sure we don't miss documenting parameters and be more aware of the changes needed to the function and class docstrings by the time we modify them - accordingly, this PR includes the fixes for the new linting warnings caught by the plugin.

## Details

<!-- A more elaborate description of the changes, if needed. -->
