### PR TITLE
Ci wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,14 @@ notifications:
   email: false
 
 # Disable double triggering when issuing a PR from a branch in the main repo.
-# branches:
-#   only:
-#     - "master"
+branches:
+  only:
+    - "master"
 
 stages:
-  - Build Linux and OSX wheels
   - Test and lint
   - Test multiple python versions
-
+  - Build Linux and OSX wheels
 
 # Parent stage definition, to avoid copy-pasting.
 job_compile_common: &job_compile_common
@@ -99,7 +98,7 @@ jobs:
     language: python
     services: docker
     stage: Build Linux and OSX wheels
-    # if: tag IS present
+    if: tag IS present
     env:
       - CIBW_BEFORE_BUILD="pip install -r requirements.txt"
       - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
@@ -116,7 +115,7 @@ jobs:
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
     os: osx
     stage: Build Linux and OSX wheels
-    # if: tag IS present
+    if: tag IS present
     addons:
       homebrew:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,10 +125,12 @@ jobs:
         update: true
     env:
       - CIBW_BEFORE_ALL=""
-      - CIBW_BEFORE_BUILD="pip install ../aihwkit-wheel-helper/delocate && pip install -r requirements.txt"
+      - CIBW_BEFORE_BUILD="pip install ../delocate && pip install -r requirements.txt"
       - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
       # - CIBW_SKIP="cp27-* cp35-* cp38-*"
       # - CIBW_TEST_COMMAND="pytest -v -s tests/"
+    before_install:
+      - git clone -b aihwkit git@github.com:filemaster/delocate.git
     install:
       - python3 -m pip install cibuildwheel==1.6.0
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,6 @@ notifications:
 #   only:
 #     - "master"
 
-# sudo: required
-
-services: docker
-
-os:
-  - linux
-  - osx
-
 stages:
   - Test and lint
   - Test multiple python versions
@@ -93,6 +85,7 @@ jobs:
     os: linux
     dist: bionic
     language: python
+    services: docker
     stage: Build Linux and OSX wheels
     if: tag IS present
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,10 @@ notifications:
 #   only:
 #     - "master"
 
-sudo: required
-
-language: python
+# sudo: required
 
 services: docker
 
-# Setup Travis to use Ubuntu 18.04 - Bionic
 os:
   - linux
   - osx
@@ -36,6 +33,8 @@ stages:
 # Parent stage definition, to avoid copy-pasting.
 job_compile_common: &job_compile_common
   os: linux
+  dist: bionic
+  language: python
   before_install:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get update
@@ -55,15 +54,11 @@ job_compile_common: &job_compile_common
 jobs:
   include:
   - name: "Compile and test. Python 3.6"
-    os: linux
-    dist: bionic
     <<: *job_compile_common
     stage: Test and lint
     python: "3.6"
 
   - name: "Compile and lint. Python 3.6"
-    os: linux
-    dist: bionic
     <<: *job_compile_common
     stage: Test and lint
     python: "3.6"
@@ -74,22 +69,16 @@ jobs:
       - make mypy
 
   - name: "Compile and test. Python 3.7"
-    os: linux
-    dist: bionic
     <<: *job_compile_common
     stage: Test multiple python versions
     python: "3.7"
 
   - name: "Compile and test. Python 3.8"
-    os: linux
-    dist: bionic
     <<: *job_compile_common
     stage: Test multiple python versions
     python: "3.8"
 
   - name: "Compile and test. Python 3.6, Torch 1.5"
-    os: linux
-    dist: bionic
     <<: *job_compile_common
     stage: Test multiple python versions
     python: "3.6"
@@ -104,6 +93,7 @@ jobs:
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on Linux x86_64"
     os: linux
     dist: bionic
+    language: python
     stage: Build Linux wheels
     if: tag IS present
     env:
@@ -125,24 +115,23 @@ jobs:
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
     os: osx
     stage: Build OSX wheels
-    if: tag IS present
+    # if: tag IS present
     addons:
       homebrew:
         packages:
           - openblas
+          - python
         update: true
     env:
       - CIBW_BEFORE_ALL=""
-      - CIBW_BEFORE_BUILD="pip install ../delocate && pip install -r requirements.txt"
+      - CIBW_BEFORE_BUILD="pip install ./delocate && pip install -r requirements.txt"
       - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
       # - CIBW_SKIP="cp27-* cp35-* cp38-*"
       # - CIBW_TEST_COMMAND="pytest -v -s tests/"
     before_install:
-      - git clone -b aihwkit git@github.com:filemaster/delocate.git
+      - git clone -b aihwkit https://github.com/filemaster/delocate.git
     install:
       - python3 -m pip install cibuildwheel==1.6.0
     script:
       # build the wheels, put them into './wheelhouse'
       - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
-      # The plan is to upload the wheels via twine only when the commit is tagged
-      # python3 -m twine <..>

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ os:
   - osx
 
 stages:
+  - Build OSX wheels
   - Test and lint
   - Test multiple python versions
   - Build Linux wheels

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ notifications:
 #     - "master"
 
 stages:
+  - Build Linux and OSX wheels
   - Test and lint
   - Test multiple python versions
-  - Build Linux and OSX wheels
+
 
 # Parent stage definition, to avoid copy-pasting.
 job_compile_common: &job_compile_common
@@ -109,7 +110,7 @@ jobs:
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
     os: osx
     stage: Build Linux and OSX wheels
-    if: tag IS present
+    # if: tag IS present
     addons:
       homebrew:
         packages:
@@ -128,3 +129,11 @@ jobs:
     script:
       # build the wheels, put them into './wheelhouse'
       - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
+    deploy:
+      provider: s3
+      access_key_id: $access_key_id
+      secret_access_key: $secret_access_key
+      bucket: "aihw-wheels"
+      skip_cleanup: true
+      upload-dir: wheelhouse
+      endpoint: https://$endpoint

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ jobs:
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
     os: osx
     stage: Build Linux and OSX wheels
-    # if: tag IS present
+    if: tag IS present
     addons:
       homebrew:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ jobs:
     env:
       - CIBW_BEFORE_ALL=""
       - CIBW_BEFORE_BUILD="pip install ./delocate && pip install -r requirements.txt"
-      - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
+      - CIBW_BUILD="cp36-macosx_x86_64" # cp37-macosx_x86_64 cp38-macosx_x86_64"
       # - CIBW_SKIP="cp27-* cp35-* cp38-*"
       # - CIBW_TEST_COMMAND="pytest -v -s tests/"
     before_install:
@@ -136,4 +136,6 @@ jobs:
       bucket: "aihw-wheels"
       skip_cleanup: true
       upload-dir: wheelhouse
-      endpoint: https://$endpoint
+      endpoint: https://s3.us-south.cloud-object-storage.appdomain.cloud
+      on:
+        all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ stages:
 
 # Parent stage definition, to avoid copy-pasting.
 job_compile_common: &job_compile_common
+  os: linux
   before_install:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get update
@@ -55,12 +56,14 @@ jobs:
   include:
   - name: "Compile and test. Python 3.6"
     os: linux
+    dist: bionic
     <<: *job_compile_common
     stage: Test and lint
     python: "3.6"
 
   - name: "Compile and lint. Python 3.6"
     os: linux
+    dist: bionic
     <<: *job_compile_common
     stage: Test and lint
     python: "3.6"
@@ -72,18 +75,21 @@ jobs:
 
   - name: "Compile and test. Python 3.7"
     os: linux
+    dist: bionic
     <<: *job_compile_common
     stage: Test multiple python versions
     python: "3.7"
 
   - name: "Compile and test. Python 3.8"
     os: linux
+    dist: bionic
     <<: *job_compile_common
     stage: Test multiple python versions
     python: "3.8"
 
   - name: "Compile and test. Python 3.6, Torch 1.5"
     os: linux
+    dist: bionic
     <<: *job_compile_common
     stage: Test multiple python versions
     python: "3.6"
@@ -97,6 +103,7 @@ jobs:
 
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on Linux x86_64"
     os: linux
+    dist: bionic
     stage: Build Linux wheels
     if: tag IS present
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ notifications:
 #     - "master"
 
 stages:
+  - Build Linux and OSX wheels
   - Test and lint
   - Test multiple python versions
-  - Build Linux and OSX wheels
+
 
 # Parent stage definition, to avoid copy-pasting.
 job_compile_common: &job_compile_common
@@ -87,15 +88,17 @@ jobs:
     language: python
     services: docker
     stage: Build Linux and OSX wheels
-    if: tag IS present
+    # if: tag IS present
     env:
       - CIBW_BEFORE_ALL="yum install -y openblas-devel gtest wget"
       - CIBW_BEFORE_BUILD="pip install -r requirements.txt mkl mkl-include pytest"
-      - CIBW_MANYLINUX_X86_64_IMAGE="manylinux2014"
-      - CIBW_MANYLINUX_I686_IMAGE="manylinux2014"
+      - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
+      - CIBW_MANYLINUX_I686_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
       - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64"
       # - CIBW_SKIP="cp27-* cp35-* cp38-*"
       # - CIBW_TEST_COMMAND="pytest -v -s tests/"
+    before_install:
+      - docker pull aihwkit/manylinux2014_x86_64_aihwkit
     install:
       - python3 -m pip install cibuildwheel==1.6.0
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,9 @@ notifications:
 #     - "master"
 
 stages:
-  - Build Linux and OSX wheels
   - Test and lint
   - Test multiple python versions
-
+  - Build Linux and OSX wheels
 
 # Parent stage definition, to avoid copy-pasting.
 job_compile_common: &job_compile_common
@@ -90,7 +89,7 @@ jobs:
     stage: Build Linux and OSX wheels
     # if: tag IS present
     env:
-      - CIBW_BEFORE_ALL="yum install -y openblas-devel gtest wget"
+      - CIBW_BEFORE_ALL=""
       - CIBW_BEFORE_BUILD="pip install -r requirements.txt mkl mkl-include pytest"
       - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
       - CIBW_MANYLINUX_I686_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
@@ -123,7 +122,7 @@ jobs:
       # - CIBW_SKIP="cp27-* cp35-* cp38-*"
       # - CIBW_TEST_COMMAND="pytest -v -s tests/"
     before_install:
-      - git clone -b aihwkit https://github.com/filemaster/delocate.git
+      - git clone -b aihwkit https://github.com/aihwkit-bot/delocate.git
     install:
       - python3 -m pip install cibuildwheel==1.6.0
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,9 @@ os:
   - osx
 
 stages:
-  - Build OSX wheels
   - Test and lint
   - Test multiple python versions
-  - Build Linux wheels
+  - Build Linux and OSX wheels
 
 # Parent stage definition, to avoid copy-pasting.
 job_compile_common: &job_compile_common
@@ -94,7 +93,7 @@ jobs:
     os: linux
     dist: bionic
     language: python
-    stage: Build Linux wheels
+    stage: Build Linux and OSX wheels
     if: tag IS present
     env:
       - CIBW_BEFORE_ALL="yum install -y openblas-devel gtest wget"
@@ -114,7 +113,7 @@ jobs:
 
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
     os: osx
-    stage: Build OSX wheels
+    stage: Build Linux and OSX wheels
     # if: tag IS present
     addons:
       homebrew:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,9 @@ language: python
 services: docker
 
 # Setup Travis to use Ubuntu 18.04 - Bionic
-os: linux
-dist: bionic
+os:
+  - linux
+  - osx
 
 stages:
   - Test and lint
@@ -52,11 +53,13 @@ job_compile_common: &job_compile_common
 jobs:
   include:
   - name: "Compile and test. Python 3.6"
+    os: linux
     <<: *job_compile_common
     stage: Test and lint
     python: "3.6"
 
   - name: "Compile and lint. Python 3.6"
+    os: linux
     <<: *job_compile_common
     stage: Test and lint
     python: "3.6"
@@ -67,16 +70,19 @@ jobs:
       - make mypy
 
   - name: "Compile and test. Python 3.7"
+    os: linux
     <<: *job_compile_common
     stage: Test multiple python versions
     python: "3.7"
 
   - name: "Compile and test. Python 3.8"
+    os: linux
     <<: *job_compile_common
     stage: Test multiple python versions
     python: "3.8"
 
   - name: "Compile and test. Python 3.6, Torch 1.5"
+    os: linux
     <<: *job_compile_common
     stage: Test multiple python versions
     python: "3.6"
@@ -89,6 +95,7 @@ jobs:
       - VERBOSE=1 pip install -v -e .
 
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on Linux x86_64"
+    os: linux
     stage: Build Linux wheels
     if: tag IS present
     env:
@@ -104,5 +111,28 @@ jobs:
     script:
       # build the wheels, put them into './wheelhouse'
       - python3 -m cibuildwheel --output-dir wheelhouse
+      # The plan is to upload the wheels via twine only when the commit is tagged
+      # python3 -m twine <..>
+
+  - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
+    os: osx
+    stage: Build OSX wheels
+    if: tag IS present
+    addons:
+      homebrew:
+        packages:
+          - openblas
+        update: true
+    env:
+      - CIBW_BEFORE_ALL=""
+      - CIBW_BEFORE_BUILD="pip install ../aihwkit-wheel-helper/delocate && pip install -r requirements.txt"
+      - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
+      # - CIBW_SKIP="cp27-* cp35-* cp38-*"
+      # - CIBW_TEST_COMMAND="pytest -v -s tests/"
+    install:
+      - python3 -m pip install cibuildwheel==1.6.0
+    script:
+      # build the wheels, put them into './wheelhouse'
+      - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
       # The plan is to upload the wheels via twine only when the commit is tagged
       # python3 -m twine <..>

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ notifications:
   email: false
 
 # Disable double triggering when issuing a PR from a branch in the main repo.
-branches:
-  only:
-    - "master"
+# branches:
+#   only:
+#     - "master"
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,17 @@ job_compile_common: &job_compile_common
     - pip install "parameterized==0.7.4"
     - make pytest
 
+build_deploy_common: &build_deploy_common
+  deploy:
+    provider: s3
+    access_key_id: $ACCESS_KEY_ID
+    secret_access_key: $SECRET_ACCESS_KEY
+    bucket: "aihw-wheels"
+    skip_cleanup: true
+    local_dir: wheelhouse
+    endpoint: https://$ENDPOINT
+    on:
+      all_branches: true
 
 jobs:
   include:
@@ -90,13 +101,9 @@ jobs:
     stage: Build Linux and OSX wheels
     # if: tag IS present
     env:
-      - CIBW_BEFORE_ALL=""
-      - CIBW_BEFORE_BUILD="pip install -r requirements.txt mkl mkl-include pytest"
+      - CIBW_BEFORE_BUILD="pip install -r requirements.txt"
       - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
-      - CIBW_MANYLINUX_I686_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
       - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64"
-      # - CIBW_SKIP="cp27-* cp35-* cp38-*"
-      # - CIBW_TEST_COMMAND="pytest -v -s tests/"
     before_install:
       - docker pull aihwkit/manylinux2014_x86_64_aihwkit
     install:
@@ -104,8 +111,7 @@ jobs:
     script:
       # build the wheels, put them into './wheelhouse'
       - python3 -m cibuildwheel --output-dir wheelhouse
-      # The plan is to upload the wheels via twine only when the commit is tagged
-      # python3 -m twine <..>
+    <<: *build_deploy_common
 
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
     os: osx
@@ -117,11 +123,8 @@ jobs:
           - openblas
         update: true
     env:
-      - CIBW_BEFORE_ALL=""
       - CIBW_BEFORE_BUILD="pip install ./delocate && pip install -r requirements.txt"
-      - CIBW_BUILD="cp36-macosx_x86_64" # cp37-macosx_x86_64 cp38-macosx_x86_64"
-      # - CIBW_SKIP="cp27-* cp35-* cp38-*"
-      # - CIBW_TEST_COMMAND="pytest -v -s tests/"
+      - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
     before_install:
       - git clone -b aihwkit https://github.com/aihwkit-bot/delocate.git
     install:
@@ -129,13 +132,4 @@ jobs:
     script:
       # build the wheels, put them into './wheelhouse'
       - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
-    deploy:
-      provider: s3
-      access_key_id: $access_key_id
-      secret_access_key: $secret_access_key
-      bucket: "aihw-wheels"
-      skip_cleanup: true
-      upload-dir: wheelhouse
-      endpoint: https://s3.us-south.cloud-object-storage.appdomain.cloud
-      on:
-        all_branches: true
+    <<: *build_deploy_common

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,6 @@ jobs:
       homebrew:
         packages:
           - openblas
-          - python
         update: true
     env:
       - CIBW_BEFORE_ALL=""


### PR DESCRIPTION
## Related issues

Travis-CI generates the Linux and MacOS wheel packages.

## Description

On new tags, Travis generates the wheel packages for Mac and Linux and uploads the files to S3.

