### PR TITLE
Honour the strict flag in _load_from_state_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 * Serialization of `Modules` that contain children analog layers is now
   possible, both when using containers such as `Sequential` and when using
-  analog layers as custom Module attributes. (\#74)
+  analog layers as custom Module attributes. (\#74, \#80)
 * The build system has been improved, with experimental Windows support and
   supporting using CUDA 11 correctly. (\#58, \#67, \#68)
 

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -193,11 +193,16 @@ class AnalogModuleBase(Module):
         module, but not its descendants.
 
         This method is a specialization of ``Module._load_from_state_dict``
-        that takes into account the extra `analog_tile_state` key used by
+        that takes into account the extra ``analog_tile_state`` key used by
         analog layers.
         """
-        analog_state = state_dict.pop('{}analog_tile_state'.format(prefix))
-        self.analog_tile.__setstate__(analog_state)
+        key = '{}analog_tile_state'.format(prefix)
+        if key in state_dict:
+            analog_state = state_dict.pop(key)
+            self.analog_tile.__setstate__(analog_state)
+        elif strict:
+            missing_keys.append(key)
+
         super()._load_from_state_dict(
             state_dict, prefix, local_metadata, strict, missing_keys,
             unexpected_keys, error_msgs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -278,3 +278,19 @@ class SerializationTest(ParametrizedTestCase):
         if self.bias:
             assert_array_almost_equal(model_biases, new_model_biases)
             assert_array_almost_equal(tile_biases, new_tile_biases)
+
+    def test_state_dict_analog_strict(self):
+        """Test the `strict` flag for analog layers."""
+        model = self.get_layer()
+        state_dict = model.state_dict()
+
+        # Remove the analog key from the state dict.
+        del state_dict['analog_tile_state']
+
+        # Check that it fails when using `strict`.
+        with self.assertRaises(RuntimeError) as context:
+            model.load_state_dict(state_dict, strict=True)
+        self.assertIn('Missing key', str(context.exception))
+
+        # Check that it passes when not using `strict`.
+        model.load_state_dict(state_dict, strict=False)


### PR DESCRIPTION
## Related issues

#59 

## Description

Make the analog layers `_load_from_state_dict` more flexible, checking for the existence of the custom `analog_tile_state` key instead of blindly assuming it will be present.

This allows for the `strict` flag to work as intended, which in turn enables loading the state dict of a digital network in an equivalent analog network and other use cases.

## Details

Real credit to @Fabio-83 for discovering the issue and providing spot-on suggestions!
