### PR TITLE
Adjust conda instructions for scikit-build

### DIFF
--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -69,7 +69,8 @@ miniconda
 On a miniconda-based system, the following commands can be used for installing
 the minimal dependencies [#f3]_::
 
-    $ conda install cmake openblas pybind11 scikit-build
+    $ conda install cmake openblas pybind11
+    $ conda install -c conda-forge scikit-build
     $ conda install pytorch -c pytorch
 
 

--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -71,7 +71,7 @@ the minimal dependencies [#f3]_::
 
     $ conda install cmake openblas pybind11
     $ conda install -c conda-forge scikit-build
-    $ conda install pytorch -c pytorch
+    $ conda install -c pytorch pytorch
 
 
 Windows (Experimental)


### PR DESCRIPTION


## Related issues

#21 

## Description

Small fix in the advanced install guide, pointing to using the right
channel (`conda-forge`) for installing `scikit-build` when using conda.

## Details

<!-- A more elaborate description of the changes, if needed. -->
