### PR TITLE
Fix adding dependency on cub target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,10 @@ if(USE_CUDA)
   set_property(TARGET RPU_GPU PROPERTY CUDA_ARCHITECTURES ${RPU_CUDA_ARCHITECTURES})
 
   if(${CUDAToolkit_VERSION_MAJOR} LESS 11)
-    add_dependencies(RPU_GPU cub)
+    # The "cub" target only exists if cub was downloaded during build.
+    if(TARGET cub)
+        add_dependencies(RPU_GPU cub)
+    endif()
   endif()
 
 endif(USE_CUDA)


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Fix the `add_dependency` on the `cub` target, as in the cases where
cub is installed system-wide and not downloaded automatically during
`dependencies_cuda.cmake` the target would not be present, causing
`cmake` to stop.

## Details

<!-- A more elaborate description of the changes, if needed. -->
