### PR TITLE
Allow specifying torch version via environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ notifications:
 branches:
   only:
     - "master"
+    - /^release\/.*$/
 
 stages:
   - Test and lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,12 @@ job_compile_common: &job_compile_common
 build_deploy_common: &build_deploy_common
   deploy:
     provider: s3
-    access_key_id: $ACCESS_KEY_ID
-    secret_access_key: $SECRET_ACCESS_KEY
-    bucket: "aihw-wheels"
+    access_key_id: $COS_ACCESS_KEY_ID
+    secret_access_key: $COS_SECRET_ACCESS_KEY
+    bucket: $COS_BUCKET
     skip_cleanup: true
     local_dir: wheelhouse
-    endpoint: https://$ENDPOINT
+    endpoint: https://$COS_ENDPOINT
     on:
       all_branches: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ jobs:
     install:
       - python3 -m pip install cibuildwheel==1.6.0
     script:
-      # build the wheels, put them into './wheelhouse'
+      # Build the wheels into './wheelhouse'.
       - python3 -m cibuildwheel --output-dir wheelhouse
     <<: *build_deploy_common
 
@@ -133,6 +133,6 @@ jobs:
     install:
       - python3 -m pip install cibuildwheel==1.6.0
     script:
-      # build the wheels, put them into './wheelhouse'
+      # Build the wheels into './wheelhouse'.
       - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
     <<: *build_deploy_common

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ jobs:
     language: python
     services: docker
     stage: Build Linux and OSX wheels
-    if: tag IS present
+    if: branch =~ /^release\/.*$/
     env:
       # Use a specific torch version.
       - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
@@ -117,7 +117,7 @@ jobs:
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
     os: osx
     stage: Build Linux and OSX wheels
-    if: tag IS present
+    if: branch =~ /^release\/.*$/
     addons:
       homebrew:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,9 @@ jobs:
     stage: Build Linux and OSX wheels
     if: tag IS present
     env:
-      - CIBW_BEFORE_BUILD="pip install -r requirements.txt"
+      # Use a specific torch version.
+      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
+      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install -r requirements.txt"
       - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
       - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64"
     before_install:
@@ -122,7 +124,9 @@ jobs:
           - openblas
         update: true
     env:
-      - CIBW_BEFORE_BUILD="pip install ./delocate && pip install -r requirements.txt"
+      # Use a specific torch version.
+      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
+      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install ./delocate && pip install -r requirements.txt"
       - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
     before_install:
       - git clone -b aihwkit https://github.com/aihwkit-bot/delocate.git

--- a/docs/source/developer_install.rst
+++ b/docs/source/developer_install.rst
@@ -121,5 +121,16 @@ the compiler to ``clang`` in osx systems::
 
     $ python setup.py build_ext --inplace -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
 
+Environment variables
+"""""""""""""""""""""
+
+The following environment variables are taken into account during the build
+process:
+
+============================  ================================================
+Environment variable          Description
+============================  ================================================
+``TORCH_VERSION_SPECIFIER``   If present, sets the ``pytorch`` dependency version in the built Python package
+============================  ================================================
 
 .. _virtual environment: https://docs.python.org/3/library/venv.html

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import find_packages
 from skbuild import setup
 
 INSTALL_REQUIRES = [
-    'torch>=1.5',
+    'torch{}'.format(os.getenv('TORCH_VERSION_SPECIFIER', '>=1.5')),
     'numpy>=1.18',
     'dataclasses==0.7; python_version < "3.7"'
 ]
@@ -43,7 +43,7 @@ setup(
     description='IBM Analog Hardware Acceleration Kit',
     long_description=get_long_description(),
     long_description_content_type='text/markdown',
-    url='https://github.ibm.com/ETX/ai-hardware-toolkit',
+    url='https://github.com/IBM/aihwkit',
     author='IBM Research',
     author_email='aihwkit@us.ibm.com',
     license='Apache 2.0',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import find_packages
 from skbuild import setup
 
 INSTALL_REQUIRES = [
-    'torch>=1.2',
+    'torch>=1.5',
     'numpy>=1.18',
     'dataclasses==0.7; python_version < "3.7"'
 ]


### PR DESCRIPTION
## Related issues

#52

## Description

Allow setting the `pytorch` dependency version specification at wheel building time via an environment variable (falling back to a lax `>=1.5` if not present); and use it to make the `cibuildwheel` invocation enforce specific `pytorch==1.6.0` in the produced wheels.

This paves the way towards reducing the impact of #52 (by allowing us to set the supported versions for a specific wheel and version). 

## Details

Some CI aspects are also revised - in particular, creating wheels not on tags but on specific branches and an additional environment variable. 
