### PR TITLE
Update osx image to 12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,7 @@ jobs:
 
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
     os: osx
+    osx_image: xcode12.2
     stage: Build Linux and OSX wheels
     if: branch =~ /^release\/.*$/
     addons:


### PR DESCRIPTION
## Related issues

Travis is not able to generate the OSX Wheels because Brew update takes too much time to complete a job and it finishes with a timeout error message.

## Description

Travis is running the default OSX image (`Xcode 9.4.1`) and Brew need to update too much packages.

## Details

Update OSX image to the latest version: `Xcode 12.2`
