### PR TITLE
Allow building windows wheel from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,85 +56,85 @@ build_deploy_common: &build_deploy_common
 
 jobs:
   include:
-  - name: "Compile and test. Python 3.6"
-    <<: *job_compile_common
-    stage: Test and lint
-    python: "3.6"
-
-  - name: "Compile and lint. Python 3.6"
-    <<: *job_compile_common
-    stage: Test and lint
-    python: "3.6"
-    script:
-      - pip install -r requirements-dev.txt
-      - make pycodestyle
-      - make pylint
-      - make mypy
-
-  - name: "Compile and test. Python 3.7"
-    <<: *job_compile_common
-    stage: Test multiple python versions
-    python: "3.7"
-
-  - name: "Compile and test. Python 3.8"
-    <<: *job_compile_common
-    stage: Test multiple python versions
-    python: "3.8"
-
-  - name: "Compile and test. Python 3.6, Torch 1.5"
-    <<: *job_compile_common
-    stage: Test multiple python versions
-    python: "3.6"
-    install:
-      # Set the python executable, to force cmake picking the right one.
-      - PYTHON_EXECUTABLE=~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python$TRAVIS_PYTHON_VERSION
-      - pip install "torch==1.5.1"
-      - pip install -r requirements.txt pytest
-      # Install the package in editable mode.
-      - VERBOSE=1 pip install -v -e .
-
-  - name: "Build wheel for Python 3.6, 3.7, 3.8 on Linux x86_64"
-    os: linux
-    dist: bionic
-    language: python
-    services: docker
-    stage: Build Linux and OSX wheels
-    if: branch =~ /^release\/.*$/
-    env:
-      # Use a specific torch version.
-      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
-      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install -r requirements.txt"
-      - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
-      - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64"
-    before_install:
-      - docker pull aihwkit/manylinux2014_x86_64_aihwkit
-    install:
-      - python3 -m pip install cibuildwheel==1.6.0
-    script:
-      # Build the wheels into './wheelhouse'.
-      - python3 -m cibuildwheel --output-dir wheelhouse
-    <<: *build_deploy_common
-
-  - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
-    os: osx
-    osx_image: xcode12.2
-    stage: Build Linux and OSX wheels
-    if: branch =~ /^release\/.*$/
-    addons:
-      homebrew:
-        packages:
-          - openblas
-        update: true
-    env:
-      # Use a specific torch version.
-      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
-      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install ./delocate && pip install -r requirements.txt"
-      - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
-    before_install:
-      - git clone -b aihwkit https://github.com/aihwkit-bot/delocate.git
-    install:
-      - python3 -m pip install cibuildwheel==1.6.0
-    script:
-      # Build the wheels into './wheelhouse'.
-      - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
-    <<: *build_deploy_common
+#  - name: "Compile and test. Python 3.6"
+#    <<: *job_compile_common
+#    stage: Test and lint
+#    python: "3.6"
+#
+#  - name: "Compile and lint. Python 3.6"
+#    <<: *job_compile_common
+#    stage: Test and lint
+#    python: "3.6"
+#    script:
+#      - pip install -r requirements-dev.txt
+#      - make pycodestyle
+#      - make pylint
+#      - make mypy
+#
+#  - name: "Compile and test. Python 3.7"
+#    <<: *job_compile_common
+#    stage: Test multiple python versions
+#    python: "3.7"
+#
+#  - name: "Compile and test. Python 3.8"
+#    <<: *job_compile_common
+#    stage: Test multiple python versions
+#    python: "3.8"
+#
+#  - name: "Compile and test. Python 3.6, Torch 1.5"
+#    <<: *job_compile_common
+#    stage: Test multiple python versions
+#    python: "3.6"
+#    install:
+#      # Set the python executable, to force cmake picking the right one.
+#      - PYTHON_EXECUTABLE=~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python$TRAVIS_PYTHON_VERSION
+#      - pip install "torch==1.5.1"
+#      - pip install -r requirements.txt pytest
+#      # Install the package in editable mode.
+#      - VERBOSE=1 pip install -v -e .
+#
+#  - name: "Build wheel for Python 3.6, 3.7, 3.8 on Linux x86_64"
+#    os: linux
+#    dist: bionic
+#    language: python
+#    services: docker
+#    stage: Build Linux and OSX wheels
+#    if: branch =~ /^release\/.*$/
+#    env:
+#      # Use a specific torch version.
+#      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
+#      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install -r requirements.txt"
+#      - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
+#      - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64"
+#    before_install:
+#      - docker pull aihwkit/manylinux2014_x86_64_aihwkit
+#    install:
+#      - python3 -m pip install cibuildwheel==1.6.0
+#    script:
+#      # Build the wheels into './wheelhouse'.
+#      - python3 -m cibuildwheel --output-dir wheelhouse
+#    <<: *build_deploy_common
+#
+#  - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
+#    os: osx
+#    osx_image: xcode12.2
+#    stage: Build Linux and OSX wheels
+#    if: branch =~ /^release\/.*$/
+#    addons:
+#      homebrew:
+#        packages:
+#          - openblas
+#        update: true
+#    env:
+#      # Use a specific torch version.
+#      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
+#      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install ./delocate && pip install -r requirements.txt"
+#      - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
+#    before_install:
+#      - git clone -b aihwkit https://github.com/aihwkit-bot/delocate.git
+#    install:
+#      - python3 -m pip install cibuildwheel==1.6.0
+#    script:
+#      # Build the wheels into './wheelhouse'.
+#      - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
+#    <<: *build_deploy_common

--- a/.travis.yml
+++ b/.travis.yml
@@ -166,4 +166,4 @@ jobs:
     script:
       # Build the wheels into './wheelhouse'.
       - python3 -m cibuildwheel --output-dir wheelhouse
-    # <<: *build_deploy_common
+    <<: *build_deploy_common

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ notifications:
   email: false
 
 # Disable double triggering when issuing a PR from a branch in the main repo.
-#branches:
-#  only:
-#    - "master"
-#    - /^release\/.*$/
+branches:
+  only:
+    - "master"
+    - /^release\/.*$/
 
 stages:
   - Test and lint
   - Test multiple python versions
-  - Build Linux and OSX wheels
+  - Build wheels
 
 # Parent stage definition, to avoid copy-pasting.
 job_compile_common: &job_compile_common
@@ -56,102 +56,102 @@ build_deploy_common: &build_deploy_common
 
 jobs:
   include:
-#  - name: "Compile and test. Python 3.6"
-#    <<: *job_compile_common
-#    stage: Test and lint
-#    python: "3.6"
-#
-#  - name: "Compile and lint. Python 3.6"
-#    <<: *job_compile_common
-#    stage: Test and lint
-#    python: "3.6"
-#    script:
-#      - pip install -r requirements-dev.txt
-#      - make pycodestyle
-#      - make pylint
-#      - make mypy
-#
-#  - name: "Compile and test. Python 3.7"
-#    <<: *job_compile_common
-#    stage: Test multiple python versions
-#    python: "3.7"
-#
-#  - name: "Compile and test. Python 3.8"
-#    <<: *job_compile_common
-#    stage: Test multiple python versions
-#    python: "3.8"
-#
-#  - name: "Compile and test. Python 3.6, Torch 1.5"
-#    <<: *job_compile_common
-#    stage: Test multiple python versions
-#    python: "3.6"
-#    install:
-#      # Set the python executable, to force cmake picking the right one.
-#      - PYTHON_EXECUTABLE=~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python$TRAVIS_PYTHON_VERSION
-#      - pip install "torch==1.5.1"
-#      - pip install -r requirements.txt pytest
-#      # Install the package in editable mode.
-#      - VERBOSE=1 pip install -v -e .
-#
-#  - name: "Build wheel for Python 3.6, 3.7, 3.8 on Linux x86_64"
-#    os: linux
-#    dist: bionic
-#    language: python
-#    services: docker
-#    stage: Build Linux and OSX wheels
-#    if: branch =~ /^release\/.*$/
-#    env:
-#      # Use a specific torch version.
-#      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
-#      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install -r requirements.txt"
-#      - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
-#      - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64"
-#    before_install:
-#      - docker pull aihwkit/manylinux2014_x86_64_aihwkit
-#    install:
-#      - python3 -m pip install cibuildwheel==1.6.0
-#    script:
-#      # Build the wheels into './wheelhouse'.
-#      - python3 -m cibuildwheel --output-dir wheelhouse
-#    <<: *build_deploy_common
-#
-#  - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
-#    os: osx
-#    osx_image: xcode12.2
-#    stage: Build Linux and OSX wheels
-#    if: branch =~ /^release\/.*$/
-#    addons:
-#      homebrew:
-#        packages:
-#          - openblas
-#        update: true
-#    env:
-#      # Use a specific torch version.
-#      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
-#      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install ./delocate && pip install -r requirements.txt"
-#      - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
-#    before_install:
-#      - git clone -b aihwkit https://github.com/aihwkit-bot/delocate.git
-#    install:
-#      - python3 -m pip install cibuildwheel==1.6.0
-#    script:
-#      # Build the wheels into './wheelhouse'.
-#      - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
-#    <<: *build_deploy_common
+  - name: "Compile and test. Python 3.6"
+    <<: *job_compile_common
+    stage: Test and lint
+    python: "3.6"
+
+  - name: "Compile and lint. Python 3.6"
+    <<: *job_compile_common
+    stage: Test and lint
+    python: "3.6"
+    script:
+      - pip install -r requirements-dev.txt
+      - make pycodestyle
+      - make pylint
+      - make mypy
+
+  - name: "Compile and test. Python 3.7"
+    <<: *job_compile_common
+    stage: Test multiple python versions
+    python: "3.7"
+
+  - name: "Compile and test. Python 3.8"
+    <<: *job_compile_common
+    stage: Test multiple python versions
+    python: "3.8"
+
+  - name: "Compile and test. Python 3.6, Torch 1.5"
+    <<: *job_compile_common
+    stage: Test multiple python versions
+    python: "3.6"
+    install:
+      # Set the python executable, to force cmake picking the right one.
+      - PYTHON_EXECUTABLE=~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python$TRAVIS_PYTHON_VERSION
+      - pip install "torch==1.5.1"
+      - pip install -r requirements.txt pytest
+      # Install the package in editable mode.
+      - VERBOSE=1 pip install -v -e .
 
   - name: "Build wheel for Python 3.6, 3.7, 3.8 on Linux x86_64"
+    os: linux
+    dist: bionic
+    language: python
+    services: docker
+    stage: Build wheels
+    if: branch =~ /^release\/.*$/
+    env:
+      # Use a specific torch version.
+      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
+      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install -r requirements.txt"
+      - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
+      - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64"
+    before_install:
+      - docker pull aihwkit/manylinux2014_x86_64_aihwkit
+    install:
+      - python3 -m pip install cibuildwheel==1.6.0
+    script:
+      # Build the wheels into './wheelhouse'.
+      - python3 -m cibuildwheel --output-dir wheelhouse
+    <<: *build_deploy_common
+
+  - name: "Build wheel for Python 3.6, 3.7, 3.8 on OS X"
+    os: osx
+    osx_image: xcode12.2
+    stage: Build wheels
+    if: branch =~ /^release\/.*$/
+    addons:
+      homebrew:
+        packages:
+          - openblas
+        update: true
+    env:
+      # Use a specific torch version.
+      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
+      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install ./delocate && pip install -r requirements.txt"
+      - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
+    before_install:
+      - git clone -b aihwkit https://github.com/aihwkit-bot/delocate.git
+    install:
+      - python3 -m pip install cibuildwheel==1.6.0
+    script:
+      # Build the wheels into './wheelhouse'.
+      - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
+    <<: *build_deploy_common
+
+  - name: "Build wheel for Python 3.6, 3.7, 3.8 on win64"
     os: windows
     language: shell
-    stage: Build Linux and OSX wheels
-#    if: branch =~ /^release\/.*$/
+    stage: Build wheels
+    if: branch =~ /^release\/win.*$/
     env:
-      - OPENBLAS_ROOT=C:\\BLAS
-      - OPENBLAS_ROOT_DIR=C:\\BLAS
       # Use a specific torch version.
       - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
       - CIBW_BEFORE_BUILD="pip install torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html && pip install -r requirements.txt"
-      - CIBW_BUILD_VERBOSITY=1
       - CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64"
+      # Use unzipped OpenBLAS.
+      - OPENBLAS_ROOT=C:\\BLAS
+      - OPENBLAS_ROOT_DIR=C:\\BLAS
     before_install:
       # Install base python, and ensure it's on the PATH.
       - choco install python --version 3.8.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,17 +145,24 @@ jobs:
     stage: Build Linux and OSX wheels
 #    if: branch =~ /^release\/.*$/
     env:
+      - OPENBLAS_ROOT=C:\\BLAS
+      - OPENBLAS_ROOT_DIR=C:\\BLAS
       # Use a specific torch version.
       - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
-      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install -r requirements.txt"
-      - CIBW_BUILD="cp38-win32"
+      - CIBW_BEFORE_BUILD="pip install torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html && pip install -r requirements.txt"
+      - CIBW_BUILD_VERBOSITY=1
+      - CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64"
     before_install:
-      - choco install python --version 3.8.0
+      # Install base python, and ensure it's on the PATH.
+      - choco install python --version 3.8.6
       - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
-      # make sure it's on PATH as 'python3'
       - ln -s /c/Python38/python.exe /c/Python38/python3.exe
+      # Download and unzip OpenBLAS.
+      - wget https://github.com/xianyi/OpenBLAS/releases/download/v0.3.12/OpenBLAS-0.3.12-x64.zip -q -O openblas.zip
+      - mkdir C:\\BLAS
+      - 7z x openblas.zip -oc:\\BLAS
     install:
-      - python3 -m pip install cibuildwheel==1.6.0
+      - python3 -m pip install cibuildwheel==1.6.4
     script:
       # Build the wheels into './wheelhouse'.
       - python3 -m cibuildwheel --output-dir wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ notifications:
   email: false
 
 # Disable double triggering when issuing a PR from a branch in the main repo.
-branches:
-  only:
-    - "master"
-    - /^release\/.*$/
+#branches:
+#  only:
+#    - "master"
+#    - /^release\/.*$/
 
 stages:
   - Test and lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,3 +138,25 @@ jobs:
 #      # Build the wheels into './wheelhouse'.
 #      - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
 #    <<: *build_deploy_common
+
+  - name: "Build wheel for Python 3.6, 3.7, 3.8 on Linux x86_64"
+    os: windows
+    language: shell
+    stage: Build Linux and OSX wheels
+#    if: branch =~ /^release\/.*$/
+    env:
+      # Use a specific torch version.
+      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
+      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install -r requirements.txt"
+      - CIBW_BUILD="cp38-win32"
+    before_install:
+      - choco install python --version 3.8.0
+      - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+      # make sure it's on PATH as 'python3'
+      - ln -s /c/Python38/python.exe /c/Python38/python3.exe
+    install:
+      - python3 -m pip install cibuildwheel==1.6.0
+    script:
+      # Build the wheels into './wheelhouse'.
+      - python3 -m cibuildwheel --output-dir wheelhouse
+    # <<: *build_deploy_common

--- a/cmake/Modules/FindOpenBLAS.cmake
+++ b/cmake/Modules/FindOpenBLAS.cmake
@@ -55,7 +55,14 @@ SET(Open_BLAS_LIB_SEARCH_PATHS
 )
 
 FIND_PATH(OpenBLAS_INCLUDE_DIR NAMES openblas_config.h PATHS ${Open_BLAS_INCLUDE_SEARCH_PATHS})
-FIND_LIBRARY(OpenBLAS_LIB NAMES openblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS})
+if(WIN32)
+    # The official OpenBLAS github releases (-x64) name the library
+    # `libopenblas.*`, whereas the default `CMAKE_FIND_LIBRARY_PREFIXES` does
+    # not contain `lib`.
+    FIND_LIBRARY(OpenBLAS_LIB NAMES openblas libopenblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS})
+else()
+    FIND_LIBRARY(OpenBLAS_LIB NAMES openblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS})
+endif()
 # maybe add the openblasp64 if available
 
 SET(OpenBLAS_FOUND ON)


### PR DESCRIPTION
## Related issues

#12 

## Description

Add a new job to the wheels stage that uses `cibuildwheel` to create Windows wheels:
* the wheels use `torch+cpu` from [the torch wheel repo](https://download.pytorch.org/whl/torch_stable.html). It seems the torch Windows wheels are not uploaded to pypi systematically, and some errors were encountered using the ones that were available (1.7.0).
* the job uses the [x64-specific release](https://github.com/xianyi/OpenBLAS) of OpenBLAS. It has the advantage of avoiding compilation (at the expense of hard-coding some paths as environment variables and a tweak to `FindTorch.cmake`)

Please note this is still experimental, and no Windows wheels will be published yet.

## Details

The wheel do not included the `.dll` dependencies, as `cibuildwheel` does not "repair" the wheels in the same way as Linux/OSX. This will be fixed in future iterations - in the meantime, the building of wheels have been left opt-in with a different branch name (`release/win-` instead of just `release/`).

More information: https://github.com/joerick/cibuildwheel/issues/459
