### PR TITLE
Use the same dataset root folder in examples

### DIFF
--- a/examples/03_mnist_training.py
+++ b/examples/03_mnist_training.py
@@ -34,8 +34,7 @@ from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
 
 # Path where the datasets will be stored.
-TRAIN_DATASET = 'data/TRAIN_DATASET'
-TEST_DATASET = 'data/TEST_DATASET'
+PATH_DATASET = 'data/DATASET'
 
 # Network definition.
 INPUT_SIZE = 784
@@ -52,9 +51,9 @@ def load_images():
     transform = transforms.Compose([transforms.ToTensor()])
 
     # Load the images.
-    train_set = datasets.MNIST(TRAIN_DATASET,
+    train_set = datasets.MNIST(PATH_DATASET,
                                download=True, train=True, transform=transform)
-    val_set = datasets.MNIST(TEST_DATASET,
+    val_set = datasets.MNIST(PATH_DATASET,
                              download=True, train=False, transform=transform)
     train_data = torch.utils.data.DataLoader(
         train_set, batch_size=BATCH_SIZE, shuffle=True)

--- a/examples/03_mnist_training.py
+++ b/examples/03_mnist_training.py
@@ -19,6 +19,7 @@ Uses learning rates of η = 0.01, 0.005, and 0.0025
 for epochs 0–10, 11–20, and 21–30, respectively.
 """
 
+import os
 from time import time
 
 # Imports from PyTorch.
@@ -34,7 +35,7 @@ from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
 
 # Path where the datasets will be stored.
-PATH_DATASET = 'data/DATASET'
+PATH_DATASET = os.path.join('data', 'DATASET')
 
 # Network definition.
 INPUT_SIZE = 784

--- a/examples/04_lenet5_training.py
+++ b/examples/04_lenet5_training.py
@@ -44,8 +44,7 @@ if torch.cuda.is_available():
     USE_CUDA = 1
 
 # Path to store datasets
-TRAIN_DATASET = os.path.join('data', 'TRAIN_DATASET')
-TEST_DATASET = os.path.join('data', 'TEST_DATASET')
+PATH_DATASET = os.path.join('data', 'DATASET')
 
 # Path to store results
 RESULTS = os.path.join('results', 'LENET5')
@@ -69,8 +68,8 @@ RPU_CONFIG = SingleRPUConfig(device=ConstantStepDevice())
 def load_images():
     """Load images for train from torchvision datasets."""
     transform = transforms.Compose([transforms.ToTensor()])
-    train_set = datasets.MNIST(TRAIN_DATASET, download=True, train=True, transform=transform)
-    val_set = datasets.MNIST(TEST_DATASET, download=True, train=False, transform=transform)
+    train_set = datasets.MNIST(PATH_DATASET, download=True, train=True, transform=transform)
+    val_set = datasets.MNIST(PATH_DATASET, download=True, train=False, transform=transform)
     train_data = torch.utils.data.DataLoader(train_set, batch_size=BATCH_SIZE, shuffle=True)
     validation_data = torch.utils.data.DataLoader(val_set, batch_size=BATCH_SIZE, shuffle=False)
 

--- a/examples/06_lenet5_hardware_aware.py
+++ b/examples/06_lenet5_hardware_aware.py
@@ -41,8 +41,7 @@ if torch.cuda.is_available():
     USE_CUDA = 1
 
 # Path to store datasets
-TRAIN_DATASET = os.path.join('data', 'TRAIN_DATASET')
-TEST_DATASET = os.path.join('data', 'TEST_DATASET')
+PATH_DATASET = os.path.join('data', 'DATASET')
 
 # Path to store results
 RESULTS = os.path.join('results', 'LENET5')
@@ -66,8 +65,8 @@ RPU_CONFIG.noise_model = PCMLikeNoiseModel(g_max=25.0)
 def load_images():
     """Load images for train from torchvision datasets."""
     transform = transforms.Compose([transforms.ToTensor()])
-    train_set = datasets.MNIST(TRAIN_DATASET, download=True, train=True, transform=transform)
-    val_set = datasets.MNIST(TEST_DATASET, download=True, train=False, transform=transform)
+    train_set = datasets.MNIST(PATH_DATASET, download=True, train=True, transform=transform)
+    val_set = datasets.MNIST(PATH_DATASET, download=True, train=False, transform=transform)
     train_data = torch.utils.data.DataLoader(train_set, batch_size=BATCH_SIZE, shuffle=True)
     validation_data = torch.utils.data.DataLoader(val_set, batch_size=BATCH_SIZE, shuffle=False)
 


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Use the same dataset root folder both for the training data loader and
the test data loader. torchvision creates another folder inside the
root folder (`MNIST/`) and is able to use the same data files for both
the sets.

## Details

Hopefully this avoids downloading the same data twice.
