### PR TITLE
Use type alias for rpu_config in layers

### DIFF
--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -27,6 +27,9 @@ from aihwkit.simulator.tiles import (
     AnalogTile, BaseTile, FloatingPointTile, InferenceTile
 )
 
+RPUConfigAlias = Union[FloatingPointRPUConfig, SingleRPUConfig,
+                       UnitCellRPUConfig, InferenceRPUConfig]
+
 
 class AnalogModuleBase(Module):
     """Base class for analog Modules.
@@ -55,9 +58,7 @@ class AnalogModuleBase(Module):
             in_features: int,
             out_features: int,
             bias: bool,
-            rpu_config: Optional[
-                Union[FloatingPointRPUConfig, SingleRPUConfig,
-                      UnitCellRPUConfig, InferenceRPUConfig]] = None,
+            rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False
     ) -> BaseTile:
         """Create an analog tile and setup this layer for using it.

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -19,10 +19,7 @@ from torch.nn import Conv2d, Unfold
 from torch.nn.modules.utils import _pair
 
 from aihwkit.nn.functions import AnalogIndexedFunction
-from aihwkit.nn.modules.base import AnalogModuleBase
-from aihwkit.simulator.configs import (
-    FloatingPointRPUConfig, SingleRPUConfig, UnitCellRPUConfig
-)
+from aihwkit.nn.modules.base import AnalogModuleBase, RPUConfigAlias
 
 
 class AnalogConv2d(Conv2d, AnalogModuleBase):
@@ -82,8 +79,7 @@ class AnalogConv2d(Conv2d, AnalogModuleBase):
             groups: int = 1,
             bias: bool = True,
             padding_mode: str = 'zeros',
-            rpu_config: Optional[
-                Union[FloatingPointRPUConfig, SingleRPUConfig, UnitCellRPUConfig]] = None,
+            rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
     ):
         # pylint: disable=too-many-arguments

--- a/src/aihwkit/nn/modules/linear.py
+++ b/src/aihwkit/nn/modules/linear.py
@@ -12,17 +12,13 @@
 
 """Analog layers."""
 
-from typing import Optional, Union
+from typing import Optional
 
 from torch import Tensor
 from torch.nn import Linear
 
 from aihwkit.nn.functions import AnalogFunction
-from aihwkit.nn.modules.base import AnalogModuleBase
-from aihwkit.simulator.configs import (
-    FloatingPointRPUConfig, InferenceRPUConfig, SingleRPUConfig,
-    UnitCellRPUConfig
-)
+from aihwkit.nn.modules.base import AnalogModuleBase, RPUConfigAlias
 
 
 class AnalogLinear(Linear, AnalogModuleBase):
@@ -58,9 +54,7 @@ class AnalogLinear(Linear, AnalogModuleBase):
             in_features: int,
             out_features: int,
             bias: bool = True,
-            rpu_config: Optional[
-                Union[FloatingPointRPUConfig, SingleRPUConfig,
-                      UnitCellRPUConfig, InferenceRPUConfig]] = None,
+            rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
     ):
         # Create the tile.


### PR DESCRIPTION


## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Use a type alias for the `rpu_config` init parameter in the layers,
reducing verbosity and making it easier to propagate to new layers.

## Details

Actually comes from a small fix - in the `AnalogConv2d` layer, we were not declaring `InferenceRPUConfig` as part of the accepted types, which in turn was causing some IDE warnings in example 06.
