### PR TITLE
RPUCuda update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,17 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-* Deterministic bitlines for analog training (\XX)
-* More noise types for hardware-aware training for inference (polynomial)
-* Additional bound management schemes (worst case, average max, shift)
-* cycle-to-cycle output referred MAC weight noise that resembles the conductance
-  dependent PCM read noise stastistics
-* C++ backend improvements (slice backward/forward/update, direct update)
-* Option to excluded bias row for hardware-aware training noise
+* Option to choose deterministic pulse trains for the rank-1 update of
+  analog devices during training (\#99)
+* More noise types for hardware-aware training for inference
+  (polynomial) (\#99)
+* Additional bound management schemes (worst case, average max, shift) (\#99)
+* Cycle-to-cycle output referred analog multipl-and-accumulate weight
+  noise that resembles the conductance dependent PCM read noise
+  stastistics (\#99)
+* C++ backend improvements (slice backward/forward/update, direct
+  update) (\#99)
+* Option to excluded bias row for hardware-aware training noise (\#99)
 * The `rpu_config` is now pretty-printed in a readable manner (excluding the
   default settings and other readability tweak). (\#60)
 * Added a new `ReferenceUnitCell` which has two devices, where one is fixed and
@@ -55,6 +59,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
+* Faulty backward noise management error message removed for perfect backward
+  and CUDA (\#99)
 * Serialization of `Modules` that contain children analog layers is now
   possible, both when using containers such as `Sequential` and when using
   analog layers as custom Module attributes. (\#74, \#80)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+* Deterministic bitlines for analog training (\XX)
+* More noise types for hardware-aware training for inference (polynomial)
+* Additional bound management schemes (worst case, average max, shift)
+* cycle-to-cycle output referred MAC weight noise that resembles the conductance
+  dependent PCM read noise stastistics
+* C++ backend improvements (slice backward/forward/update, direct update)
+* Option to excluded bias row for hardware-aware training noise
 * The `rpu_config` is now pretty-printed in a readable manner (excluding the
   default settings and other readability tweak). (\#60)
 * Added a new `ReferenceUnitCell` which has two devices, where one is fixed and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
+* Fixed small issues that resulted in warnings for windows compilation
 * Faulty backward noise management error message removed for perfect backward
   and CUDA (\#99)
 * Serialization of `Modules` that contain children analog layers is now

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ adjustable parameters. Features include:
 * Forward pass output-referred noise and device fluctuations, as well
   as adjustable ADC and DAC discretization and bounds
 * Stochastic update pulse trains for rows and columns with finite
-  weight update size per pulse coincidence 
-* Device-to-device systematic variations, cycle-to-cycle noise and 
-  adjustable asymmetry during analog update 
+  weight update size per pulse coincidence
+* Device-to-device systematic variations, cycle-to-cycle noise and
+  adjustable asymmetry during analog update
 * Adjustable device behavior for exploration of material specifications for
   training and inference
 * State-of-the-art dynamic input scaling, bound management, and update
@@ -100,7 +100,7 @@ called the [von Neumann bottleneck].
 Analog AI delivers radical performance improvements by combining compute and
 memory in a single device, eliminating the von Neumann bottleneck. By leveraging
 the physical properties of memory devices, computation happens at the same place
-where the data is stored. Such in-memory computing hardware increases the speed 
+where the data is stored. Such in-memory computing hardware increases the speed
 and energy-efficiency needed for the next generation of AI. 
 
 ## What is an in-memory computing chip?
@@ -108,7 +108,7 @@ and energy-efficiency needed for the next generation of AI. 
 An in-memory computing chip typically consists of multiple arrays of memory
 devices that communicate with each other. Many types of memory devices such as
 [phase-change memory] (PCM), [resistive random-access memory] (RRAM), and
-[Flash memory] can be used for in-memory computing. 
+[Flash memory] can be used for in-memory computing.
 
 Memory devices have the ability to store synaptic weights in their analog
 charge (Flash) or conductance (PCM, RRAM) state. When these devices are arranged
@@ -116,7 +116,7 @@ in a crossbar configuration, it allows to perform an analog matrix-vector
 multiplication in a single time step, exploiting the advantages of analog
 storage capability and [Kirchhoff’s circuits laws]. You can learn more about
 it in our [online demo].
- 
+
 In deep learning, data propagation through multiple layers of a neural network
 involves a sequence of matrix multiplications, as each layer can be represented
 as a matrix of synaptic weights. The devices are arranged in multiple crossbar

--- a/examples/09_simple_layer_deterministic_pulses.py
+++ b/examples/09_simple_layer_deterministic_pulses.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""aihwkit example 9: simple network with one layer using
+deterministic pulse trains for update.
+
+Simple network that consist of one analog layer. The network aims to learn
+to sum all the elements from one array.
+
+"""
+
+# Imports from PyTorch.
+from torch import Tensor
+from torch.nn.functional import mse_loss
+
+# Imports from aihwkit.
+from aihwkit.nn import AnalogLinear
+from aihwkit.optim import AnalogSGD
+from aihwkit.simulator.configs import SingleRPUConfig
+from aihwkit.simulator.configs.devices import ConstantStepDevice
+from aihwkit.simulator.configs.utils import PulseType
+from aihwkit.simulator.rpu_base import cuda
+
+# Prepare the datasets (input and expected output).
+x = Tensor([[0.1, 0.2, 0.4, 0.3], [0.2, 0.1, 0.1, 0.3]])
+y = Tensor([[1.0, 0.5], [0.7, 0.3]])
+
+# Define a single-layer network, using a constant step device type.
+rpu_config = SingleRPUConfig(device=ConstantStepDevice())
+rpu_config.update.pulse_type = PulseType.DETERMINISTIC_IMPLICIT
+rpu_config.update.desired_bl = 10 # max number in this case
+rpu_config.update.update_bl_management = True # will vary up to 10 on demand
+rpu_config.update.d_res_implicit = 0.1 # effective resolution of x bit lines
+rpu_config.update.x_res_implicit = 0.1 # effective resolution of d bit lines
+
+model = AnalogLinear(4, 2, bias=True,
+                     rpu_config=rpu_config)
+print(model.analog_tile.tile)
+# Move the model and tensors to cuda if it is available.
+if cuda.is_compiled():
+    x = x.cuda()
+    y = y.cuda()
+    model.cuda()
+
+# Define an analog-aware optimizer, preparing it for using the layers.
+opt = AnalogSGD(model.parameters(), lr=0.1)
+opt.regroup_param_groups(model)
+
+for epoch in range(100):
+    # Add the training Tensor to the model (input).
+    pred = model(x)
+    # Add the expected output Tensor.
+    loss = mse_loss(pred, y)
+    # Run training (backward propagation).
+    loss.backward()
+
+    opt.step()
+    print('Loss error: {:.16f}'.format(loss))

--- a/examples/README.md
+++ b/examples/README.md
@@ -265,6 +265,35 @@ rpu_config = UnitCellRPUConfig(
 Similarly to example 1 the network is trained over 100 epochs with an analog Stochastic Gradient
 Descent optimizer and the loss is printed for every epoch.
 
+## Example 8: [`09_simple_layer_deterministic_pulses.py`]
+
+This example shows how to select different pulsing schemes for the
+analog update. By default, we use stochastic pulses for activation
+and errors to update the devices with a step in up or down direction
+only if pulses conincide at a crosspoint. Note, that we indeed
+generate stochastic pulse trains for each input line and thus  do no
+short-cut in the simulation.
+
+Here, in this example, we change the updaate to be performed using
+deterministic pulse trains that yield always the same number of
+coincident pulses at a cross point, if the same inputs are
+given. Implicitely, one can design the stored pulse train structure to
+quantize the input values in a number of bins, which can be changed
+by the ``*_res_imilicit``  parameters. 
+
+```
+rpu_config = SingleRPUConfig(device=ConstantStepDevice())
+rpu_config.update.pulse_type = PulseType.DETERMINISTIC_IMPLICIT
+rpu_config.update.desired_bl = 10 # max number in this case
+rpu_config.update.update_bl_management = True # will vary up to 10 on demand
+rpu_config.update.d_res_implicit = 0.1 # effective resolution of x bit lines
+rpu_config.update.x_res_implicit = 0.1 # effective resolution of d bit lines
+
+```
+Similarly to example 1 the network is trained over 100 epochs with an analog Stochastic Gradient
+Descent optimizer and the loss is printed for every epoch.
+
+
 [Apache License 2.0]: LICENSE.txt
 [Resistive Processing Units]: https://aihwkit.readthedocs.io/en/latest/using_simulator.html#resistive-processing-units
 [Inference and PCM statistical model]: https://aihwkit.readthedocs.io/en/latest/pcm_inference.html

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -250,12 +250,14 @@ void declare_rpu_devices(py::module &m) {
       .def(py::init<>())
       .def_readwrite("fixed_bl", &RPU::PulsedUpdateMetaParameter<T>::fixed_BL)
       .def_readwrite("desired_bl", &RPU::PulsedUpdateMetaParameter<T>::desired_BL)
+      .def_readwrite("d_res_implicit", &RPU::PulsedUpdateMetaParameter<T>::d_res_implicit)
       .def_readwrite("pulse_type", &RPU::PulsedUpdateMetaParameter<T>::pulse_type)
       .def_readwrite("res", &RPU::PulsedUpdateMetaParameter<T>::res)
       .def_readwrite("sto_round", &RPU::PulsedUpdateMetaParameter<T>::sto_round)
       .def_readwrite("update_management", &RPU::PulsedUpdateMetaParameter<T>::update_management)
       .def_readwrite(
-          "update_bl_management", &RPU::PulsedUpdateMetaParameter<T>::update_bl_management);
+          "update_bl_management", &RPU::PulsedUpdateMetaParameter<T>::update_bl_management)
+      .def_readwrite("x_res_implicit", &RPU::PulsedUpdateMetaParameter<T>::x_res_implicit);
 
   py::class_<RPU::IOMetaParameter<T>>(m, "AnalogTileInputOutputParameter")
       .def(py::init<>())
@@ -268,6 +270,8 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("is_perfect", &RPU::IOMetaParameter<T>::is_perfect)
       .def_readwrite("max_bm_factor", &RPU::IOMetaParameter<T>::max_bm_factor)
       .def_readwrite("max_bm_res", &RPU::IOMetaParameter<T>::max_bm_res)
+      .def_readwrite("nm_assumed_wmax", &RPU::IOMetaParameter<T>::nm_assumed_wmax)
+      .def_readwrite("nm_decay", &RPU::IOMetaParameter<T>::nm_decay)
       .def_readwrite("nm_thres", &RPU::IOMetaParameter<T>::nm_thres)
       .def_readwrite("noise_management", &RPU::IOMetaParameter<T>::noise_management)
       .def_readwrite("out_bound", &RPU::IOMetaParameter<T>::out_bound)
@@ -428,7 +432,9 @@ void declare_rpu_devices(py::module &m) {
    **/
   py::enum_<RPU::BoundManagementType>(m, "BoundManagementType")
       .value("None", RPU::BoundManagementType::None)
-      .value("Iterative", RPU::BoundManagementType::Iterative);
+      .value("Iterative", RPU::BoundManagementType::Iterative)
+      .value("IterativeWorstCase", RPU::BoundManagementType::IterativeWorstCase)
+      .value("Shift", RPU::BoundManagementType::Shift);
 
   py::enum_<RPU::VectorDeviceUpdatePolicy>(m, "VectorUnitCellUpdatePolicy")
       .value("All", RPU::VectorDeviceUpdatePolicy::All)
@@ -439,17 +445,21 @@ void declare_rpu_devices(py::module &m) {
   py::enum_<RPU::NoiseManagementType>(m, "NoiseManagementType")
       .value("None", RPU::NoiseManagementType::None)
       .value("AbsMax", RPU::NoiseManagementType::AbsMax)
+      .value("AbsMaxNPSum", RPU::NoiseManagementType::AbsMaxNPSum)
+      .value("Max", RPU::NoiseManagementType::Max)
       .value("Constant", RPU::NoiseManagementType::Constant)
-      .value("Max", RPU::NoiseManagementType::Max);
+      .value("AverageAbsMax", RPU::NoiseManagementType::AverageAbsMax);
 
   py::enum_<RPU::OutputWeightNoiseType>(m, "WeightNoiseType")
       .value("None", RPU::OutputWeightNoiseType::None)
-      .value("AdditiveConstant", RPU::OutputWeightNoiseType::AdditiveConstant);
+      .value("AdditiveConstant", RPU::OutputWeightNoiseType::AdditiveConstant)
+      .value("PCMRead", RPU::OutputWeightNoiseType::PCMRead);
 
   py::enum_<RPU::PulseType>(m, "PulseType")
       .value("None", RPU::PulseType::None)
       .value("StochasticCompressed", RPU::PulseType::StochasticCompressed)
       .value("Stochastic", RPU::PulseType::Stochastic)
       .value("NoneWithDevice", RPU::PulseType::NoneWithDevice)
-      .value("MeanCount", RPU::PulseType::MeanCount);
+      .value("MeanCount", RPU::PulseType::MeanCount)
+      .value("DeterministicImplicit", RPU::PulseType::DeterministicImplicit);
 }

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
@@ -30,8 +30,12 @@ void declare_rpu_tiles(py::module &m) {
       .def_readwrite("dorefa_clip", &RPU::WeightModifierParameter::dorefa_clip)
       .def_readwrite("pdrop", &RPU::WeightModifierParameter::pdrop)
       .def_readwrite("enable_during_test", &RPU::WeightModifierParameter::enable_during_test)
+      .def_readwrite("copy_last_column", &RPU::WeightModifierParameter::copy_last_column)
       .def_readwrite("rel_to_actual_wmax", &RPU::WeightModifierParameter::rel_to_actual_wmax)
       .def_readwrite("assumed_wmax", &RPU::WeightModifierParameter::assumed_wmax)
+      .def_readwrite("coeff0", &RPU::WeightModifierParameter::coeff0)
+      .def_readwrite("coeff1", &RPU::WeightModifierParameter::coeff1)
+      .def_readwrite("coeff2", &RPU::WeightModifierParameter::coeff2)
       .def_readwrite("type", &RPU::WeightModifierParameter::type);
 
   py::enum_<RPU::WeightModifierType>(m, "WeightModifierType")
@@ -40,7 +44,8 @@ void declare_rpu_tiles(py::module &m) {
       .value("MultNormal", RPU::WeightModifierType::MultNormal)
       .value("AddNormal", RPU::WeightModifierType::AddNormal)
       .value("DiscretizeAddNormal", RPU::WeightModifierType::DiscretizeAddNormal)
-      .value("DoReFa", RPU::WeightModifierType::DoReFa);
+      .value("DoReFa", RPU::WeightModifierType::DoReFa)
+      .value("Poly", RPU::WeightModifierType::Poly);
 
   py::class_<RPU::WeightClipParameter>(m, "WeightClipParameter")
       .def(py::init<>())
@@ -445,7 +450,6 @@ void declare_rpu_tiles(py::module &m) {
            Args:
                weight_modifier_params: parameters of the modifications.
            )pbdoc")
-
       .def(
           "diffuse_weights", &Class::diffuseWeights,
           R"pbdoc(
@@ -461,7 +465,6 @@ void declare_rpu_tiles(py::module &m) {
                alpha: decay scale
                bias_no_decay: Whether to not decay the bias row
            )pbdoc")
-
       .def(
           "reset_columns",
           [](Class &self, int start_col, int n_cols, T reset_prob) {

--- a/src/rpucuda/cuda/bit_line_maker.h
+++ b/src/rpucuda/cuda/bit_line_maker.h
@@ -19,14 +19,14 @@
 namespace RPU {
 
 enum BLMOutputFormat {
-  NotSet,  // dummy init
-  FP,      // floating point mode for future uses
-  UI32,    // standard 32-bit word of bits per x,d value [more than one
-           // word supported]. First bit is sign
-  BO64,    // 64 word with sign bits in upper 32-bit word and data in
-           // lower. Batch major ordering. Here more than one batch
-           // value can be squeezed together in one word. Useful for
-           // small BL, will speed up loading across batches
+  NotSet, // dummy init
+  FP,     // floating point mode for implicit pulses
+  UI32,   // standard 32-bit word of bits per x,d value [more than one word supported]. First bit is
+          // sign
+  BO64,   // 64 word with sign bits in upper 32-bit word and data in
+          // lower. Batch major ordering. Here more than one batch
+          // value can be squeezed together in one word. Useful for
+          // small BL, will speed up loading across batches
   UI32BO64 // translate mode, first UI32 than compressed into BO64
 };
 
@@ -46,9 +46,10 @@ public:
       const bool x_trans = false,
       const bool d_trans = false,
       const bool out_trans = false,
-      const int use_bo64 = 0);
+      const int use_bo64 = 0,
+      const bool implicit_pulses = false);
 
-  BLMOutputFormat getFormat(int use_bo64, bool implicit_pulses = false);
+  BLMOutputFormat getFormat(int use_bo64, bool implicit_pulses);
 
   T *getXData() const;
   T *getDData() const;
@@ -72,12 +73,13 @@ public:
   }
   inline int getNK32Current() const { return current_BL_ / 32 + 1; };
   void getCountsDebug(uint32_t *x_counts, uint32_t *d_counts);
+  void getFPCounts(T *x_counts, T *d_counts);
 
   inline T getCurrentLR() const { return current_lr_; };
   // helper for debug
   UpdateManagementHelper<T> *getUmh() const { return &*umh_; };
 
-  void initializeBLBuffers(int m_batch, int BL, int use_bo64);
+  void initializeBLBuffers(int m_batch, int BL, int use_bo64, bool implicit_pulses);
 
 private:
   CudaContext *context_ = nullptr;

--- a/src/rpucuda/cuda/bit_line_maker_test.cpp
+++ b/src/rpucuda/cuda/bit_line_maker_test.cpp
@@ -119,7 +119,7 @@ public:
     z3 = new T[size[2] * m_batch];
     z4 = new T[size[3] * m_batch];
 
-    auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_real_distribution<T> udist(-1., 1.);
     auto urnd = std::bind(udist, generator);
@@ -324,7 +324,7 @@ public:
     x_counts_trans = new uint32_t[x_size * m_batch * nK32];
     d_counts_trans = new uint32_t[d_size * m_batch * nK32];
 
-    auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_real_distribution<num_t> udist(-1., 1.);
     auto urnd = std::bind(udist, generator);

--- a/src/rpucuda/cuda/cuda_math_util.cu
+++ b/src/rpucuda/cuda/cuda_math_util.cu
@@ -18,10 +18,6 @@
   cublasHandle_t handle = context->getBlasHandle();                                                \
   CUBLAS_CALL(cublasSetStream(handle, context->getStream()))
 
-#define RPU_GET_CUBLAS_HANDLE                                                                      \
-  cublasHandle_t handle = context->getBlasHandle();                                                \
-  CUBLAS_CALL(cublasSetStream(handle, context->getStream()))
-
 #define RPU_SET_CUBLAS_POINTER_MODE_DEVICE                                                         \
   cublasPointerMode_t p_mode;                                                                      \
   CUBLAS_CALL(cublasGetPointerMode(handle, &p_mode));                                              \
@@ -684,10 +680,8 @@ template void elemconst<float>(const CudaContext *, float *, const int, const fl
 #ifdef RPU_USE_DOUBLE
 template void elemconst<double>(const CudaContext *, double *, const int, const double);
 #endif
-template void
-elemconst<unsigned int>(const CudaContext *, unsigned int *, const int, const unsigned int);
-template void
-elemconst<uint64_t>(const CudaContext *, uint64_t *, const int, const uint64_t);
+template void elemconst<uint32_t>(const CudaContext *, uint32_t *, const int, const uint32_t);
+template void elemconst<uint64_t>(const CudaContext *, uint64_t *, const int, const uint64_t);
 template void elemconst<int>(const CudaContext *, int *, const int, const int);
 template void elemconst<char>(const CudaContext *, char *, const int, const char);
 
@@ -1063,9 +1057,17 @@ RPU_CMU_DEFINE_CWI(float *, float *);
 RPU_CMU_DEFINE_CWI(float *, IndexReaderInputIterator<float>);
 RPU_CMU_DEFINE_CWI(float *, IndexReaderTransInputIterator<float>);
 RPU_CMU_DEFINE_CWI(float *, PermuterTransInputIterator<float>);
+RPU_CMU_DEFINE_CWI(float *, IndexReaderSliceInputIterator<TRANS_FLOAT(true)>);
+RPU_CMU_DEFINE_CWI(float *, IndexReaderSliceInputIterator<TRANS_FLOAT(false)>);
+RPU_CMU_DEFINE_CWI(float *, SliceInputIterator<TRANS_FLOAT(true)>);
+RPU_CMU_DEFINE_CWI(float *, SliceInputIterator<TRANS_FLOAT(false)>);
 RPU_CMU_DEFINE_CWI(PermuterTransOutputIterator<float>, const float *);
 RPU_CMU_DEFINE_CWI(IndexReaderOutputIterator<float>, const float *);
 RPU_CMU_DEFINE_CWI(IndexReaderTransOutputIterator<float>, const float *);
+RPU_CMU_DEFINE_CWI(IndexReaderSliceOutputIterator<TRANS_FLOAT(true)>, const float *);
+RPU_CMU_DEFINE_CWI(IndexReaderSliceOutputIterator<TRANS_FLOAT(false)>, const float *);
+RPU_CMU_DEFINE_CWI(SliceOutputIterator<TRANS_FLOAT(true)>, const float *);
+RPU_CMU_DEFINE_CWI(SliceOutputIterator<TRANS_FLOAT(false)>, const float *);
 
 #undef TRANS_FLOAT
 
@@ -1076,9 +1078,17 @@ RPU_CMU_DEFINE_CWI(double *, double *);
 RPU_CMU_DEFINE_CWI(double *, IndexReaderInputIterator<double>);
 RPU_CMU_DEFINE_CWI(double *, IndexReaderTransInputIterator<double>);
 RPU_CMU_DEFINE_CWI(double *, PermuterTransInputIterator<double>);
+RPU_CMU_DEFINE_CWI(double *, IndexReaderSliceInputIterator<TRANS_DOUBLE(true)>);
+RPU_CMU_DEFINE_CWI(double *, IndexReaderSliceInputIterator<TRANS_DOUBLE(false)>);
+RPU_CMU_DEFINE_CWI(double *, SliceInputIterator<TRANS_DOUBLE(true)>);
+RPU_CMU_DEFINE_CWI(double *, SliceInputIterator<TRANS_DOUBLE(false)>);
 RPU_CMU_DEFINE_CWI(PermuterTransOutputIterator<double>, const double *);
 RPU_CMU_DEFINE_CWI(IndexReaderOutputIterator<double>, const double *);
 RPU_CMU_DEFINE_CWI(IndexReaderTransOutputIterator<double>, const double *);
+RPU_CMU_DEFINE_CWI(IndexReaderSliceOutputIterator<TRANS_DOUBLE(true)>, const double *);
+RPU_CMU_DEFINE_CWI(IndexReaderSliceOutputIterator<TRANS_DOUBLE(false)>, const double *);
+RPU_CMU_DEFINE_CWI(SliceOutputIterator<TRANS_DOUBLE(true)>, const double *);
+RPU_CMU_DEFINE_CWI(SliceOutputIterator<TRANS_DOUBLE(false)>, const double *);
 
 #undef TRANS_DOUBLE
 #endif

--- a/src/rpucuda/cuda/cuda_math_util.h
+++ b/src/rpucuda/cuda/cuda_math_util.h
@@ -230,8 +230,6 @@ void copyWithIterator(
 // to overcome compiling issues. ONLY forks for IteratorT=T * of const T * respectively. Else it
 // will cause a compilation error. To be guarded with std::is_same<>
 template <typename T, typename IteratorT> T *fakeCast(IteratorT X);
-
 template <typename T, typename IteratorT> const T *fakeCastConst(IteratorT X);
-
 } // namespace math
 } // namespace RPU

--- a/src/rpucuda/cuda/cuda_util.cu
+++ b/src/rpucuda/cuda/cuda_util.cu
@@ -288,9 +288,6 @@ void CudaContext::init() {
   } else {
     CUDA_CALL(cudaGetDevice(&gpu_id_));
   }
-  // int gpu_count = 0;
-  // cuDeviceGetCount(&gpu_count);
-  // std::cout << "GPU devices " << gpu_count     << ", using ID " << gpu_id_ << std::endl;
 
   env_ = new CublasEnvironment(gpu_id_);
   stream_id_ = 0;
@@ -317,11 +314,11 @@ CudaContext::CudaContext(cudaStream_t shared_stream, int gpu_id) : gpu_id_(gpu_i
 
   // ignore the test for shared stream 0. Pytorch seem to like 0
   // if (!shared_stream) {
-  // RPU_FATAL("Shared stream should not be NULL!");
+  //  RPU_FATAL("Shared stream should not be NULL!");
   //} else {
   shared_ = true;
   streams_.push_back(shared_stream);
-  //}
+  // }
 }
 
 CudaContext::~CudaContext() {

--- a/src/rpucuda/cuda/forward_backward_pass.h
+++ b/src/rpucuda/cuda/forward_backward_pass.h
@@ -177,12 +177,12 @@ void backwardMatrixIteratorIOManaged(
 
       return;
     }
+  } else {
+    // input management
+    if (b_io_pars.bound_management != BoundManagementType::None) {
+      RPU_FATAL("Bound management is not supported for backward pass.");
+    };
   }
-
-  // input management
-  if (b_io_pars.bound_management != BoundManagementType::None) {
-    RPU_FATAL("Bound management is not supported for backward pass.");
-  };
 
   b_iom.setSharedBuffer(m_batch, in_buffer, out_buffer);
   b_iom.initWithInput(D_input, b_io_pars, m_batch, d_trans, alpha);

--- a/src/rpucuda/cuda/io_iterator.h
+++ b/src/rpucuda/cuda/io_iterator.h
@@ -47,6 +47,34 @@ public:
   const T *data_;
 };
 
+template <typename T> class IndicatorInputIterator {
+public:
+  typedef IndicatorInputIterator<T> self_type;
+  typedef int difference_type;
+  typedef T value_type;
+  typedef T *pointer;
+  typedef T reference;
+  typedef std::input_iterator_tag iterator_category;
+
+  __host__ __device__ __forceinline__
+  IndicatorInputIterator(const T *data, const T indicator, const T scale) {
+    data_ = data;
+    indicator_ = indicator;
+    scale_ = scale;
+  }
+  __host__ __device__ __forceinline__ T operator[](int idx) const {
+    return static_cast<T>(data_[idx] == indicator_) * scale_;
+  }
+
+  __host__ __device__ __forceinline__ self_type operator+(int n) const {
+    self_type retval(data_ + n, indicator_, scale_);
+    return retval;
+  }
+  const T *data_;
+  T indicator_;
+  T scale_;
+};
+
 // Iterators
 template <typename T> class IndexReaderInputIterator {
 
@@ -275,6 +303,313 @@ public:
   T *data_;
   const int *indices_;
   int M_, L_, m_, output_matrix_size_;
+};
+
+// *****  batch slice iterator
+template <bool trans> // trans true
+__host__ __device__ __forceinline__ int setM(int xd_size, int m_batch, int dim3);
+
+template <> // trans true
+__host__ __device__ __forceinline__ int setM<true>(int xd_size, int m_batch, int dim3) {
+  return m_batch * dim3;
+}
+template <> // trans false
+__host__ __device__ __forceinline__ int setM<false>(int xd_size, int m_batch, int dim3) {
+  return m_batch * xd_size;
+}
+
+template <bool trans> // trans true
+__host__ __device__ __forceinline__ void getNewIdx(
+    int &new_idx,
+    int &i_dim3,
+    int idx,
+    const int *batch_indices,
+    int xd_size,
+    int m_batch_slice,
+    int m_batch,
+    int M);
+
+template <> // trans true
+__host__ __device__ __forceinline__ void getNewIdx<true>(
+    int &new_idx,
+    int &i_dim3,
+    int idx,
+    const int *batch_indices,
+    int xd_size,
+    int m_batch_slice,
+    int m_batch,
+    int M) {
+  // order of IDX is m_batch_slice x dim3 x xd_size
+  // order of DATA is m_batch x xd_size x dim3
+
+  i_dim3 = (idx % M) / m_batch_slice;
+  int i_batch_slice = idx % m_batch_slice;
+  int i_xd = idx / M;
+  int batch_idx =
+      batch_indices[i_batch_slice + m_batch * i_dim3]; // note: batch_indices are m_batch*dim3 and
+                                                       // need to be given with the correct offset.
+  new_idx = batch_idx + m_batch * i_xd;
+};
+
+template <> // trans false
+__host__ __device__ __forceinline__ void getNewIdx<false>(
+    int &new_idx,
+    int &i_dim3,
+    int idx,
+    const int *batch_indices,
+    int xd_size,
+    int m_batch_slice,
+    int m_batch,
+    int M) {
+  // order if IDX is xd_index x m_batch_slice x dim3
+  // order of data is xd_index x m_batch * dim3
+
+  i_dim3 = idx / M;
+  int i_batch_slice = (idx % M) / xd_size;
+  int i_xd = idx % xd_size;
+  int batch_idx = batch_indices[i_batch_slice + m_batch * i_dim3];
+  new_idx = batch_idx * xd_size + i_xd;
+};
+
+template <bool trans, typename T> class IndexReaderSliceInputIterator {
+
+public:
+  typedef IndexReaderSliceInputIterator<trans, T> self_type;
+  typedef int difference_type;
+  typedef T value_type;
+  typedef T *pointer;
+  typedef T reference;
+  typedef std::input_iterator_tag iterator_category;
+
+  __host__ __device__ __forceinline__ IndexReaderSliceInputIterator(
+      const T *data,
+      const int *indices,
+      const int input_matrix_size,
+      const int xd_size,
+      const int m_batch,
+      const int dim3,
+      const int m_batch_slice,
+      const int *batch_indices) {
+
+    batch_indices_ = batch_indices; // for each dim3 differently. length: m_batch_slice*dim3
+    data_ = data;
+    M_ = setM<trans>(xd_size, m_batch_slice, dim3);
+    input_matrix_size_ = input_matrix_size;
+    xd_size_ = xd_size;
+    m_batch_ = m_batch;
+    m_batch_slice_ = m_batch_slice;
+    indices_ = indices;
+    offset_ = 0;
+  };
+
+  __host__ __device__ __forceinline__ IndexReaderSliceInputIterator(
+      const T *data,
+      const int *indices,
+      const int input_matrix_size,
+      const int xd_size,
+      const int m_batch,
+      const int M,
+      const int m_batch_slice,
+      const int *batch_indices,
+      const int offset) {
+    batch_indices_ = batch_indices;
+    data_ = data;
+    M_ = M;
+    input_matrix_size_ = input_matrix_size;
+    xd_size_ = xd_size;
+    m_batch_ = m_batch;
+    m_batch_slice_ = m_batch_slice;
+    indices_ = indices;
+    offset_ = offset;
+  }
+
+  __host__ __device__ __forceinline__ T operator[](int idx_in) const {
+    int idx = idx_in + offset_;
+    int new_idx, i_dim3;
+    getNewIdx<trans>(new_idx, i_dim3, idx, batch_indices_, xd_size_, m_batch_slice_, m_batch_, M_);
+
+    int j = indices_[new_idx];
+    return (j <= 1) ? (T)j : data_[(j - 2) + i_dim3 * input_matrix_size_];
+  };
+
+  __host__ __device__ __forceinline__ self_type operator+(int n) const {
+    self_type retval(
+        data_, indices_, input_matrix_size_, xd_size_, m_batch_, M_, m_batch_slice_, batch_indices_,
+        offset_ + n);
+    return retval;
+  };
+
+  const T *data_;
+  const int *indices_;
+  const int *batch_indices_;
+  int offset_, M_, input_matrix_size_, m_batch_, m_batch_slice_, xd_size_;
+};
+
+template <bool trans, typename T> class IndexReaderSliceOutputIterator {
+
+private:
+  // Proxy object
+  struct Reference {
+    T *ptr_;
+
+    __host__ __device__ __forceinline__ Reference(T *ptr) : ptr_(ptr) {}
+
+    __device__ __forceinline__ T operator=(T val) {
+      if (ptr_ != nullptr)
+        atomicAdd(ptr_, val);
+      return val;
+    }
+  };
+
+public:
+  __host__ __device__ __forceinline__ IndexReaderSliceOutputIterator(
+      T *data,
+      const int *indices,
+      const int output_matrix_size,
+      const int xd_size,
+      const int m_batch,
+      const int dim3,
+      const int m_batch_slice,
+      const int *batch_indices) {
+    batch_indices_ = batch_indices; // for each dim3 differently. should be new_m
+    data_ = data;
+    M_ = setM<trans>(xd_size, m_batch_slice, dim3);
+    output_matrix_size_ = output_matrix_size;
+    xd_size_ = xd_size;
+    m_batch_ = m_batch;
+    m_batch_slice_ = m_batch_slice;
+    indices_ = indices;
+  };
+
+  __host__ __device__ __forceinline__ Reference operator[](int idx) const {
+
+    int new_idx, i_dim3;
+    getNewIdx<trans>(new_idx, i_dim3, idx, batch_indices_, xd_size_, m_batch_slice_, m_batch_, M_);
+
+    int j = indices_[new_idx];
+
+    if (j <= 1)
+      return Reference(nullptr);
+    else
+      return Reference(data_ + ((j - 2) + i_dim3 * output_matrix_size_));
+  };
+
+  T *data_;
+  const int *indices_;
+  const int *batch_indices_;
+  int M_, output_matrix_size_, m_batch_, m_batch_slice_, xd_size_;
+};
+
+template <bool trans, typename T> class SliceInputIterator {
+
+public:
+  typedef SliceInputIterator<trans, T> self_type;
+  typedef int difference_type;
+  typedef T value_type;
+  typedef T *pointer;
+  typedef T reference;
+  typedef std::input_iterator_tag iterator_category;
+
+  __host__ __device__ __forceinline__ SliceInputIterator(
+      const T *data,
+      const int xd_size,
+      const int m_batch,
+      const int dim3,
+      const int m_batch_slice,
+      const int *batch_indices) {
+
+    batch_indices_ = batch_indices; // for each dim3 differently. length: m_batch_slice*dim3
+    data_ = data;
+    M_ = setM<trans>(xd_size, m_batch_slice, dim3);
+    input_matrix_size_ = m_batch * xd_size;
+    xd_size_ = xd_size;
+    m_batch_ = m_batch;
+    m_batch_slice_ = m_batch_slice;
+    offset_ = 0;
+  };
+
+  __host__ __device__ __forceinline__ SliceInputIterator(
+      const T *data,
+      const int input_matrix_size,
+      const int xd_size,
+      const int m_batch,
+      const int M,
+      const int m_batch_slice,
+      const int *batch_indices,
+      const int offset) {
+    batch_indices_ = batch_indices;
+    data_ = data;
+    M_ = M;
+    input_matrix_size_ = input_matrix_size;
+    xd_size_ = xd_size;
+    m_batch_ = m_batch;
+    m_batch_slice_ = m_batch_slice;
+    offset_ = offset;
+  }
+
+  __host__ __device__ __forceinline__ T operator[](int idx_in) const {
+    int idx = idx_in + offset_;
+    int j, i_dim3;
+    getNewIdx<trans>(j, i_dim3, idx, batch_indices_, xd_size_, m_batch_slice_, m_batch_, M_);
+
+    return data_[j + i_dim3 * input_matrix_size_];
+  };
+
+  __host__ __device__ __forceinline__ self_type operator+(int n) const {
+    self_type retval(
+        data_, input_matrix_size_, xd_size_, m_batch_, M_, m_batch_slice_, batch_indices_,
+        offset_ + n);
+    return retval;
+  };
+
+  const T *data_;
+  const int *batch_indices_;
+  int offset_, M_, input_matrix_size_, m_batch_, m_batch_slice_, xd_size_;
+};
+
+template <bool trans, typename T> class SliceOutputIterator {
+
+private:
+  // Proxy object
+  struct Reference {
+    T *ptr_;
+
+    __host__ __device__ __forceinline__ Reference(T *ptr) : ptr_(ptr) {}
+
+    __device__ __forceinline__ T operator=(T val) {
+      *ptr_ = val;
+      return val;
+    }
+  };
+
+public:
+  __host__ __device__ __forceinline__ SliceOutputIterator(
+      T *data,
+      const int xd_size,
+      const int m_batch,
+      const int dim3,
+      const int m_batch_slice,
+      const int *batch_indices) {
+    batch_indices_ = batch_indices; // for each dim3 differently. should be new_m
+    data_ = data;
+    M_ = setM<trans>(xd_size, m_batch_slice, dim3);
+    output_matrix_size_ = m_batch * xd_size;
+    xd_size_ = xd_size;
+    m_batch_ = m_batch;
+    m_batch_slice_ = m_batch_slice;
+  };
+
+  __host__ __device__ __forceinline__ Reference operator[](int idx) const {
+
+    int j, i_dim3;
+    getNewIdx<trans>(j, i_dim3, idx, batch_indices_, xd_size_, m_batch_slice_, m_batch_, M_);
+
+    return Reference(data_ + (j + i_dim3 * output_matrix_size_));
+  };
+
+  T *data_;
+  const int *batch_indices_;
+  int M_, output_matrix_size_, m_batch_, m_batch_slice_, xd_size_;
 };
 
 } // namespace RPU

--- a/src/rpucuda/cuda/io_manager.h
+++ b/src/rpucuda/cuda/io_manager.h
@@ -62,6 +62,7 @@ public:
 private:
   void applyOutputWeightNoise(const bool out_trans);
   void applyOutputNonIdealities(const T *dev_weights, const bool out_trans);
+  void applyOutputPCMReadNoise(const T *dev_weights, const bool out_trans);
 
   void initializeBatchBuffer(int m_batch);
 
@@ -74,6 +75,7 @@ private:
   int in_size_ = 0;
   int out_size_ = 0;
   std::unique_ptr<NoiseManager<T>> noise_manager_ = nullptr;
+  std::unique_ptr<Maximizer<T>> output_maximizer_ = nullptr;
 
   int buffer_m_batch_ = 0;
   int temp_m_batch_ = 0;
@@ -104,13 +106,17 @@ private:
   std::unique_ptr<CudaArray<float>> dev_scale_values_ = nullptr;
   std::unique_ptr<CudaArray<int>> dev_bound_exceeded_ = nullptr;
   std::unique_ptr<CudaArray<int>> dev_any_exceeded_ = nullptr;
-
+  std::unique_ptr<CudaArray<int>> dev_channel_exceeded_ = nullptr;
   std::unique_ptr<CudaArray<char>> dev_flagged_temp_storage_ = nullptr;
   std::unique_ptr<CudaArray<int>> dev_selected_bidx_ = nullptr;
   std::unique_ptr<CudaArray<int>> dev_selected_m_batch_ = nullptr;
 
   std::unique_ptr<CudaArray<T>> dev_wnoise_buffer_ = nullptr;
   std::unique_ptr<CudaArray<T>> dev_wnoise_ones_ = nullptr;
+
+  std::unique_ptr<CudaArray<T>> dev_extra_weight_buffer_ = nullptr;
+  std::unique_ptr<CudaArray<T>> dev_extra_batch_buffer_ = nullptr;
+  std::unique_ptr<CudaArray<T>> dev_a_buffer_ = nullptr;
 };
 
 } // namespace RPU

--- a/src/rpucuda/cuda/maximizer_test.cpp
+++ b/src/rpucuda/cuda/maximizer_test.cpp
@@ -55,7 +55,7 @@ public:
     max_values = new float[this->m_batch];
     max_values2 = new float[this->m_batch];
 
-    auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_real_distribution<num_t> udist(-1.2, 1.2);
     auto urnd = std::bind(udist, generator);

--- a/src/rpucuda/cuda/pulsed_weight_updater.h
+++ b/src/rpucuda/cuda/pulsed_weight_updater.h
@@ -56,6 +56,18 @@ public:
       const bool d_trans,
       const T beta = (T)1.0);
 
+  template <typename XInputIteratorT, typename DInputIteratorT>
+  void doDirectUpdate(
+      XInputIteratorT x_in,
+      DInputIteratorT d_in,
+      AbstractRPUDeviceCuda<T> *rpucuda_device,
+      T *dev_weights,
+      const T lr,
+      const int m_batch,
+      const bool x_trans,
+      const bool d_trans,
+      const T beta = (T)1.0);
+
   void setSharedBuffer(
       int m_batch,
       std::shared_ptr<CudaArray<T>> x_buffer = nullptr,
@@ -98,6 +110,7 @@ private:
       const bool x_trans_in,
       const bool d_trans_in);
 
+  void checkBuffers(int m_batch);
   CudaContext *context_ = nullptr;
   int x_size_ = 0;
   int d_size_ = 0;

--- a/src/rpucuda/cuda/pulsed_weight_updater_test.cpp
+++ b/src/rpucuda/cuda/pulsed_weight_updater_test.cpp
@@ -107,7 +107,7 @@ public:
     ref_w = new num_t[d_size * x_size];
     ref_w_batch = new num_t[d_size * x_size];
 
-    auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_int_distribution<unsigned int> idist(0, ((uint32_t)1) << 31);
     auto irnd = std::bind(idist, generator);

--- a/src/rpucuda/cuda/pwu_kernel.h
+++ b/src/rpucuda/cuda/pwu_kernel.h
@@ -505,7 +505,7 @@ __global__ void kernelUpdateWBatchSum(
 
         getNfromCount<one_sided, count_t>(n, negative, mixed, xptr, dptr, nK32, xsz, dsz);
 
-        RPU_UPDATE_WITH_SUM_N_INNER();
+        RPU_UPDATE_WITH_SUM_N_INNER({});
 
       } // batch
       // last update
@@ -907,7 +907,7 @@ __global__ void kernelUpdateWBatchSharedSum(
 
         RPU_UWBS_LOAD_COUNTS_N(count_t);
 
-        RPU_UPDATE_WITH_SUM_N_INNER();
+        RPU_UPDATE_WITH_SUM_N_INNER({});
 
       } // batch
       // last update

--- a/src/rpucuda/cuda/pwu_kernel_parameter_base.h
+++ b/src/rpucuda/cuda/pwu_kernel_parameter_base.h
@@ -54,11 +54,28 @@ public:
     out_trans = out_trans_in;
     use_bo64 = use_bo64_in;
     valid = true;
+    implicit_pulses = up.needsImplicitPulses();
 
-    if (use_bo64 > 0) {
-      sizeof_count = sizeof(uint64_t);
+    if (implicit_pulses) {
+
+      if (sizeof(T) == sizeof(double)) {
+        RPU_FATAL("Double not supported yet.");
+      } else {
+
+        sizeof_count = sizeof(float);
+
+        if (use_bo64) {
+          valid = false;
+        }
+      }
+
     } else {
-      sizeof_count = sizeof(uint32_t);
+
+      if (use_bo64 > 0) {
+        sizeof_count = sizeof(uint64_t);
+      } else {
+        sizeof_count = sizeof(uint32_t);
+      }
     }
 
     name = update_name;
@@ -70,6 +87,9 @@ public:
     }
     if (use_bo64 > 1) {
       name += "/BO64";
+    }
+    if (implicit_pulses) {
+      name += "/Implicit";
     }
 
     if (use_bo64 > 0 && (nK32 > 1)) {
@@ -99,6 +119,7 @@ public:
   inline std::string getName() { return this->name; };
   inline bool getOutTrans() { return this->out_trans; };
   inline int getUseBo64() { return this->use_bo64; };
+  inline int getImplicitPulses() { return this->implicit_pulses; };
 
   inline void forceBo64Translate() {
     if (this->use_bo64 == 1) {
@@ -109,7 +130,7 @@ public:
   inline void force32() { this->use_bo64 = 0; };            // debug hack
 
   inline void ensureChunk() {
-    if (use_bo64 || out_trans) {
+    if (use_bo64 || out_trans || implicit_pulses) {
       valid = false;
     }
   };
@@ -127,6 +148,7 @@ public:
     std::cout << "\t nK32:\t\t " << nK32 << std::endl;
     std::cout << "\t m_batch:\t " << m_batch << std::endl;
     std::cout << "\t timing:\t " << timing << std::endl;
+    std::cout << "\t implicit:\t " << implicit_pulses << std::endl;
   };
 
 public:
@@ -141,6 +163,7 @@ protected:
   int shared_mem = 0;
   int shared_mem_per_batch = 0;
   bool out_trans = false;
+  bool implicit_pulses = false;
   int sizeof_count = 4;
   int use_bo64 = 0;
   int nK32 = 1;

--- a/src/rpucuda/cuda/rpucuda.h
+++ b/src/rpucuda/cuda/rpucuda.h
@@ -133,7 +133,10 @@ protected:
       const int size,
       const int m_batch,
       const int dim3,
-      const bool trans) override;
+      const bool trans,
+      const int m_batch_slice = 0,
+      const int *batch_indices = nullptr) override;
+
   void copyIndexedOutput(
       T *out_tensor,
       const T *src_tensor,
@@ -142,7 +145,27 @@ protected:
       const int size,
       const int m_batch,
       const int dim3,
-      const bool trans) override;
+      const bool trans,
+      const int m_batch_slice = 0,
+      const int *batch_indices = nullptr) override;
+  void copySliceInput(
+      T *out_tensor,
+      const T *src_tensor,
+      const int size,
+      const int m_batch,
+      const int dim3,
+      const bool trans,
+      const int m_batch_slice,
+      const int *batch_indices) override;
+  void copySliceOutput(
+      T *out_tensor,
+      const T *src_tensor,
+      const int size,
+      const int m_batch,
+      const int dim3,
+      const bool trans,
+      const int m_batch_slice,
+      const int *batch_indices) override;
 
   void setZero(T *v, const int size) override {
     RPU::math::elemconst<T>(context_, v, size, (T)0.0);
@@ -154,8 +177,10 @@ public:
   void decayWeights(bool bias_no_decay) override;
   void decayWeights(T alpha, bool bias_no_decay) override;
 
-  void clipWeights(const WeightClipParameter &wclpar) override;
   void diffuseWeights() override;
+
+  void clipWeights(T clip) override;
+  void clipWeights(const WeightClipParameter &wclpar) override;
 
   T **getWeights() override; // host weights. implicit copy from CUDA
 
@@ -176,7 +201,6 @@ protected:
   std::shared_ptr<CudaContext> shared_context_ = nullptr;
   std::unique_ptr<CudaContext> rnd_diffusion_context_ = nullptr;
   std::unique_ptr<CudaArray<float>> dev_diffusion_nrnd_ = nullptr;
-
   std::unique_ptr<CudaArray<T>> dev_weights_ = nullptr;
   std::unique_ptr<CudaArray<T>> dev_weights_buffer_ = nullptr;
   std::unique_ptr<CudaArray<T>> dev_fb_weights_ = nullptr;
@@ -190,12 +214,13 @@ protected:
 
   std::unique_ptr<CudaArray<T>> dev_temp_tensor_ = nullptr;
 
+  std::unique_ptr<WeightClipperCuda<T>> wclipper_cuda_ = nullptr;
+
 private:
   void
   initFrom(const RPUSimple<T> &rpu_in); // to populate from CPU->CUDA, will be called by constructor
   void initialize(CudaContext *c);
   std::unique_ptr<WeightModifierCuda<T>> fb_wmodifier_cuda_ = nullptr;
-  std::unique_ptr<WeightClipperCuda<T>> wclipper_cuda_ = nullptr;
 };
 
 } // namespace RPU

--- a/src/rpucuda/cuda/rpucuda_constantstep_device.cu
+++ b/src/rpucuda/cuda/rpucuda_constantstep_device.cu
@@ -69,12 +69,10 @@ pwukpvec_t<T> ConstantStepRPUDeviceCuda<T>::getUpdateKernels(
   pwukpvec_t<T> v;
 
   if (getPar().dw_min_std > 0.33) { // 3 sigma
-    v.push_back(
-        RPU::make_unique<PWUKernelParameterSingleFunctor<T, UpdateFunctorConstantStepLargeNoise<T>, 1>>
-            ARGS(FunctorLargeNoise));
-    v.push_back(
-        RPU::make_unique<PWUKernelParameterBatchFunctor<T, UpdateFunctorConstantStepLargeNoise<T>, 1>>
-            ARGS(FunctorLargeNoise));
+    v.push_back(RPU::make_unique<PWUKernelParameterSingleFunctor<
+                    T, UpdateFunctorConstantStepLargeNoise<T>, 1>> ARGS(FunctorLargeNoise));
+    v.push_back(RPU::make_unique<PWUKernelParameterBatchFunctor<
+                    T, UpdateFunctorConstantStepLargeNoise<T>, 1>> ARGS(FunctorLargeNoise));
     v.push_back(RPU::make_unique<PWUKernelParameterBatchSharedFunctor<
                     T, UpdateFunctorConstantStepLargeNoise<T>, 1>> ARGS(FunctorLargeNoise));
 
@@ -84,8 +82,8 @@ pwukpvec_t<T> ConstantStepRPUDeviceCuda<T>::getUpdateKernels(
     v.push_back(RPU::make_unique<PWUKernelParameterBatchSharedSum<T>> ARGS(Sum));
     v.push_back(RPU::make_unique<PWUKernelParameterBatchSharedSumBoundCheck<T>> ARGS(SumBC));
     v.push_back(
-        RPU::make_unique<PWUKernelParameterBatchSharedFunctor<T, UpdateFunctorConstantStep<T>, 1>> ARGS(
-            Functor));
+        RPU::make_unique<PWUKernelParameterBatchSharedFunctor<T, UpdateFunctorConstantStep<T>, 1>>
+            ARGS(Functor));
 
     v.push_back(RPU::make_unique<PWUKernelParameterBatchSum<T>> ARGS(Sum));
     v.push_back(RPU::make_unique<PWUKernelParameterBatchSumBoundCheck<T>> ARGS(SumBC));

--- a/src/rpucuda/cuda/rpucuda_difference_device.cu
+++ b/src/rpucuda/cuda/rpucuda_difference_device.cu
@@ -100,11 +100,11 @@ void DifferenceRPUDeviceCuda<T>::resetCols(
   VectorRPUDeviceCuda<T>::resetCols(dev_weights, start_col, n_cols, reset_prob);
 }
 
-template <typename T> inline bool DifferenceRPUDevice<T>::isInverted() const {
+template <typename T> bool DifferenceRPUDeviceCuda<T>::isInverted() const {
   return g_plus_ == 0;
 }
 
-template <typename T> inline void DifferenceRPUDevice<T>::invert() {
+template <typename T> void DifferenceRPUDeviceCuda<T>::invert() {
   std::swap(g_plus_, g_minus_);
   std::swap(this->dev_reduce_weightening_, this->dev_reduce_weightening_inverted_);
 }

--- a/src/rpucuda/cuda/rpucuda_difference_device.h
+++ b/src/rpucuda/cuda/rpucuda_difference_device.h
@@ -67,11 +67,10 @@ public:
       bool out_trans,
       const PulsedUpdateMetaParameter<T> &up) override;
 
-  inline void invert();
+  void invert();
 
-protected:
 private:
-  inline bool isInverted() const;
+  bool isInverted() const;
 
   int g_plus_ = 1;
   int g_minus_ = 0;

--- a/src/rpucuda/cuda/rpucuda_expstep_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_expstep_test.cpp
@@ -110,7 +110,7 @@ public:
     culayer_pulsed = RPU::make_unique<RPUCudaPulsed<num_t>>(context, *layer_pulsed);
     culayer_pulsed->disp();
 
-    auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_real_distribution<num_t> udist(-1.2, 1.2);
     auto urnd = std::bind(udist, generator);

--- a/src/rpucuda/cuda/rpucuda_linearstep_device.cu
+++ b/src/rpucuda/cuda/rpucuda_linearstep_device.cu
@@ -118,9 +118,11 @@ pwukpvec_t<T> LinearStepRPUDeviceCuda<T>::getUpdateKernels(
   const auto &par = getPar();
   if (par.ls_mult_noise) {
     v.push_back(
-        RPU::make_unique<PWUKernelParameterSingleFunctor<T, UpdateFunctorLinearStepMult<T>, 1>> ARGS);
+        RPU::make_unique<PWUKernelParameterSingleFunctor<T, UpdateFunctorLinearStepMult<T>, 1>>
+            ARGS);
     v.push_back(
-        RPU::make_unique<PWUKernelParameterBatchFunctor<T, UpdateFunctorLinearStepMult<T>, 1>> ARGS);
+        RPU::make_unique<PWUKernelParameterBatchFunctor<T, UpdateFunctorLinearStepMult<T>, 1>>
+            ARGS);
     v.push_back(
         RPU::make_unique<PWUKernelParameterBatchSharedFunctor<T, UpdateFunctorLinearStepMult<T>, 1>>
             ARGS);
@@ -128,7 +130,8 @@ pwukpvec_t<T> LinearStepRPUDeviceCuda<T>::getUpdateKernels(
   } else {
 
     v.push_back(
-        RPU::make_unique<PWUKernelParameterSingleFunctor<T, UpdateFunctorLinearStepAdd<T>, 1>> ARGS);
+        RPU::make_unique<PWUKernelParameterSingleFunctor<T, UpdateFunctorLinearStepAdd<T>, 1>>
+            ARGS);
     v.push_back(
         RPU::make_unique<PWUKernelParameterBatchFunctor<T, UpdateFunctorLinearStepAdd<T>, 1>> ARGS);
     v.push_back(

--- a/src/rpucuda/cuda/rpucuda_linearstep_device.h
+++ b/src/rpucuda/cuda/rpucuda_linearstep_device.h
@@ -26,8 +26,7 @@ public:
       LinearStepRPUDeviceCuda,
       LinearStepRPUDevice,
       /*ctor body*/
-      dev_slope_ =
-          std::unique_ptr<CudaArray<float>>(new CudaArray<float>(this->context_, 2 * this->size_));
+      dev_slope_ = RPU::make_unique<CudaArray<float>>(this->context_, 2 * this->size_);
       ,
       /*dtor body*/
       ,

--- a/src/rpucuda/cuda/rpucuda_linearstep_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_linearstep_test.cpp
@@ -113,7 +113,7 @@ public:
     culayer_pulsed = RPU::make_unique<RPUCudaPulsed<num_t>>(context, *layer_pulsed);
     culayer_pulsed->disp();
 
-    auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_real_distribution<num_t> udist(-1.2, 1.2);
     auto urnd = std::bind(udist, generator);

--- a/src/rpucuda/cuda/rpucuda_pulsed.h
+++ b/src/rpucuda/cuda/rpucuda_pulsed.h
@@ -117,9 +117,43 @@ public:
       const T *X_input, const T *D_input, int total_input_size, int m_batch, int dim3, bool trans)
       override;
 
+  void forwardIndexedSlice(
+      const T *X_input,
+      T *D_output,
+      int total_input_size,
+      int m_batch,
+      int dim3,
+      bool trans,
+      int m_batch_slice,
+      const int *batch_indices,
+      bool is_test) override;
+
+  void backwardIndexedSlice(
+      const T *D_input,
+      T *X_output,
+      int total_output_size,
+      int m_batch,
+      int dim3,
+      bool trans,
+      int m_batch_slice,
+      const int *batch_indices) override;
+
+  void updateIndexedSlice(
+      const T *X_input,
+      const T *D_input,
+      int total_input_size,
+      int m_batch,
+      int dim3,
+      bool trans,
+      int m_batch_slice,
+      const int *batch_indices) override;
+
   void decayWeights(bool bias_no_decay) override;
   void decayWeights(T alpha, bool bias_no_decay) override;
   void diffuseWeights() override;
+
+  void clipWeights(T clip) override;
+  void clipWeights(const WeightClipParameter &wclpar) override;
 
   void resetCols(int start_col, int n_cols, T reset_prob) override;
 

--- a/src/rpucuda/cuda/rpucuda_pulsed_device.h
+++ b/src/rpucuda/cuda/rpucuda_pulsed_device.h
@@ -41,8 +41,25 @@ public:
     swap(static_cast<SimpleRPUDeviceCuda<T> &>(a), static_cast<SimpleRPUDeviceCuda<T> &>(b));
   }
   bool isPulsedDevice() const override { return true; };
+  bool hasDirectUpdate() const override { return false; };
+  void doDirectUpdate(
+      const T *x_input,
+      const T *d_input,
+      T *dev_weights,
+      const T lr,
+      const int m_batch,
+      const bool x_trans,
+      const bool d_trans,
+      const T beta,
+      T *x_buffer = nullptr,
+      T *d_buffer = nullptr) override {
+    RPU_FATAL("No direct update supported with this device.");
+  }
+
   /* Resets columns of the weights matrix to 0 (with noise reset_std)*/
-  void resetCols(T *dev_weights, int start_col, int n_cols, T reset_prob) {RPU_FATAL("Needs implementation");};
+  void resetCols(T *dev_weights, int start_col, int n_cols, T reset_prob) {
+    RPU_FATAL("Needs implementation");
+  };
 
   virtual T getDwMin() const = 0;
   virtual void runUpdateKernel(
@@ -63,7 +80,7 @@ public:
       bool out_trans,
       const PulsedUpdateMetaParameter<T> &up) = 0;
 
-  PulsedRPUDeviceCudaBase<T> *clone() const override {RPU_FATAL("Needs implementation");};
+  PulsedRPUDeviceCudaBase<T> *clone() const override { RPU_FATAL("Needs implementation"); };
 };
 
 /* Base class for all devices that do a simple pulsed update with 6 parameters*/

--- a/src/rpucuda/cuda/rpucuda_simple_device.h
+++ b/src/rpucuda/cuda/rpucuda_simple_device.h
@@ -32,6 +32,20 @@ public:
   virtual std::vector<T> getHiddenWeights() const = 0;
   virtual void applyWeightUpdate(T *dev_weights, T *dw_and_current_weight_out) = 0;
   virtual AbstractRPUDeviceMetaParameter<T> &getPar() const = 0;
+
+  virtual void doDirectUpdate(
+      const T *x_input,
+      const T *d_input,
+      T *dev_weights,
+      const T lr,
+      const int m_batch,
+      const bool x_trans,
+      const bool d_trans,
+      const T beta,
+      T *x_buffer,
+      T *d_buffer) = 0;
+  virtual bool hasDirectUpdate() const = 0;
+
   virtual int getHiddenUpdateIdx() const { return 0; };
   virtual void setHiddenUpdateIdx(int idx){};
 
@@ -91,6 +105,19 @@ public:
   };
   DeviceUpdateType implements() const override { return this->getPar().implements(); };
   SimpleRPUDeviceCuda<T> *clone() const override { return new SimpleRPUDeviceCuda<T>(*this); }
+
+  bool hasDirectUpdate() const override { return true; };
+  void doDirectUpdate(
+      const T *x_input,
+      const T *d_input,
+      T *dev_weights,
+      const T lr,
+      const int m_batch,
+      const bool x_trans,
+      const bool d_trans,
+      const T beta,
+      T *x_buffer = nullptr,
+      T *d_buffer = nullptr) override;
 
 protected:
   int x_size_ = 0;

--- a/src/rpucuda/cuda/rpucuda_simple_device_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_simple_device_test.cpp
@@ -115,7 +115,7 @@ public:
     simple_cuda->setWeights(refweights[0]);
     simple_cuda->setLearningRate(lr);
 
-    auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_real_distribution<num_t> udist(-1.2, 1.2);
     auto urnd = std::bind(udist, generator);

--- a/src/rpucuda/cuda/rpucuda_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_test.cpp
@@ -63,7 +63,7 @@ public:
     culayer_simple = RPU::make_unique<RPUCudaSimple<T>>(context, *layer_simple);
 
     // generate random numbers
-    auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_real_distribution<T> udist(-1, 1);
     auto urnd = std::bind(udist, generator);
@@ -129,7 +129,7 @@ public:
     culayer_simple = RPU::make_unique<RPUCudaSimple<num_t>>(context, *layer_simple);
 
     // generate random numbers
-    auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_real_distribution<num_t> udist(-1., 1.);
     auto urnd = std::bind(udist, generator);

--- a/src/rpucuda/cuda/rpucuda_transfer_device.cu
+++ b/src/rpucuda/cuda/rpucuda_transfer_device.cu
@@ -25,8 +25,10 @@ namespace RPU {
 */
 
 template <typename T> void TransferRPUDeviceCuda<T>::initialize() {
-  transfer_pwu_ = RPU::make_unique<PulsedWeightUpdater<T>>(this->context_, this->x_size_, this->d_size_);
-  transfer_iom_ = RPU::make_unique<InputOutputManager<T>>(this->context_, this->x_size_, this->d_size_);
+  transfer_pwu_ =
+      RPU::make_unique<PulsedWeightUpdater<T>>(this->context_, this->x_size_, this->d_size_);
+  transfer_iom_ =
+      RPU::make_unique<InputOutputManager<T>>(this->context_, this->x_size_, this->d_size_);
 }
 
 template <typename T>
@@ -120,7 +122,7 @@ void TransferRPUDeviceCuda<T>::populateFrom(const AbstractRPUDevice<T> &rpu_devi
   initialize(); // pwu/iom
 
   current_col_indices_.resize(this->n_devices_ - 1);
-  std::fill(current_col_indices_.begin(), current_col_indices_.end(), 0);
+  std::fill(current_col_indices_.begin(), current_col_indices_.end(), (int) 0);
 
   this->current_update_idx_ = 0;
 

--- a/src/rpucuda/cuda/rpucuda_vector_device.cu
+++ b/src/rpucuda/cuda/rpucuda_vector_device.cu
@@ -141,7 +141,7 @@ void VectorRPUDeviceCuda<T>::populateFrom(const AbstractRPUDevice<T> &rpu_device
 
   // populate vector device
   current_update_idx_ = 0;
-  current_device_idx_ = getPar().first_update_idx;
+  current_device_idx_ = rpu_device.getCurrentDeviceIdx();
   n_devices_ = 0;
 
   dw_min_ = rpu_device.getDwMin();

--- a/src/rpucuda/cuda/rpucuda_vector_device_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_vector_device_test.cpp
@@ -142,7 +142,7 @@ public:
     culayer_pulsed = RPU::make_unique<RPUCudaPulsed<num_t>>(context, *layer_pulsed);
     culayer_pulsed->disp();
 
-    auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_real_distribution<num_t> udist(-1.2, 1.2);
     auto urnd = std::bind(udist, generator);
@@ -259,7 +259,6 @@ public:
     delete[] x_counts32;
     delete[] d_counts32;
   };
-
   void TearDown() { Array_2D_Free(refweights); }
 
   std::unique_ptr<CudaContext> context_container;

--- a/src/rpucuda/cuda/update_management_helper.cu
+++ b/src/rpucuda/cuda/update_management_helper.cu
@@ -276,7 +276,8 @@ int debugKernelTranslateTransFormatToBatchOrder64Format(
   T lr = 0.01;
   BitLineMaker<T> blm(&c, size, size);
   blm.makeCounts(
-      dev_indata.getData(), dev_indata.getData(), up, dwmin, lr, m_batch, false, false, true, 2);
+      dev_indata.getData(), dev_indata.getData(), up, dwmin, lr, m_batch, false, false, true, 2,
+      false); // compute B64 to init buffer for below
 
   UpdateManagementHelper<T> *umh = blm.getUmh();
   c.synchronize();
@@ -637,7 +638,16 @@ RPU_UMH_ITER_TEMPLATE(float, IndexReaderInputIterator<float>, const float *);
 RPU_UMH_ITER_TEMPLATE(float, IndexReaderTransInputIterator<float>, const float *);
 RPU_UMH_ITER_TEMPLATE(
     float, IndexReaderTransInputIterator<float>, PermuterTransInputIterator<float>);
+RPU_UMH_ITER_TEMPLATE(
+    float, IndexReaderSliceInputIterator<TRANSFLOAT(true)>, SliceInputIterator<TRANSFLOAT(true)>);
+RPU_UMH_ITER_TEMPLATE(
+    float, IndexReaderSliceInputIterator<TRANSFLOAT(false)>, SliceInputIterator<TRANSFLOAT(false)>);
+
 RPU_UMH_ITER_TEMPLATE(float, const float *, PermuterTransInputIterator<float>);
+RPU_UMH_ITER_TEMPLATE(float, const float *, SliceInputIterator<TRANSFLOAT(true)>);
+RPU_UMH_ITER_TEMPLATE(float, const float *, SliceInputIterator<TRANSFLOAT(false)>);
+RPU_UMH_ITER_TEMPLATE(float, IndexReaderSliceInputIterator<TRANSFLOAT(true)>, const float *);
+RPU_UMH_ITER_TEMPLATE(float, IndexReaderSliceInputIterator<TRANSFLOAT(false)>, const float *);
 
 #undef TRANSFLOAT
 

--- a/src/rpucuda/cuda/update_management_helper_test.cpp
+++ b/src/rpucuda/cuda/update_management_helper_test.cpp
@@ -39,7 +39,7 @@ public:
     x1 = new T[size * m_batch];
     d1 = new T[size * m_batch];
 
-    auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::uniform_real_distribution<T> udist(-1., 1.);
     auto urnd = std::bind(udist, generator);

--- a/src/rpucuda/cuda/weight_clipper_cuda.cu
+++ b/src/rpucuda/cuda/weight_clipper_cuda.cu
@@ -1,3 +1,15 @@
+/**
+ * (C) Copyright 2020 IBM. All Rights Reserved.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 #include "cuda_math_util.h"
 #include "io_iterator.h"
 #include "weight_clipper_cuda.h"

--- a/src/rpucuda/cuda/weight_clipper_cuda.h
+++ b/src/rpucuda/cuda/weight_clipper_cuda.h
@@ -1,3 +1,15 @@
+/**
+ * (C) Copyright 2020 IBM. All Rights Reserved.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 #pragma once
 
 #include "cuda_util.h"

--- a/src/rpucuda/cuda/weight_clipper_cuda_test.cpp
+++ b/src/rpucuda/cuda/weight_clipper_cuda_test.cpp
@@ -1,3 +1,15 @@
+/**
+ * (C) Copyright 2020 IBM. All Rights Reserved.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 #include "cuda.h"
 #include "cuda_util.h"
 #include "utility_functions.h"
@@ -34,7 +46,7 @@ public:
     w = new num_t[size];
     v = new num_t[size]();
 
-    auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
     std::default_random_engine generator{seed};
     std::normal_distribution<num_t> ndist{0.0, 1.0};
     auto nrnd = std::bind(ndist, generator);

--- a/src/rpucuda/dense_bit_line_maker.h
+++ b/src/rpucuda/dense_bit_line_maker.h
@@ -67,8 +67,28 @@ private:
       const int d_size,
       const int BL);
 
+  inline void generateCoincidencesDetI(
+      int *coincidences,
+      const T *x_values,
+      const int x_size,
+      const T *d_values,
+      const int d_size,
+      const int BL);
+
   inline void generateCountsMean(
       int *counts,
+      const T *v,
+      const int v_inc,
+      const int v_size,
+      const T p,
+      RNG<T> *rng,
+      const int BL,
+      const T res,
+      const bool sto_round,
+      const T lr);
+
+  inline void generateDetImplicit(
+      T *pcounts,
       const T *v,
       const int v_inc,
       const int v_size,

--- a/src/rpucuda/math_util.h
+++ b/src/rpucuda/math_util.h
@@ -25,8 +25,12 @@ extern "C" {
 #endif
 #endif
 
+#ifndef MIN
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef MAX
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
 
 namespace RPU {
 namespace math {

--- a/src/rpucuda/rng.h
+++ b/src/rpucuda/rng.h
@@ -33,8 +33,8 @@ typedef int randomint_t;
 #endif
 
 // NEED TO BE 0x7FFF for FASTRAND!!!
-#define FIXED_LIST_SIZE 0x7FFF
-
+#define FIXED_LIST_SIZE 32768
+#define FIXED_LIST_SIZE_MSK 0x7FFF
 namespace RPU {
 
 static randomint_t g_seed;
@@ -116,7 +116,7 @@ public:
 #endif
 #else
 #ifdef RPU_USE_FASTMOD
-    return gauss_numbers_list_[RANDFUN() & FIXED_LIST_SIZE];
+    return gauss_numbers_list_[RANDFUN() & FIXED_LIST_SIZE_MSK];
 #else
     return gauss_numbers_list_[RANDFUN() % gauss_list_size_];
 #endif

--- a/src/rpucuda/rpu_difference_device.cpp
+++ b/src/rpucuda/rpu_difference_device.cpp
@@ -95,7 +95,7 @@ void DifferenceRPUDevice<T>::populate(
 /*********************************************************************************/
 /* update */
 
-template <typename T> inline bool DifferenceRPUDevice<T>::isInverted() const {
+template <typename T> bool DifferenceRPUDevice<T>::isInverted() const {
   return g_plus_ == 0;
 }
 
@@ -169,6 +169,8 @@ void DifferenceRPUDevice<T>::resetCols(
 template <typename T> bool DifferenceRPUDevice<T>::onSetWeights(T **weights) {
   // note: we use this to update the internal weights for each device.
   // all weights are set to *identical* values...
+
+  VectorRPUDevice<T>::resetCounters(true);
 
   T *w = weights[0];
 

--- a/src/rpucuda/rpu_difference_device.h
+++ b/src/rpucuda/rpu_difference_device.h
@@ -43,12 +43,12 @@ template <typename T> struct DifferenceRPUDeviceMetaParameter : VectorRPUDeviceM
   };
 
   void initialize() override {
-    VectorRPUDeviceMetaParameter<T>::initialize();
-
-    // different parameteter settings are not allowed because we
+    // different parameter settings are not allowed because we
     // like to be able to invert. For this we mirror copy the exact
     // DP . This does not work when the specifications of the RPU
     // arrays are different.
+
+    VectorRPUDeviceMetaParameter<T>::initialize();
 
     if (!this->vec_par.size()) {
       RPU_FATAL("Expect non-empty vec par");
@@ -132,7 +132,7 @@ protected:
   void populate(const DifferenceRPUDeviceMetaParameter<T> &par, RealWorldRNG<T> *rng);
 
 private:
-  inline bool isInverted() const;
+  bool isInverted() const;
 
   int g_plus_ = 1;
   int g_minus_ = 0;

--- a/src/rpucuda/rpu_forward_backward_pass.h
+++ b/src/rpucuda/rpu_forward_backward_pass.h
@@ -69,6 +69,9 @@ public:
     swap(a.b_io_, b.b_io_);
     swap(a.tmp_x_values_, b.tmp_x_values_);
     swap(a.tmp_d_values_, b.tmp_d_values_);
+    swap(a.aux_nm_value_, b.aux_nm_value_);
+    swap(a.rng_, b.rng_);
+    swap(a.checked_implemented_, b.checked_implemented_);
   }
 
   void forwardVector(
@@ -95,10 +98,11 @@ private:
   T *tmp_x_values_ = nullptr;
   T *tmp_d_values_ = nullptr;
 
-  bool checked_implemented_ = false;
+  T aux_nm_value_ = -1.0;
   IOMetaParameter<T> f_io_;
   IOMetaParameter<T> b_io_;
   bool containers_allocated_ = false;
+  bool checked_implemented_ = false;
   std::shared_ptr<RNG<T>> rng_ = nullptr;
 };
 

--- a/src/rpucuda/rpu_linearstep_device.cpp
+++ b/src/rpucuda/rpu_linearstep_device.cpp
@@ -12,10 +12,9 @@
 
 #include "rpu_linearstep_device.h"
 #include "utility_functions.h"
-#include <iostream>
-//#include <random>
 #include <chrono>
 #include <cmath>
+#include <iostream>
 #include <limits>
 
 namespace RPU {

--- a/src/rpucuda/rpu_pulsed.h
+++ b/src/rpucuda/rpu_pulsed.h
@@ -55,7 +55,10 @@ public:
   void decayWeights(bool bias_no_decay) override;
   void decayWeights(T alpha, bool bias_no_decay) override;
   void diffuseWeights() override;
+  void clipWeights(T clip) override;
+  void clipWeights(const WeightClipParameter &wclpar) override;
   void resetCols(int start_col, int n_cols, T reset_prob) override;
+
   void updateVectorWithCounts(
       const T *x_input,
       const T *d_input,
@@ -121,11 +124,13 @@ template <typename T> struct PulsedMetaParameter {
     swap(a.f_io, b.f_io);
     swap(a.b_io, b.b_io);
     swap(a.up, b.up);
+
     swap(a._par_initialized, b._par_initialized);
   }
 
   IOMetaParameter<T> f_io;
   IOMetaParameter<T> b_io;
+
   PulsedUpdateMetaParameter<T> up;
 
   RPUPulsed<T> *createRPUArray(int x_size, int d_size, AbstractRPUDeviceMetaParameter<T> *dp);
@@ -134,7 +139,7 @@ template <typename T> struct PulsedMetaParameter {
   void initialize();
 
   void print() const;
-  void printToStream(std::stringstream &ss) const;
+  void printToStream(std::stringstream &ss, bool suppress_update = false) const;
 };
 
 } // namespace RPU

--- a/src/rpucuda/rpu_pulsed_device.h
+++ b/src/rpucuda/rpu_pulsed_device.h
@@ -35,14 +35,26 @@ template <typename T> struct PulsedRPUDeviceMetaParameterBase : SimpleRPUDeviceM
   PulsedRPUDeviceMetaParameterBase() {}
 
   std::string getName() const override { return "PulsedRPUDeviceParameterBase"; };
-  PulsedRPUDeviceBase<T> *createDevice(int x_size, int d_size, RealWorldRNG<T> *rng) override {RPU_FATAL("Needs implementation");};
-  PulsedRPUDeviceMetaParameterBase<T> *clone() const override {RPU_FATAL("Needs implementation");};
+  PulsedRPUDeviceBase<T> *createDevice(int x_size, int d_size, RealWorldRNG<T> *rng) override {
+    RPU_FATAL("Needs implementation");
+  };
+  PulsedRPUDeviceMetaParameterBase<T> *clone() const override {
+    RPU_FATAL("Needs implementation");
+  };
   DeviceUpdateType implements() const override { return DeviceUpdateType::Undefined; };
+
+  friend void
+  swap(PulsedRPUDeviceMetaParameterBase<T> &a, PulsedRPUDeviceMetaParameterBase<T> &b) noexcept {
+    using std::swap;
+    swap(
+        static_cast<SimpleRPUDeviceMetaParameter<T> &>(a),
+        static_cast<SimpleRPUDeviceMetaParameter<T> &>(b));
+  }
 };
 
 template <typename T> struct PulsedRPUDeviceMetaParameter : PulsedRPUDeviceMetaParameterBase<T> {
 
-  bool legacy_params = false; // to not load the reset params
+  bool legacy_params = false; // to not load the reset/drfit params
 
   T dw_min = (T)0.001;
   T dw_min_dtod = (T)0.3;
@@ -76,8 +88,10 @@ template <typename T> struct PulsedRPUDeviceMetaParameter : PulsedRPUDeviceMetaP
   void printToStream(std::stringstream &ss) const override;
   using SimpleMetaParameter<T>::print;
   std::string getName() const override { return "PulsedRPUDeviceParameter"; };
-  PulsedRPUDevice<T> *createDevice(int x_size, int d_size, RealWorldRNG<T> *rng) override {RPU_FATAL("Needs implementation");};
-  PulsedRPUDeviceMetaParameter<T> *clone() const override {RPU_FATAL("Needs implementation");};
+  PulsedRPUDevice<T> *createDevice(int x_size, int d_size, RealWorldRNG<T> *rng) override {
+    RPU_FATAL("Needs implementation");
+  };
+  PulsedRPUDeviceMetaParameter<T> *clone() const override { RPU_FATAL("Needs implementation"); };
   DeviceUpdateType implements() const override { return DeviceUpdateType::Undefined; };
 };
 
@@ -104,11 +118,13 @@ public:
   }
 
   bool isPulsedDevice() const override { return true; };
-  PulsedRPUDeviceBase<T> *clone() const override {RPU_FATAL("Needs implementation");};
+  PulsedRPUDeviceBase<T> *clone() const override { RPU_FATAL("Needs implementation"); };
 
   virtual T getDwMin() const = 0;
-  void resetCols(
-      T **weights, int start_col, int n_cols, T reset_prob, RealWorldRNG<T> &rng) override {RPU_FATAL("Needs implementation");};
+  void
+  resetCols(T **weights, int start_col, int n_cols, T reset_prob, RealWorldRNG<T> &rng) override {
+    RPU_FATAL("Needs implementation");
+  };
   virtual void doSparseUpdate(
       T **weights, int i, const int *x_signed_indices, int x_count, int d_sign, RNG<T> *rng) {
     RPU_FATAL("Sparse update not available for this device!");
@@ -218,6 +234,7 @@ public:
   bool onSetWeights(T **weights) override;
   void
   resetCols(T **weights, int start_col, int n_cols, T reset_prob, RealWorldRNG<T> &rng) override;
+
   void copyInvertDeviceParameter(const PulsedRPUDeviceBase<T> *rpu_device) override;
 
 protected:

--- a/src/rpucuda/rpu_pulsed_meta_parameter.cpp
+++ b/src/rpucuda/rpu_pulsed_meta_parameter.cpp
@@ -72,6 +72,13 @@ template <typename T> void IOMetaParameter<T>::initializeForForward() {
     if (isinf(this->out_bound)) {
       RPU_FATAL("Forward out bound needs to be finite");
     }
+
+    if (this->bound_management == BoundManagementType::Shift) {
+      this->nm_thres = (T)0.0;
+      if (this->out_scale != 1.0) {
+        RPU_FATAL("Forward out scale should 1.0 for shift mangement");
+      }
+    }
   }
 }
 
@@ -123,6 +130,8 @@ template <typename T> void PulsedUpdateMetaParameter<T>::initialize() {
     update_management = update_management || update_bl_management;
 
     detail::checkRes(res);
+    detail::checkRes(x_res_implicit);
+    detail::checkRes(d_res_implicit);
   }
 
   if (_currently_tuning) {

--- a/src/rpucuda/rpu_transfer_device.h
+++ b/src/rpucuda/rpu_transfer_device.h
@@ -148,8 +148,11 @@ public:
   void diffuseWeights(T **weights, RNG<T> &rng) override;
   void clipWeights(T **weights, T clip) override;
 
+  void
+  resetCols(T **weights, int start_col, int n_cols, T reset_prob, RealWorldRNG<T> &rng) override;
+
   void setDeviceParameter(const std::vector<T *> &data_ptrs) override;
-  void setHiddenUpdateIdx(int idx) override{}; // ignored
+  void setHiddenUpdateIdx(int idx) override{};
 
   void finishUpdateCycle(
       T **weights, const PulsedUpdateMetaParameter<T> &up, T current_lr, int m_batch_info) override;
@@ -177,6 +180,7 @@ protected:
   void populate(const TransferRPUDeviceMetaParameter<T> &par, RealWorldRNG<T> *rng);
   void reduceToWeights(T **weights) const override;
   T **getDeviceWeights(int device_idx) const;
+  int resetCounters(bool force = false) override;
 
   std::unique_ptr<ForwardBackwardPassIOManaged<T>> transfer_fb_pass_ = nullptr;
   std::unique_ptr<PulsedRPUWeightUpdater<T>> transfer_pwu_ = nullptr;
@@ -188,8 +192,6 @@ protected:
   T **last_weight_ = nullptr;
   std::vector<T> transfer_tmp_;
   bool fully_hidden_ = false;
-
-private:
 };
 
 } // namespace RPU

--- a/src/rpucuda/rpu_transfer_device_test.cpp
+++ b/src/rpucuda/rpu_transfer_device_test.cpp
@@ -233,7 +233,6 @@ TEST_P(RPUDeviceTestFixture, doSparseUpdateWithTransfer) {
   num_t sc = reduce_weightening[0] + reduce_weightening[1];
   for (int j = 0; j < this->d_size; j++) {
     for (int i = 0; i < this->x_size; i++) {
-      // std::cout << "w(" << j << "," << i << ")=" << this->weights[j][i] << std::endl;
       if (j == rowidx && i == this->colidx) {
         ASSERT_FLOAT_EQ(this->weights[j][i], sc * dx);
       } else {

--- a/src/rpucuda/rpu_vector_device.h
+++ b/src/rpucuda/rpu_vector_device.h
@@ -43,11 +43,10 @@ template <typename T> struct VectorRPUDeviceMetaParameter : PulsedRPUDeviceMetaP
   friend void
   swap(VectorRPUDeviceMetaParameter<T> &a, VectorRPUDeviceMetaParameter<T> &b) noexcept {
     using std::swap;
-    swap(static_cast<SimpleMetaParameter<T> &>(a), static_cast<SimpleMetaParameter<T> &>(b));
-    swap(a._device_parameter_mode_manual, b._device_parameter_mode_manual);
-    swap(a._par_initialized, b._par_initialized);
+    swap(
+        static_cast<PulsedRPUDeviceMetaParameterBase<T> &>(a),
+        static_cast<PulsedRPUDeviceMetaParameterBase<T> &>(b));
 
-    swap(a.construction_seed, b.construction_seed);
     swap(a.vec_par, b.vec_par);
     swap(a.same_context, b.same_context);
     swap(a.update_policy, b.update_policy);
@@ -66,7 +65,7 @@ template <typename T> struct VectorRPUDeviceMetaParameter : PulsedRPUDeviceMetaP
     return ss.str();
   };
 
-  // appends a parameter vector to vec_par. Returns True if successful
+  /* appends a parameter vector to vec_par. Returns True if successful */
   bool appendVecPar(AbstractRPUDeviceMetaParameter<T> *par);
 
   VectorRPUDevice<T> *createDevice(int x_size, int d_size, RealWorldRNG<T> *rng) override {
@@ -157,6 +156,7 @@ public:
   };
   inline T ***getWeightVec() const { return weights_vec_; };
   inline const T *getReduceWeightening() const { return reduce_weightening_.data(); };
+  inline int getCurrentDeviceIdx() const { return current_device_idx_; };
 
   VectorRPUDevice<T> *clone() const override { return new VectorRPUDevice<T>(*this); };
 
@@ -166,6 +166,7 @@ public:
   void clipWeights(T **weights, T clip) override;
   void
   resetCols(T **weights, int start_col, int n_cols, T reset_prob, RealWorldRNG<T> &rng) override;
+
   bool onSetWeights(T **weights) override;
   void initUpdateCycle(
       T **weights, const PulsedUpdateMetaParameter<T> &up, T current_lr, int m_batch_info) override;
@@ -189,6 +190,8 @@ protected:
   int current_device_idx_ = 0;
   unsigned long current_update_idx_ = 0;
   RealWorldRNG<T> rw_rng_{0};
+
+  virtual int resetCounters(bool force = false);
 
 private:
   void freeContainers();

--- a/src/rpucuda/rpu_weight_updater.cpp
+++ b/src/rpucuda/rpu_weight_updater.cpp
@@ -153,7 +153,11 @@ void PulsedRPUWeightUpdater<T>::updateVectorWithDevice(
   }
 
   // handle cases with no device or FP device
-  if (checkForFPUpdate(rpu_device_in) || up_.pulse_type == PulseType::NoneWithDevice) {
+  if (rpu_device_in != nullptr && rpu_device_in->hasDirectUpdate()) {
+    rpu_device_in->doDirectVectorUpdate(
+        weights, x_input, x_inc, d_input, d_inc, learning_rate, m_batch_info);
+    return;
+  } else if (up_.pulse_type == PulseType::NoneWithDevice || checkForFPUpdate(rpu_device_in)) {
 
     RPUWeightUpdater<T>::updateVector(weights, x_input, x_inc, d_input, d_inc, learning_rate);
 

--- a/src/rpucuda/weight_clipper.cpp
+++ b/src/rpucuda/weight_clipper.cpp
@@ -1,3 +1,15 @@
+/**
+ * (C) Copyright 2020 IBM. All Rights Reserved.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 #include "weight_clipper.h"
 #include "math_util.h"
 #include "utility_functions.h"
@@ -34,7 +46,7 @@ template <typename T> void WeightClipper<T>::apply(T *weights, const WeightClipP
     if (amax_values_.size() < (size_t)d_size_) {
       amax_values_.resize(d_size_);
     }
-    std::fill(amax_values_.begin(), amax_values_.end(), 0.0);
+    std::fill(amax_values_.begin(), amax_values_.end(), (T)0.0);
 
     // compute max per row
     PRAGMA_SIMD

--- a/src/rpucuda/weight_clipper.h
+++ b/src/rpucuda/weight_clipper.h
@@ -1,3 +1,15 @@
+/**
+ * (C) Copyright 2020 IBM. All Rights Reserved.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 #pragma once
 
 #include "rng.h"

--- a/tests/test_inference_tiles.py
+++ b/tests/test_inference_tiles.py
@@ -19,7 +19,10 @@ from torch.nn.functional import mse_loss
 from aihwkit.nn import AnalogLinear
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs.utils import (
-    WeightNoiseType, WeightClipType, WeightModifierType
+    WeightNoiseType,
+    WeightClipType,
+    WeightModifierType,
+    WeightModifierParameter
 )
 from aihwkit.simulator.noise_models import PCMLikeNoiseModel
 
@@ -94,7 +97,6 @@ class InferenceTileTest(ParametrizedTestCase):
         rpu_config = self.get_rpu_config()
         rpu_config.clip.type = WeightClipType.FIXED_VALUE
         rpu_config.clip.fixed_value = 0.3
-
         analog_tile = self.get_tile(2, 3, rpu_config=rpu_config, bias=True)
 
         weights = Tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
@@ -110,17 +112,18 @@ class InferenceTileTest(ParametrizedTestCase):
         self.assertNotAlmostEqualTensor(tile_weights, weights)
         self.assertNotAlmostEqualTensor(tile_biases, biases)
 
-    def test_post_forward_modifier(self):
+    def do_post_forward_modifier_test(self, modifier):
         """Tests whether post update diffusion is performed"""
         rpu_config = self.get_rpu_config()
-        rpu_config.forward.is_perfect = True
+        rpu_config.drift_compensation = None
+        rpu_config.forward.w_noise = 0.0
+        rpu_config.forward.out_noise = 0.0
+        rpu_config.forward.inp_noise = 0.0
 
-        rpu_config.modifier.type = WeightModifierType.ADD_NORMAL
-        rpu_config.modifier.std_dev = 1.0
-        rpu_config.modifier.enable_during_test = False
+        if modifier is not None:
+            rpu_config.modifier = modifier
 
         analog_tile = self.get_tile(2, 3, rpu_config=rpu_config, bias=True)
-
         x_input = Tensor([[0.1, 0.2, 0.3]])
         weights = Tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
         biases = Tensor([-0.1, -0.2])
@@ -132,7 +135,6 @@ class InferenceTileTest(ParametrizedTestCase):
         analog_tile.set_weights(weights, biases)
 
         x_output = analog_tile.forward(x_input, is_test=True)
-        analog_tile.post_update_step()
         x_output_post = analog_tile.forward(x_input, is_test=False)
         x_output_post_true = analog_tile.forward(x_input, is_test=True)
         tile_weights, tile_biases = analog_tile.get_weights()
@@ -140,5 +142,47 @@ class InferenceTileTest(ParametrizedTestCase):
         self.assertTensorAlmostEqual(tile_weights, weights)
         self.assertTensorAlmostEqual(tile_biases, biases)
 
-        self.assertNotAlmostEqualTensor(x_output, x_output_post)
+        if modifier is None:
+            self.assertTensorAlmostEqual(x_output, x_output_post)
+        else:
+            self.assertNotAlmostEqualTensor(x_output, x_output_post)
+
         self.assertTensorAlmostEqual(x_output, x_output_post_true)
+
+    def get_modifier(self, mod_type):
+        """Returns the modifier parameter """
+        modifier = WeightModifierParameter()
+        modifier.std_dev = 1.0
+        modifier.enable_during_test = False
+        modifier.res = 0.132
+        modifier.type = mod_type
+        modifier.coeff0 = 1.0
+        modifier.coeff1 = 0.1
+        modifier.coeff2 = 0.2
+        modifier.rel_to_actual_wmax = False
+        modifier.assumed_wmax = 1.0
+        return modifier
+
+    def test_post_forward_modifier_types(self):
+        """Tests whether post update diffusion is performed"""
+
+        self.do_post_forward_modifier_test(None)
+
+        modifier = self.get_modifier(WeightModifierType.POLY)
+        self.do_post_forward_modifier_test(modifier)
+
+        modifier = self.get_modifier(WeightModifierType.DOREFA)
+        self.do_post_forward_modifier_test(modifier)
+
+        modifier = self.get_modifier(WeightModifierType.MULT_NORMAL)
+        self.do_post_forward_modifier_test(modifier)
+
+        modifier = self.get_modifier(WeightModifierType.DISCRETIZE)
+        self.do_post_forward_modifier_test(modifier)
+
+        modifier = self.get_modifier(WeightModifierType.DISCRETIZE_ADD_NORMAL)
+        self.do_post_forward_modifier_test(modifier)
+
+        modifier = self.get_modifier(WeightModifierType.COPY)
+        modifier.pdrop = 0.9999
+        self.do_post_forward_modifier_test(modifier)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -234,9 +234,8 @@ class SerializationTest(ParametrizedTestCase):
         new_model.load_state_dict(model.state_dict())
 
         # Compare the new model weights and biases.
-        (new_model_weights, new_model_biases,
-         new_tile_weights, new_tile_biases) = self.get_layer_and_tile_weights(
-            new_children_layer)
+        (new_model_weights, new_model_biases, new_tile_weights, new_tile_biases) = \
+            self.get_layer_and_tile_weights(new_children_layer)
 
         assert_array_almost_equal(model_weights, new_model_weights)
         assert_array_almost_equal(tile_weights, new_tile_weights)
@@ -258,8 +257,8 @@ class SerializationTest(ParametrizedTestCase):
         model = CustomModule(children_layer)
 
         # Keep track of the current weights and biases for comparing.
-        (model_weights, model_biases,
-         tile_weights, tile_biases) = self.get_layer_and_tile_weights(children_layer)
+        (model_weights, model_biases, tile_weights, tile_biases) = \
+            self.get_layer_and_tile_weights(children_layer)
 
         self.assertIn('custom_child.analog_tile_state', model.state_dict())
 
@@ -269,9 +268,8 @@ class SerializationTest(ParametrizedTestCase):
         new_model.load_state_dict(model.state_dict())
 
         # Compare the new model weights and biases.
-        (new_model_weights, new_model_biases,
-         new_tile_weights, new_tile_biases) = self.get_layer_and_tile_weights(
-            new_children_layer)
+        (new_model_weights, new_model_biases, new_tile_weights, new_tile_biases) = \
+            self.get_layer_and_tile_weights(new_children_layer)
 
         assert_array_almost_equal(model_weights, new_model_weights)
         assert_array_almost_equal(tile_weights, new_tile_weights)


### PR DESCRIPTION
## Description
In this PR the RPUCuda C++ backend has been updated with a number of features and enhancements, which means also that new options in the ``rpu_config`` of many devices are available:
* **deterministic implicit bit lines** for pulsed analog update
* RAPA convolution ready (training multiple tiles for one conv layer)  
* polynomial weight noise per minibatch for hardware-aware training for  inference chips 
* worst case bound management 
* average absolute max noise management
* cycle-to-cycle PCM read noise during each analog multiply-and-accumulate
* shift management (for better SNR before softmax)
* ``directUpdate`` capability for future more complicated meta devices 
* Option to omit the bias row for hardware-aware training weight noise (``copy_last_column``)
