### PR TITLE
Changelog and doc tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,28 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [UNRELEASED]
 
-## [0.2.1] - 2020/11/26
-
 ### Added
 
 * Option to choose deterministic pulse trains for the rank-1 update of
-  analog devices during training (\#99)
+  analog devices during training. (\#99)
 * More noise types for hardware-aware training for inference
-  (polynomial) (\#99)
-* Additional bound management schemes (worst case, average max, shift) (\#99)
-* Cycle-to-cycle output referred analog multipl-and-accumulate weight
+  (polynomial). (\#99)
+* Additional bound management schemes (worst case, average max, shift). (\#99)
+* Cycle-to-cycle output referred analog multiply-and-accumulate weight
   noise that resembles the conductance dependent PCM read noise
-  stastistics (\#99)
+  statistics. (\#99)
 * C++ backend improvements (slice backward/forward/update, direct
-  update) (\#99)
-* Option to excluded bias row for hardware-aware training noise (\#99)
+  update). (\#99)
+* Option to excluded bias row for hardware-aware training noise. (\#99)
+
+#### Fixed
+
+* Fixed small issues that resulted in warnings for windows compilation. (\#99)
+* Faulty backward noise management error message removed for perfect backward
+  and CUDA. (\#99)
+
+## [0.2.1] - 2020/11/26
+
 * The `rpu_config` is now pretty-printed in a readable manner (excluding the
   default settings and other readability tweak). (\#60)
 * Added a new `ReferenceUnitCell` which has two devices, where one is fixed and
@@ -59,9 +66,6 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
-* Fixed small issues that resulted in warnings for windows compilation
-* Faulty backward noise management error message removed for perfect backward
-  and CUDA (\#99)
 * Serialization of `Modules` that contain children analog layers is now
   possible, both when using containers such as `Sequential` and when using
   analog layers as custom Module attributes. (\#74, \#80)

--- a/examples/09_simple_layer_deterministic_pulses.py
+++ b/examples/09_simple_layer_deterministic_pulses.py
@@ -15,7 +15,6 @@ deterministic pulse trains for update.
 
 Simple network that consist of one analog layer. The network aims to learn
 to sum all the elements from one array.
-
 """
 
 # Imports from PyTorch.
@@ -37,10 +36,10 @@ y = Tensor([[1.0, 0.5], [0.7, 0.3]])
 # Define a single-layer network, using a constant step device type.
 rpu_config = SingleRPUConfig(device=ConstantStepDevice())
 rpu_config.update.pulse_type = PulseType.DETERMINISTIC_IMPLICIT
-rpu_config.update.desired_bl = 10 # max number in this case
-rpu_config.update.update_bl_management = True # will vary up to 10 on demand
-rpu_config.update.d_res_implicit = 0.1 # effective resolution of x bit lines
-rpu_config.update.x_res_implicit = 0.1 # effective resolution of d bit lines
+rpu_config.update.desired_bl = 10  # max number in this case
+rpu_config.update.update_bl_management = True  # will vary up to 10 on demand
+rpu_config.update.d_res_implicit = 0.1  # effective resolution of x bit lines
+rpu_config.update.x_res_implicit = 0.1  # effective resolution of d bit lines
 
 model = AnalogLinear(4, 2, bias=True,
                      rpu_config=rpu_config)

--- a/examples/README.md
+++ b/examples/README.md
@@ -265,21 +265,17 @@ rpu_config = UnitCellRPUConfig(
 Similarly to example 1 the network is trained over 100 epochs with an analog Stochastic Gradient
 Descent optimizer and the loss is printed for every epoch.
 
-## Example 8: [`09_simple_layer_deterministic_pulses.py`]
+## Example 9: [`09_simple_layer_deterministic_pulses.py`]
 
-This example shows how to select different pulsing schemes for the
-analog update. By default, we use stochastic pulses for activation
-and errors to update the devices with a step in up or down direction
-only if pulses conincide at a crosspoint. Note, that we indeed
-generate stochastic pulse trains for each input line and thus  do no
-short-cut in the simulation.
+This example shows how to select different pulsing schemes for the analog update. By default, we
+use stochastic pulses for activation and errors to update the devices with a step in up or down
+direction only if pulses coincide at a crosspoint. Note that we indeed generate stochastic pulse
+trains for each input line and thus do no short-cut in the simulation.
 
-Here, in this example, we change the updaate to be performed using
-deterministic pulse trains that yield always the same number of
-coincident pulses at a cross point, if the same inputs are
-given. Implicitely, one can design the stored pulse train structure to
-quantize the input values in a number of bins, which can be changed
-by the ``*_res_imilicit``  parameters. 
+Here, in this example, we change the update to be performed using deterministic pulse trains that
+yield always the same number of coincident pulses at a cross point, if the same inputs are
+given. Implicitly, one can design the stored pulse train structure to quantize the input values in
+a number of bins, which can be changed by the ``*_res_imilicit``  parameters. 
 
 ```
 rpu_config = SingleRPUConfig(device=ConstantStepDevice())
@@ -294,7 +290,6 @@ Similarly to example 1 the network is trained over 100 epochs with an analog Sto
 Descent optimizer and the loss is printed for every epoch.
 
 
-[Apache License 2.0]: LICENSE.txt
 [Resistive Processing Units]: https://aihwkit.readthedocs.io/en/latest/using_simulator.html#resistive-processing-units
 [Inference and PCM statistical model]: https://aihwkit.readthedocs.io/en/latest/pcm_inference.html
 [Unit Cell Device]: https://aihwkit.readthedocs.io/en/latest/using_simulator.html#unit-cell-device
@@ -318,3 +313,4 @@ Front. Neurosci.]: https://www.frontiersin.org/articles/10.3389/fnins.2020.00103
 [`06_lenet5_hardware_aware.py`]: 06_lenet5_hardware_aware.py
 [`07_simple_layer_with_other_devices.py`]: 07_simple_layer_with_other_devices.py
 [`08_simple_layer_with_tiki_taka.py`]: 08_simple_layer_with_tiki_taka.py
+[`09_simple_layer_deterministic_pulses.py`]: 09_simple_layer_deterministic_pulses.py

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -83,7 +83,7 @@ class NoiseManagementType(Enum):
     ABS_MAX_NP_SUM = 'AbsMaxNPSum'
     """Takes a worst case scenario of the weight matrix to calculate the
     input scale to ensure that output is not clipping. Assumed weight
-    value is constant and given by ``nm_assumed_wmax``. """
+    value is constant and given by ``nm_assumed_wmax``."""
 
     MAX = 'Max'
     r"""Use :math:`\alpha\equiv\max{\mathbf{x}}`."""
@@ -374,7 +374,6 @@ class UpdateParameters(_PrintableMixin):
     """Resolution ie. bin width in ``0..1``) of the update probability for
     the stochastic bit line generation.  Use -1 for turning discretization
     off. Can be given as number of steps as well.
-
     """
 
     x_res_implicit: float = 0
@@ -389,7 +388,6 @@ class UpdateParameters(_PrintableMixin):
     """
 
     sto_round: bool = False
-
     """Whether to enable stochastic rounding."""
 
     update_bl_management: bool = True


### PR DESCRIPTION
## Related issues

#99 

## Description

Small round of documentation-related tweaks as a follow-up to #99:

* Revise CHANGELOG, moving the new entries to the unreleased section
* Add link to the example in the example overview and tweak word-wrapping
* Misc tweaks to docstrings

## Details

<!-- A more elaborate description of the changes, if needed. -->
