### PR TITLE
Parametrize test_post_forward_modifier_types

### DIFF
--- a/tests/test_inference_tiles.py
+++ b/tests/test_inference_tiles.py
@@ -96,7 +96,7 @@ class InferenceTileTest(ParametrizedTestCase):
         self.assertNotAlmostEqualTensor(model.analog_tile.alpha, ones((1,)))
 
     def test_post_update_step_clip(self):
-        """Tests whether post update diffusion is performed"""
+        """Tests whether post update diffusion is performed."""
         rpu_config = self.get_rpu_config()
         rpu_config.clip.type = WeightClipType.FIXED_VALUE
         rpu_config.clip.fixed_value = 0.3
@@ -124,7 +124,7 @@ class InferenceTileTest(ParametrizedTestCase):
         ('copy', WeightModifierType.COPY,),
     ])
     def test_post_forward_modifier_types(self, _, modifier_type):
-        """Tests whether post update diffusion is performed"""
+        """Tests whether post update diffusion is performed."""
         rpu_config = self.get_rpu_config()
         rpu_config.drift_compensation = None
         rpu_config.forward.w_noise = 0.0
@@ -162,8 +162,10 @@ class InferenceTileTest(ParametrizedTestCase):
         self.assertTensorAlmostEqual(x_output, x_output_post_true)
 
     @staticmethod
-    def get_modifier(modifier_type: Optional[WeightModifierType]):
-        """Returns the modifier parameter """
+    def get_modifier(
+            modifier_type: Optional[WeightModifierType]
+    ) -> Optional[WeightModifierParameter]:
+        """Returns the modifier parameter."""
         if modifier_type is None:
             return None
 

--- a/tests/test_inference_tiles.py
+++ b/tests/test_inference_tiles.py
@@ -12,6 +12,9 @@
 
 """Tests for inference tiles."""
 
+from typing import Optional
+
+from parameterized import parameterized
 from torch import ones
 from torch import Tensor
 from torch.nn.functional import mse_loss
@@ -112,7 +115,15 @@ class InferenceTileTest(ParametrizedTestCase):
         self.assertNotAlmostEqualTensor(tile_weights, weights)
         self.assertNotAlmostEqualTensor(tile_biases, biases)
 
-    def do_post_forward_modifier_test(self, modifier):
+    @parameterized.expand([
+        ('none', None,),
+        ('dorefa', WeightModifierType.DOREFA,),
+        ('mult_normal', WeightModifierType.MULT_NORMAL,),
+        ('discretize', WeightModifierType.DISCRETIZE,),
+        ('add_normal', WeightModifierType.DISCRETIZE_ADD_NORMAL,),
+        ('copy', WeightModifierType.COPY,),
+    ])
+    def test_post_forward_modifier_types(self, _, modifier_type):
         """Tests whether post update diffusion is performed"""
         rpu_config = self.get_rpu_config()
         rpu_config.drift_compensation = None
@@ -120,6 +131,7 @@ class InferenceTileTest(ParametrizedTestCase):
         rpu_config.forward.out_noise = 0.0
         rpu_config.forward.inp_noise = 0.0
 
+        modifier = self.get_modifier(modifier_type)
         if modifier is not None:
             rpu_config.modifier = modifier
 
@@ -149,40 +161,25 @@ class InferenceTileTest(ParametrizedTestCase):
 
         self.assertTensorAlmostEqual(x_output, x_output_post_true)
 
-    def get_modifier(self, mod_type):
+    @staticmethod
+    def get_modifier(modifier_type: Optional[WeightModifierType]):
         """Returns the modifier parameter """
-        modifier = WeightModifierParameter()
-        modifier.std_dev = 1.0
-        modifier.enable_during_test = False
-        modifier.res = 0.132
-        modifier.type = mod_type
-        modifier.coeff0 = 1.0
-        modifier.coeff1 = 0.1
-        modifier.coeff2 = 0.2
-        modifier.rel_to_actual_wmax = False
-        modifier.assumed_wmax = 1.0
+        if modifier_type is None:
+            return None
+
+        modifier = WeightModifierParameter(
+            type=modifier_type,
+            std_dev=1.0,
+            enable_during_test=False,
+            res=0.132,
+            coeff0=1.0,
+            coeff1=0.1,
+            coeff2=0.2,
+            rel_to_actual_wmax=False,
+            assumed_wmax=1.0
+        )
+
+        if modifier_type == WeightModifierType.COPY:
+            modifier.pdrop = 0.9999
+
         return modifier
-
-    def test_post_forward_modifier_types(self):
-        """Tests whether post update diffusion is performed"""
-
-        self.do_post_forward_modifier_test(None)
-
-        modifier = self.get_modifier(WeightModifierType.POLY)
-        self.do_post_forward_modifier_test(modifier)
-
-        modifier = self.get_modifier(WeightModifierType.DOREFA)
-        self.do_post_forward_modifier_test(modifier)
-
-        modifier = self.get_modifier(WeightModifierType.MULT_NORMAL)
-        self.do_post_forward_modifier_test(modifier)
-
-        modifier = self.get_modifier(WeightModifierType.DISCRETIZE)
-        self.do_post_forward_modifier_test(modifier)
-
-        modifier = self.get_modifier(WeightModifierType.DISCRETIZE_ADD_NORMAL)
-        self.do_post_forward_modifier_test(modifier)
-
-        modifier = self.get_modifier(WeightModifierType.COPY)
-        modifier.pdrop = 0.9999
-        self.do_post_forward_modifier_test(modifier)


### PR DESCRIPTION


## Related issues

Closes #101 

## Description

Use `parametrized` for performing `test_post_forward_modifier_types`
over the different types of modifiers as a single test per modifier.

## Details

<!-- A more elaborate description of the changes, if needed. -->
