### PR TITLE
Update CUDA indexed tiles bindings

### DIFF
--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
@@ -671,7 +671,7 @@ void declare_rpu_tiles(py::module &m) {
            )pbdoc")
       .def(
           "forward_indexed",
-          [](Class &self, const torch::Tensor &x_input_, const torch::Tensor &d_tensor_,// int d_image_size,
+          [](Class &self, const torch::Tensor &x_input_, const torch::Tensor &d_tensor_,
              bool is_test = false) {
             auto x_input = x_input_.contiguous();
             auto d_tensor = d_tensor_.contiguous();

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
@@ -723,7 +723,7 @@ void declare_rpu_tiles(py::module &m) {
                 d_image_size, N, true);
             return x_tensor;
           },
-          py::arg("d_input"), py::arg("x_tensor"), //py::arg("d_image_size"),
+          py::arg("d_input"), py::arg("x_tensor"),
           R"pbdoc(
            Compute the dot product using an index matrix (backward pass).
 

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -466,6 +466,9 @@ class BaseTile(Generic[RPUConfigGeneric]):
             _, _, _, _, depth_out, height_out, width_out = self.image_sizes
             d_tensor = empty(n_batch, channel_out, depth_out, height_out, width_out)
 
+        if self.is_cuda:
+            d_tensor = d_tensor.to(self.device)
+
         return self.tile.forward_indexed(x_input, d_tensor, is_test)
 
     def backward_indexed(self, d_input: Tensor) -> Tensor:
@@ -493,6 +496,9 @@ class BaseTile(Generic[RPUConfigGeneric]):
             channel_in, depth_in, height_in, width_in, _, _, _ \
                 = self.image_sizes
             x_tensor = empty(n_batch, channel_in, depth_in, height_in, width_in)
+
+        if self.is_cuda:
+            x_tensor = x_tensor.to(self.device)
 
         return self.tile.backward_indexed(d_input, x_tensor)
 

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -458,14 +458,15 @@ class BaseTile(Generic[RPUConfigGeneric]):
             _, _, height_out = self.image_sizes
             d_tensor = empty(n_batch, channel_out, height_out)
 
-        if len(self.image_sizes) == 5:
+        elif len(self.image_sizes) == 5:
             _, _, _, height_out, width_out = self.image_sizes
             d_tensor = empty(n_batch, channel_out, height_out, width_out)
 
-        if len(self.image_sizes) == 7:
+        elif len(self.image_sizes) == 7:
             _, _, _, _, depth_out, height_out, width_out = self.image_sizes
             d_tensor = empty(n_batch, channel_out, depth_out, height_out, width_out)
 
+        # Move helper tensor to cuda if needed.
         if self.is_cuda:
             d_tensor = d_tensor.to(self.device)
 
@@ -480,7 +481,13 @@ class BaseTile(Generic[RPUConfigGeneric]):
 
         Returns:
             torch.Tensor: ``[N, in_size]`` tensor. If ``in_trans`` is set, transposed.
+
+        Raises:
+            TileError: if the indexed tile has not been initialized.
         """
+        if not self.image_sizes:
+            raise TileError('self.image_sizes is not initialized. Please use '
+                            'set_indexed()')
 
         n_batch = d_input.size(0)
 
@@ -488,15 +495,16 @@ class BaseTile(Generic[RPUConfigGeneric]):
             channel_in, height_in, _ = self.image_sizes
             x_tensor = empty(n_batch, channel_in, height_in)
 
-        if len(self.image_sizes) == 5:
+        elif len(self.image_sizes) == 5:
             channel_in, height_in, width_in, _, _ = self.image_sizes
             x_tensor = empty(n_batch, channel_in, height_in, width_in)
 
-        if len(self.image_sizes) == 7:
+        elif len(self.image_sizes) == 7:
             channel_in, depth_in, height_in, width_in, _, _, _ \
                 = self.image_sizes
             x_tensor = empty(n_batch, channel_in, depth_in, height_in, width_in)
 
+        # Move helper tensor to cuda if needed.
         if self.is_cuda:
             x_tensor = x_tensor.to(self.device)
 


### PR DESCRIPTION
## Related issues

Closes #114 

## Description

Apply the same changes from #102 to the CUDA-enabled version of the tiles bindings so both signatures (and the logic) are in sync, which allows them to be called correctly from the Python layers.

## Details

Small tweaks were needed in `tiles/base.py` for moving the tensor to CUDA where needed - the rest of the changes in the file are minor style updates.
