### PR TITLE
Bump mypy to 0.800

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mypy==0.790
+mypy==0.800
 pycodestyle==2.6.0
 pylint==2.6.0
 pytest==6.1.2

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -103,11 +103,9 @@ class AnalogModuleBase(Module):
         elif isinstance(rpu_config, InferenceRPUConfig):
             tile_class = self.TILE_CLASS_INFERENCE
         else:
-            tile_class = self.TILE_CLASS_ANALOG  # type: ignore
+            tile_class = self.TILE_CLASS_ANALOG
 
-        return tile_class(
-            out_features, in_features, rpu_config, bias=bias  # type: ignore
-        )
+        return tile_class(out_features, in_features, rpu_config, bias=bias)
 
     def set_weights(
             self,

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -91,8 +91,8 @@ class AnalogConv1d(Conv1d, AnalogModuleBase):
         if dilation != 1:
             raise ValueError('Only dilation = 1 is supported')
 
-        kernel_size = _single(kernel_size)
-        self.in_features = (in_channels // groups) * kernel_size[0]  # type: ignore
+        kernel_size_tuple = _single(kernel_size)
+        self.in_features = (in_channels // groups) * kernel_size_tuple[0]
         self.out_features = out_channels
 
         # Create the tile and set the analog.
@@ -137,8 +137,11 @@ class AnalogConv1d(Conv1d, AnalogModuleBase):
             shape = [1] + [1] + list(x_input.shape[2:])
             fold_indices = fold_indices.reshape(*shape)
             if not all(item == 0 for item in self.padding):
-                fold_indices = pad(fold_indices, pad=(
-                    self.padding[0], self.padding[0]), mode="constant", value=0)
+                fold_indices = pad(
+                    fold_indices,
+                    pad=(self.padding[0], self.padding[0]),
+                    mode='constant',
+                    value=0)
             unfold = fold_indices.unfold(2, self.kernel_size[0], self.stride[0]).clone()
 
             fold_indices = unfold.reshape(-1, self.kernel_size[0]).transpose(0, 1).flatten().round()
@@ -167,7 +170,7 @@ class AnalogConv1d(Conv1d, AnalogModuleBase):
 
             image_sizes = [self.in_channels, x_height, d_height]
             self.input_size = input_size
-            self.analog_tile.set_indexed(self.fold_indices, image_sizes)  # type: ignore
+            self.analog_tile.set_indexed(self.fold_indices, image_sizes)
 
         return AnalogIndexedFunction.apply(self.analog_tile, x_input, self.weight,
                                            self.bias, not self.training)
@@ -250,8 +253,8 @@ class AnalogConv2d(Conv2d, AnalogModuleBase):
         if padding_mode != 'zeros':
             raise ValueError('Only "zeros" padding mode is supported')
 
-        kernel_size = _pair(kernel_size)
-        self.in_features = (in_channels // groups) * kernel_size[0] * kernel_size[1]  # type: ignore
+        kernel_size_tuple = _pair(kernel_size)
+        self.in_features = (in_channels // groups) * kernel_size_tuple[0] * kernel_size_tuple[1]
         self.out_features = out_channels
 
         # Create the tile and set the analog.
@@ -314,7 +317,7 @@ class AnalogConv2d(Conv2d, AnalogModuleBase):
 
             image_sizes = [self.in_channels, x_height, x_width, d_height, d_width]
             self.input_size = input_size
-            self.analog_tile.set_indexed(self.fold_indices, image_sizes)  # type: ignore
+            self.analog_tile.set_indexed(self.fold_indices, image_sizes)
 
         return AnalogIndexedFunction.apply(self.analog_tile, x_input, self.weight,
                                            self.bias, not self.training)
@@ -399,9 +402,10 @@ class AnalogConv3d(Conv3d, AnalogModuleBase):
         if dilation != 1:
             raise ValueError('Only dilation = 1 is supported')
 
-        kernel_size = _triple(kernel_size)
-        self.in_features = (in_channels // groups) * \
-            kernel_size[0] * kernel_size[1] * kernel_size[2]  # type: ignore
+        kernel_size_tuple = _triple(kernel_size)
+        self.in_features = (in_channels // groups) * (
+            kernel_size_tuple[0] * kernel_size_tuple[1] * kernel_size_tuple[2]
+        )
         self.out_features = out_channels
 
         # Create the tile and set the analog.
@@ -487,7 +491,7 @@ class AnalogConv3d(Conv3d, AnalogModuleBase):
 
             image_sizes = [self.in_channels, x_depth, x_height, x_width, d_depth, d_height, d_width]
             self.input_size = input_size
-            self.analog_tile.set_indexed(self.fold_indices, image_sizes)  # type: ignore
+            self.analog_tile.set_indexed(self.fold_indices, image_sizes)
 
         return AnalogIndexedFunction.apply(self.analog_tile, x_input, self.weight,
                                            self.bias, not self.training)

--- a/src/aihwkit/optim/analog_sgd.py
+++ b/src/aihwkit/optim/analog_sgd.py
@@ -57,8 +57,8 @@ class AnalogSGD(SGD):
 
         # Remove the analog parameters from the main param group, and add
         # the group.
-        for param_group in new_param_groups:
-            for param in param_group['params']:  # type: ignore
+        for param_group in new_param_groups:  # type: dict
+            for param in param_group['params']:
                 # Remove the param by its id(), as removing via list.remove()
                 # seems to involve comparisons that can lead to errors.
                 index = next(


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Bump the version of `mypy` to `0.800`, taking the chance to do some cleanup of  `type: ignore` mypy hints.

## Details

While some `type: ignore` comments still remain after this PR, a number of them were able to be removed directly - and in other cases, worked-around by making use of more specific typing information (for example, using an intermediate variable in the `conv.py` lines).

