### PR TITLE
Fix osx compilation warnings

### DIFF
--- a/src/rpucuda/rpu_forward_backward_pass.h
+++ b/src/rpucuda/rpu_forward_backward_pass.h
@@ -53,7 +53,7 @@ template <typename T> class ForwardBackwardPassIOManaged : public ForwardBackwar
 public:
   explicit ForwardBackwardPassIOManaged(int x_size, int d_size, std::shared_ptr<RNG<T>> rng);
   ForwardBackwardPassIOManaged(){};
-  ~ForwardBackwardPassIOManaged();
+  virtual ~ForwardBackwardPassIOManaged();
 
   ForwardBackwardPassIOManaged(const ForwardBackwardPassIOManaged<T> &);
   ForwardBackwardPassIOManaged<T> &operator=(const ForwardBackwardPassIOManaged<T> &);

--- a/src/rpucuda/rpu_simple_device.cpp
+++ b/src/rpucuda/rpu_simple_device.cpp
@@ -128,13 +128,13 @@ void SimpleRPUDevice<T>::populate(const SimpleRPUDeviceMetaParameter<T> &p, Real
   par_storage_->initialize();
 }
 
-template class SimpleRPUDeviceMetaParameter<float>;
+template struct SimpleRPUDeviceMetaParameter<float>;
 template class AbstractRPUDevice<float>;
 template class SimpleRPUDevice<float>;
 #ifdef RPU_USE_DOUBLE
 template class AbstractRPUDevice<double>;
 template class SimpleRPUDevice<double>;
-template class SimpleRPUDeviceMetaParameter<double>;
+template struct SimpleRPUDeviceMetaParameter<double>;
 #endif
 
 } // namespace RPU

--- a/src/rpucuda/rpu_weight_updater.h
+++ b/src/rpucuda/rpu_weight_updater.h
@@ -52,7 +52,7 @@ template <typename T> class PulsedRPUWeightUpdater : public RPUWeightUpdater<T> 
 public:
   explicit PulsedRPUWeightUpdater(int x_size, int d_size, std::shared_ptr<RNG<T>> rng);
   PulsedRPUWeightUpdater(){};
-  ~PulsedRPUWeightUpdater();
+  virtual ~PulsedRPUWeightUpdater();
 
   PulsedRPUWeightUpdater(const PulsedRPUWeightUpdater<T> &);
   PulsedRPUWeightUpdater<T> &operator=(const PulsedRPUWeightUpdater<T> &);


### PR DESCRIPTION
## Related issues

Closes #117 

## Description

Fix two types of warnings that are being generated when compiling on the latest osx/xcode:

```
warning: class template 'SimpleRPUDeviceMetaParameter' was previously declared as a struct template;
      this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
```
```
warning: delete called on non-final 'RPU::PulsedRPUWeightUpdater<float>' that has virtual functions
      but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
```

## Details

<!-- A more elaborate description of the changes, if needed. -->
