### PR TITLE
Bump pybind11 version

### DIFF
--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -31,7 +31,7 @@ Dependency                       Version   Notes
 ===============================  ========  ======
 C++11 compatible compiler
 `cmake`_                         3.18+
-`pybind11`_                      2.6.0+    Version 2.6.0 can be installed using ``pip`` (recommended)
+`pybind11`_                      2.6.2+    Versions 2.6.0+ can be installed using ``pip`` (recommended)
 `scikit-build`_                  0.11.0+
 `Python 3 development headers`_  3.6+
 BLAS implementation                        `OpenBLAS`_ or `Intel MKL`_

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Build dependencies.
 cmake>=3.18
 scikit-build>=0.11.1
-pybind11>=2.6.0
+pybind11>=2.6.2
 # Runtime dependencies.
 torch>=1.5
 numpy>=1.18


### PR DESCRIPTION
## Related issues

#111, #112

## Description

Bump the `pybind11` version to `2.6.2`. Even if it is a minor version, it includes a fix related to `~gil_scoped_release()` that seems to be causing issues with Python 3.9 and torch.

## Details

<!-- A more elaborate description of the changes, if needed. -->
