### PR TITLE
Display doc for rpu_base depending on environment

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -9,7 +9,6 @@ API Reference
    aihwkit.simulator
    aihwkit.simulator.configs
    aihwkit.simulator.noise_models
-   aihwkit.simulator.rpu_base
    aihwkit.simulator.tiles
    aihwkit.nn
    aihwkit.nn.functions
@@ -19,3 +18,11 @@ API Reference
    aihwkit.nn.modules.linear
    aihwkit.optim
    aihwkit.optim.analog_sgd
+
+
+.. only:: env_local
+
+   .. autosummary::
+        :recursive:
+
+        aihwkit.simulator.rpu_base

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,3 +73,11 @@ html_static_path = ['_static']
 
 autodoc_typehints = 'description'
 autodoc_mock_imports = ['aihwkit.simulator.rpu_base']
+
+# -- Options specific to readthedocs -----------------------------------------
+
+on_readthedocs = os.environ.get('READTHEDOCS') == 'True'
+if on_readthedocs:
+    tags.add('env_readthedocs')
+else:
+    tags.add('env_local')


### PR DESCRIPTION
## Related issues

#9

## Description

Small fix for a slightly better rendering of the `API Reference` in the documentation, not displaying `aihwkit.simulator.rpu_base` if the rendering takes place inside readthedocs. Currently, it is shown in the documentation - but as Sphinx is unable to fetch its docstrings or its contents, it is displayed as an empty entry.

## Details

<!-- A more elaborate description of the changes, if needed. -->
