### PR TITLE
Weight scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog], and this project adheres to
   mimicking their digital counterparts. (\#102, \#103).
 * Option to automatically scale the digital weights into the full range of the
   simluated crossbar by applying a fixed output global factor in
-  digital (\#???).
+  digital (\##129).
 
 #### Fixed
 
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Faulty backward noise management error message removed for perfect backward
   and CUDA. (\#99)
 * Fixed segfault when using diffusion or reset with vector unit cells for
-  CUDA.
+  CUDA (\##129).
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,17 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Option to excluded bias row for hardware-aware training noise. (\#99)
 * Two new convolution layers have been added: `AnalogConv1d` and `AnalogConv3d`,
   mimicking their digital counterparts. (\#102, \#103).
+* Option to automatically scale the digital weights into the full range of the
+  simluated crossbar by applying a fixed output global factor in
+  digital (\#???).
 
 #### Fixed
 
 * Fixed small issues that resulted in warnings for windows compilation. (\#99)
 * Faulty backward noise management error message removed for perfect backward
   and CUDA. (\#99)
+* Fixed segfault when using diffusion or reset with vector unit cells for
+  CUDA.
 
 #### Removed
 

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -41,16 +41,18 @@ class AnalogConv1d(Conv1d, AnalogModuleBase):
         in_channels: number of channels in the input image.
         out_channels: number of channels produced by the convolution.
         kernel_size: size of the convolving kernel.
-        stride: stride of the convolution-
+        stride: stride of the convolution.
         padding: zero-padding added to both sides of the input.
         dilation: spacing between kernel elements.
         groups: number of blocked connections from input channels to output
             channels.
-        bias: whether to use a bias row on the analog tile or not
+        bias: whether to use a bias row on the analog tile or not.
         padding_mode: padding strategy. Only ``'zeros'`` is supported.
         rpu_config: resistive processing unit configuration.
-        realistic_read_write: whether to enable realistic read/write
-           for setting initial weights and read out of weights
+        realistic_read_write: whether to enable realistic read/write for
+            setting initial weights and read out of weights.
+        weight_scaling_omega: the weight value where the max weight will be
+            scaled to. If zero, no weight scaling will be performed.
     """
     # pylint: disable=abstract-method
 
@@ -64,6 +66,7 @@ class AnalogConv1d(Conv1d, AnalogModuleBase):
     padding: Tuple[int]
     dilation: Tuple[int]
     realistic_read_write: bool
+    weight_scaling_omega: float
     fold_indices: Tensor
     input_size: float
     in_features: int
@@ -81,7 +84,8 @@ class AnalogConv1d(Conv1d, AnalogModuleBase):
             bias: bool = True,
             padding_mode: str = 'zeros',
             rpu_config: Optional[RPUConfigAlias] = None,
-            realistic_read_write: bool = False
+            realistic_read_write: bool = False,
+            weight_scaling_omega: float = 0.0
     ):
         # pylint: disable=too-many-arguments
         if groups != 1:
@@ -100,7 +104,8 @@ class AnalogConv1d(Conv1d, AnalogModuleBase):
                                             self.out_features,
                                             bias,
                                             rpu_config,
-                                            realistic_read_write)
+                                            realistic_read_write,
+                                            weight_scaling_omega)
 
         # Call super() after tile creation, including ``reset_parameters``.
         super().__init__(in_channels, out_channels, kernel_size, stride,
@@ -184,6 +189,12 @@ class AnalogConv1d(Conv1d, AnalogModuleBase):
             output += ', dilation={dilation}'
         if not self.use_bias:
             output += ', bias=False'
+        if self.realistic_read_write:
+            output += ', realistic_read_write={realistic_read_write}'
+        if self.weight_scaling_omega > 0:
+            alpha = self.analog_tile.tile.get_alpha_scale()
+            output += ', alpha_scale={:.3f}'.format(alpha)
+        output += ', is_cuda={}'.format(self.analog_tile.is_cuda)
         return output.format(**self.__dict__)
 
 
@@ -205,16 +216,18 @@ class AnalogConv2d(Conv2d, AnalogModuleBase):
         in_channels: number of channels in the input image.
         out_channels: number of channels produced by the convolution.
         kernel_size: size of the convolving kernel.
-        stride: stride of the convolution-
+        stride: stride of the convolution.
         padding: zero-padding added to both sides of the input.
         dilation: spacing between kernel elements.
         groups: number of blocked connections from input channels to output
             channels.
-        bias: whether to use a bias row on the analog tile or not
+        bias: whether to use a bias row on the analog tile or not.
         padding_mode: padding strategy. Only ``'zeros'`` is supported.
         rpu_config: resistive processing unit configuration.
         realistic_read_write: whether to enable realistic read/write
-           for setting initial weights and read out of weights
+            for setting initial weights and read out of weights.
+        weight_scaling_omega: the weight value where the max weight will be
+            scaled to. If zero, no weight scaling will be performed.
     """
     # pylint: disable=abstract-method
 
@@ -228,6 +241,7 @@ class AnalogConv2d(Conv2d, AnalogModuleBase):
     padding: Tuple[int, int]
     dilation: Tuple[int, int]
     realistic_read_write: bool
+    weight_scaling_omega: float
     fold_indices: Tensor
     input_size: float
     in_features: int
@@ -245,7 +259,8 @@ class AnalogConv2d(Conv2d, AnalogModuleBase):
             bias: bool = True,
             padding_mode: str = 'zeros',
             rpu_config: Optional[RPUConfigAlias] = None,
-            realistic_read_write: bool = False
+            realistic_read_write: bool = False,
+            weight_scaling_omega: float = 0.0,
     ):
         # pylint: disable=too-many-arguments
         if groups != 1:
@@ -262,7 +277,8 @@ class AnalogConv2d(Conv2d, AnalogModuleBase):
                                             self.out_features,
                                             bias,
                                             rpu_config,
-                                            realistic_read_write)
+                                            realistic_read_write,
+                                            weight_scaling_omega)
 
         # Call super() after tile creation, including ``reset_parameters``.
         super().__init__(in_channels, out_channels, kernel_size, stride,
@@ -331,6 +347,12 @@ class AnalogConv2d(Conv2d, AnalogModuleBase):
             output += ', dilation={dilation}'
         if not self.use_bias:
             output += ', bias=False'
+        if self.realistic_read_write:
+            output += ', realistic_read_write={realistic_read_write}'
+        if self.weight_scaling_omega > 0:
+            alpha = self.analog_tile.tile.get_alpha_scale()
+            output += ', alpha_scale={:.3f}'.format(alpha)
+        output += ', is_cuda={}'.format(self.analog_tile.is_cuda)
         return output.format(**self.__dict__)
 
 
@@ -352,16 +374,18 @@ class AnalogConv3d(Conv3d, AnalogModuleBase):
         in_channels: number of channels in the input image.
         out_channels: number of channels produced by the convolution.
         kernel_size: size of the convolving kernel.
-        stride: stride of the convolution-
+        stride: stride of the convolution.
         padding: zero-padding added to both sides of the input.
         dilation: spacing between kernel elements.
         groups: number of blocked connections from input channels to output
             channels.
-        bias: whether to use a bias row on the analog tile or not
+        bias: whether to use a bias row on the analog tile or not.
         padding_mode: padding strategy. Only ``'zeros'`` is supported.
         rpu_config: resistive processing unit configuration.
         realistic_read_write: whether to enable realistic read/write
-           for setting initial weights and read out of weights
+           for setting initial weights and read out of weights.
+        weight_scaling_omega: the weight value where the max weight will be
+            scaled to. If zero, no weight scaling will be performed.
     """
     # pylint: disable=abstract-method
 
@@ -375,6 +399,7 @@ class AnalogConv3d(Conv3d, AnalogModuleBase):
     padding: Tuple[int, int, int]
     dilation: Tuple[int, int, int]
     realistic_read_write: bool
+    weight_scaling_omega: float
     fold_indices: Tensor
     input_size: float
     in_features: int
@@ -392,7 +417,8 @@ class AnalogConv3d(Conv3d, AnalogModuleBase):
             bias: bool = True,
             padding_mode: str = 'zeros',
             rpu_config: Optional[RPUConfigAlias] = None,
-            realistic_read_write: bool = False
+            realistic_read_write: bool = False,
+            weight_scaling_omega: float = 0.0,
     ):
         # pylint: disable=too-many-arguments
         if groups != 1:
@@ -413,7 +439,8 @@ class AnalogConv3d(Conv3d, AnalogModuleBase):
                                             self.out_features,
                                             bias,
                                             rpu_config,
-                                            realistic_read_write)
+                                            realistic_read_write,
+                                            weight_scaling_omega)
 
         # Call super() after tile creation, including ``reset_parameters``.
         super().__init__(in_channels, out_channels, kernel_size, stride,
@@ -505,4 +532,10 @@ class AnalogConv3d(Conv3d, AnalogModuleBase):
             output += ', dilation={dilation}'
         if not self.use_bias:
             output += ', bias=False'
+        if self.realistic_read_write:
+            output += ', realistic_read_write={realistic_read_write}'
+        if self.weight_scaling_omega > 0:
+            alpha = self.analog_tile.tile.get_alpha_scale()
+            output += ', alpha_scale={:.3f}'.format(alpha)
+        output += ', is_cuda={}'.format(self.analog_tile.is_cuda)
         return output.format(**self.__dict__)

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
@@ -865,7 +865,7 @@ void declare_rpu_tiles(py::module &m) {
           R"pbdoc(
            Set the updated device index (in case multiple devices per cross-point).
 
-           Note: 
+           Note:
               Only used for vector unit cells, so far. Ignored in other cases.
 
            Args:
@@ -878,6 +878,23 @@ void declare_rpu_tiles(py::module &m) {
 
            Args:
                idx: index of the (unit cell) devices, returns 0 in all other cases.
+           )pbdoc")
+      .def(
+          "set_alpha_scale", &Class::setAlphaScale,
+          R"pbdoc( Set a global scale on the forward and backward computation,
+           which is applied in digital at the output.
+
+           Args:
+               scale: the scalar scale value (default is 1.0)
+           )pbdoc")
+      .def(
+          "get_alpha_scale", &Class::getFwdAlpha, // only allow the setting of forward/backward
+          R"pbdoc( Get the global scale for forward computation. Backward computation will use
+          the same if set by without noise.
+           )pbdoc")
+      .def(
+          "get_backward_alpha_scale", &Class::getBwdAlpha,
+          R"pbdoc( Get the global scale for backward computation.
            )pbdoc");
 
   py::class_<ClassPulsed, Class>(

--- a/src/rpucuda/cuda/rpucuda_pulsed_device.cu
+++ b/src/rpucuda/cuda/rpucuda_pulsed_device.cu
@@ -283,7 +283,7 @@ template <typename T>
 void PulsedRPUDeviceCuda<T>::resetCols(T *weights, int start_col, int n_cols, T reset_prob) {
   // col-major in CUDA.
 
-  if (dev_reset_bias_ == nullptr) {
+  if (dev_reset_bias_== nullptr) {
     return; // no reset
   }
 

--- a/tests/test_bindings_tiles.py
+++ b/tests/test_bindings_tiles.py
@@ -15,6 +15,7 @@
 from unittest import SkipTest
 
 from numpy import array, std, dot
+from numpy import abs as numpy_abs
 from numpy.random import uniform
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
@@ -173,6 +174,86 @@ class BindingsTilesTest(ParametrizedTestCase):
         cuda_python_tile = python_tile.cuda()
         init_weights_cuda = cuda_python_tile.tile.get_weights()
         assert_array_almost_equal(init_weights, init_weights_cuda)
+
+    def test_alpha_scale(self):
+        """Test the alpha scaling."""
+        n_rows = 6  # out_size aka d_size.
+        n_cols = 5  # in_size aka x_size.
+        alpha = 4.0
+        m_batch = 4
+        lr = 0.1
+
+        python_tile = self.get_noisefree_tile(n_rows, n_cols)
+        cpp_tile = python_tile.tile
+
+        init_weights = cpp_tile.get_weights().copy()
+        cpp_tile.set_learning_rate(lr)
+
+        cpp_tile.set_alpha_scale(alpha)
+        self.assertEqual(alpha, cpp_tile.get_alpha_scale())
+
+        x_t = from_numpy(uniform(-1.2, 1.2, size=(m_batch, n_cols)).astype('float32'))
+        d_t = from_numpy(uniform(-0.1, 0.1, size=(m_batch, n_rows)).astype('float32'))
+
+        if python_tile.is_cuda:
+            x_t = x_t.cuda()
+            d_t = d_t.cuda()
+
+        # Perform forward.
+        y = cpp_tile.forward(x_t).cpu()
+        self.assertIsInstance(y, Tensor)
+        assert_array_almost_equal(y.numpy(), dot(x_t.cpu(), alpha*init_weights.T))
+
+        # Perform backward.
+        z = cpp_tile.backward(d_t).cpu()
+        self.assertIsInstance(y, Tensor)
+        assert_array_almost_equal(z.numpy(), dot(d_t.cpu(), alpha*init_weights))
+
+        # Perform update.
+        cpp_tile.update(x_t, d_t, bias=False)
+        post_rank_weights = cpp_tile.get_weights().copy()
+        ref_weights = init_weights - lr/alpha*dot(d_t.cpu().T, x_t.cpu())
+
+        assert_array_almost_equal(post_rank_weights, ref_weights)
+
+    def test_alpha_get_set_weights(self):
+        """Tests that ``alpha`` does not affect ``get_weights()``."""
+        alpha = 2.0
+
+        python_tile = self.get_noisefree_tile(5, 4)
+        cpp_tile = python_tile.tile
+        init_weights = cpp_tile.get_weights().copy()
+        cpp_tile.set_alpha_scale(alpha)
+        self.assertEqual(alpha, cpp_tile.get_alpha_scale())
+
+        # Get weights with alpha.
+        init_weights2 = cpp_tile.get_weights().copy()
+        assert_array_almost_equal(init_weights, init_weights2)
+
+        # Set the weights (with alpha).
+        cpp_tile.set_weights(init_weights)
+        init_weights2 = cpp_tile.get_weights().copy()
+        assert_array_almost_equal(init_weights, init_weights2)
+
+    def test_get_set_weights_scaled(self):
+        """Test that ``alpha`` affects the ``get_weights()`` scaled."""
+        omega = 0.5
+        python_tile = self.get_noisefree_tile(5, 4)
+        cpp_tile = python_tile.tile
+        init_weights = cpp_tile.get_weights().copy()
+
+        # Get weights with alpha.
+        python_tile.set_weights_scaled(from_numpy(init_weights), omega=omega)
+
+        alpha = cpp_tile.get_alpha_scale()
+        self.assertEqual(alpha, numpy_abs(init_weights).max()/omega)
+
+        init_weights_scaled = cpp_tile.get_weights()
+
+        assert_array_almost_equal(init_weights, init_weights_scaled*alpha)
+
+        init_weights2 = python_tile.get_weights_scaled()[0].cpu().numpy()
+        assert_array_almost_equal(init_weights, init_weights2)
 
 
 @parametrize_over_tiles([


### PR DESCRIPTION
## Related issues

Added feature.

## Description

Here a conversion factor (weight scaling) is introduced that scales the weight range of the cross bar in respect to the digital output. For instance during initialization for training, the `weight_scaling_omega` factor can be used to set the absolute max of the weight matrix to some value (e.g. to the maximum of the weight range) and scale the output accordingly. This ensures that tile operates in a proper dynamic regime for a given DNN and usually improves achievable accuracy.

## Details
See  [Rasch, Gokmen & Haensch (2019)](https://arxiv.org/abs/1906.02698) for algorithmic details.    
