### PR TITLE
Move extra_repr to AnalogTileBase

### DIFF
--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -305,3 +305,17 @@ class AnalogModuleBase(Module):
 
         if isinstance(self.analog_tile, InferenceTile):
             self.analog_tile.program_weights()
+
+    def extra_repr(self) -> str:
+        """Set the extra representation of the module.
+
+        Returns:
+            A string with the extra representation.
+        """
+        output = super().extra_repr()
+        if self.realistic_read_write:
+            output += ', realistic_read_write={}'.format(self.realistic_read_write)
+        if self.weight_scaling_omega > 0:
+            output += ', weight_scaling_omega={:.3f}'.format(self.weight_scaling_omega)
+
+        return output

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -180,23 +180,6 @@ class AnalogConv1d(AnalogModuleBase, Conv1d):
         return AnalogIndexedFunction.apply(self.analog_tile, x_input, self.weight,
                                            self.bias, not self.training)
 
-    def extra_repr(self) -> str:
-        output = ('{in_channels}, {out_channels}, kernel_size={kernel_size}'
-                  ', stride={stride}')
-        if self.padding != (0,) * len(self.padding):
-            output += ', padding={padding}'
-        if self.dilation != (1,) * len(self.dilation):
-            output += ', dilation={dilation}'
-        if not self.use_bias:
-            output += ', bias=False'
-        if self.realistic_read_write:
-            output += ', realistic_read_write={realistic_read_write}'
-        if self.weight_scaling_omega > 0:
-            alpha = self.analog_tile.tile.get_alpha_scale()
-            output += ', alpha_scale={:.3f}'.format(alpha)
-        output += ', is_cuda={}'.format(self.analog_tile.is_cuda)
-        return output.format(**self.__dict__)
-
 
 class AnalogConv2d(AnalogModuleBase, Conv2d):
     """2D convolution layer that uses an analog tile.
@@ -337,23 +320,6 @@ class AnalogConv2d(AnalogModuleBase, Conv2d):
 
         return AnalogIndexedFunction.apply(self.analog_tile, x_input, self.weight,
                                            self.bias, not self.training)
-
-    def extra_repr(self) -> str:
-        output = ('{in_channels}, {out_channels}, kernel_size={kernel_size}'
-                  ', stride={stride}')
-        if self.padding != (0,) * len(self.padding):
-            output += ', padding={padding}'
-        if self.dilation != (1,) * len(self.dilation):
-            output += ', dilation={dilation}'
-        if not self.use_bias:
-            output += ', bias=False'
-        if self.realistic_read_write:
-            output += ', realistic_read_write={realistic_read_write}'
-        if self.weight_scaling_omega > 0:
-            alpha = self.analog_tile.tile.get_alpha_scale()
-            output += ', alpha_scale={:.3f}'.format(alpha)
-        output += ', is_cuda={}'.format(self.analog_tile.is_cuda)
-        return output.format(**self.__dict__)
 
 
 class AnalogConv3d(AnalogModuleBase, Conv3d):
@@ -522,20 +488,3 @@ class AnalogConv3d(AnalogModuleBase, Conv3d):
 
         return AnalogIndexedFunction.apply(self.analog_tile, x_input, self.weight,
                                            self.bias, not self.training)
-
-    def extra_repr(self) -> str:
-        output = ('{in_channels}, {out_channels}, kernel_size={kernel_size}'
-                  ', stride={stride}')
-        if self.padding != (0,) * len(self.padding):
-            output += ', padding={padding}'
-        if self.dilation != (1,) * len(self.dilation):
-            output += ', dilation={dilation}'
-        if not self.use_bias:
-            output += ', bias=False'
-        if self.realistic_read_write:
-            output += ', realistic_read_write={realistic_read_write}'
-        if self.weight_scaling_omega > 0:
-            alpha = self.analog_tile.tile.get_alpha_scale()
-            output += ', alpha_scale={:.3f}'.format(alpha)
-        output += ', is_cuda={}'.format(self.analog_tile.is_cuda)
-        return output.format(**self.__dict__)

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -23,7 +23,7 @@ from aihwkit.nn.functions import AnalogIndexedFunction
 from aihwkit.nn.modules.base import AnalogModuleBase, RPUConfigAlias
 
 
-class AnalogConv1d(Conv1d, AnalogModuleBase):
+class AnalogConv1d(AnalogModuleBase, Conv1d):
     """1D convolution layer that uses an analog tile.
 
     Applies a 1D convolution over an input signal composed of several input
@@ -198,7 +198,7 @@ class AnalogConv1d(Conv1d, AnalogModuleBase):
         return output.format(**self.__dict__)
 
 
-class AnalogConv2d(Conv2d, AnalogModuleBase):
+class AnalogConv2d(AnalogModuleBase, Conv2d):
     """2D convolution layer that uses an analog tile.
 
     Applies a 2D convolution over an input signal composed of several input
@@ -356,7 +356,7 @@ class AnalogConv2d(Conv2d, AnalogModuleBase):
         return output.format(**self.__dict__)
 
 
-class AnalogConv3d(Conv3d, AnalogModuleBase):
+class AnalogConv3d(AnalogModuleBase, Conv3d):
     """3D convolution layer that uses an analog tile.
 
     Applies a 3D convolution over an input signal composed of several input

--- a/src/aihwkit/nn/modules/linear.py
+++ b/src/aihwkit/nn/modules/linear.py
@@ -21,7 +21,7 @@ from aihwkit.nn.functions import AnalogFunction
 from aihwkit.nn.modules.base import AnalogModuleBase, RPUConfigAlias
 
 
-class AnalogLinear(Linear, AnalogModuleBase):
+class AnalogLinear(AnalogModuleBase, Linear):
     """Linear layer that uses an analog tile.
 
     Linear layer that uses an analog tile during its forward, backward and

--- a/src/aihwkit/nn/modules/linear.py
+++ b/src/aihwkit/nn/modules/linear.py
@@ -88,15 +88,3 @@ class AnalogLinear(AnalogModuleBase, Linear):
         # pylint: disable=arguments-differ
         return AnalogFunction.apply(self.analog_tile, x_input, self.weight, self.bias,
                                     not self.training)
-
-    def extra_repr(self) -> str:
-
-        output = super().extra_repr()
-        if self.realistic_read_write:
-            output += ', realistic_read_write={}'.format(self.realistic_read_write)
-        if self.weight_scaling_omega > 0:
-            alpha = self.analog_tile.tile.get_alpha_scale()
-            output += ', alpha_scale={:.3f}'.format(alpha)
-
-        return '{}, is_cuda={}'.format(output,
-                                       self.analog_tile.is_cuda)


### PR DESCRIPTION
## Related issues

#127

## Description

Revise the `extra_repr` usage:
* move to `AnalogTileBase` (slightly related to #127), adjusting the inheritance order
* rely on the default PyTorch counterparts implementation, only appending analog-specific attributes to it
* make use of only attributes of the layer that are also parameters, keeping aligned with[ `__repr__` conventions](https://docs.python.org/3/reference/datamodel.html#object.__repr__)

## Details


<!-- A more elaborate description of the changes, if needed. -->
