### PR TITLE
Random states sizes and TransferCompound CUDA bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,10 @@ The format is based on [Keep a Changelog], and this project adheres to
   update). (\#99)
 * Option to excluded bias row for hardware-aware training noise. (\#99)
 * Two new convolution layers have been added: `AnalogConv1d` and `AnalogConv3d`,
-  mimicking their digital counterparts. (\#102, \#103).
+  mimicking their digital counterparts. (\#102, \#103)
 * Option to automatically scale the digital weights into the full range of the
   simluated crossbar by applying a fixed output global factor in
-  digital (\##129).
+  digital. (\#129)
 
 #### Fixed
 
@@ -40,7 +40,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Faulty backward noise management error message removed for perfect backward
   and CUDA. (\#99)
 * Fixed segfault when using diffusion or reset with vector unit cells for
-  CUDA (\##129).
+  CUDA. (\#129)
+* Fixed random states mismatch in IoManager that could cause crashed in same
+  network size and batch size cases for CUDA, in particular for
+  `TransferCompound`. (\#132)
+* Fixed wrong update for `TransferCompound` in case of `transfer_every` smaller
+  than the batch size. (\#132)
 
 #### Removed
 

--- a/src/rpucuda/cuda/cuda_util.cu
+++ b/src/rpucuda/cuda/cuda_util.cu
@@ -71,6 +71,7 @@ void curandSetup(
     unsigned long long rseed,
     bool same_seed) {
   int m = (n + 31) / 32 * 32;
+  c->synchronizeDevice();
   dev_states = std::unique_ptr<CudaArray<curandState_t>>(new CudaArray<curandState_t>(c, m));
   curandSetup(*dev_states, rseed, same_seed);
 }

--- a/src/rpucuda/cuda/pwu_kernel_parameter_base.h
+++ b/src/rpucuda/cuda/pwu_kernel_parameter_base.h
@@ -31,7 +31,7 @@ public:
       CudaContext *construction_context,
       int x_size_in,
       int d_size_in,
-      int m_batch,
+      int m_batch_in,
       int nK32_in,
       int use_bo64_in,
       bool out_trans_in,
@@ -50,7 +50,7 @@ public:
     d_size = d_size_in;
     nK32 = nK32_in;
     size = d_size * x_size;
-    m_batch = m_batch;
+    m_batch = m_batch_in;
     out_trans = out_trans_in;
     use_bo64 = use_bo64_in;
     valid = true;
@@ -147,6 +147,8 @@ public:
     std::cout << "\t batch_stride:\t " << batch_load_stride << std::endl;
     std::cout << "\t nK32:\t\t " << nK32 << std::endl;
     std::cout << "\t m_batch:\t " << m_batch << std::endl;
+    std::cout << "\t x_size:\t " << x_size << std::endl;
+    std::cout << "\t d_size:\t " << d_size << std::endl;
     std::cout << "\t timing:\t " << timing << std::endl;
     std::cout << "\t implicit:\t " << implicit_pulses << std::endl;
   };


### PR DESCRIPTION
## Related issues

potentially #113 

## Description
A bug fix which fixed the following issues:
* Random states sizes could cause errors for some network sizes and batch settings (only CUDA)
* `TransferCompound` fix for update with `transfer_every` smaller than batchsize (only CUDA)

## Details

Corrected the random state vector sizes and chunk size offsets.
