### PR TITLE
Fix generator flag on Windows instructions

### DIFF
--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -97,7 +97,7 @@ Using this method, please make sure that the flags ``-DRPU_BLAS=MKL`` and
 commands. In particular, use the following command instead of the default one
 in the `Installing and compiling` sub-section::
 
-    $ pip install -v aihwkit --install-option="-DUSE_CUDA=ON" --install-option="-DRPU_BLAS=MKL" --install-option="-G 'Visual Studio 16 2019'"
+    $ pip install -v aihwkit --install-option="-DUSE_CUDA=ON" --install-option="-DRPU_BLAS=MKL" --install-option="-GVisual Studio 16 2019"
 
 Windows with OpenBLAS (Experimental)
 """"""""""""""""""""""""""""""""""""


### PR DESCRIPTION
## Related issues

#136 

## Description

Fix the instructions for passing the generator flag to `pip install` in the windows instructions - thanks @anu-pub for picking it and for the suggested replacement!

## Details

<!-- A more elaborate description of the changes, if needed. -->
