### PR TITLE
Add .to() to AnalogSequential

### DIFF
--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -63,6 +63,32 @@ class AnalogSequential(Sequential):
 
         return self
 
+    def to(
+            self,
+            device: Optional[Union[torch_device, str, int]] = None
+    ) -> 'AnalogSequential':
+        """Moves and/or casts the parameters, buffers and analog tiles.
+
+        Args:
+            device: the desired device of the parameters, buffers and analog
+                tiles in this module.
+
+        Returns:
+            This module in the specified device.
+
+        Raises:
+            ModuleError: if the device is not a cuda device.
+        """
+        if isinstance(device, torch_device):
+            if device.type == 'cuda':
+                raise ModuleError('Analog layer can only be moved to cuda')
+
+        super().to(device)
+
+        self._apply_to_analog(lambda m: m.cuda(device))
+
+        return self
+
     def drift_analog_weights(self, t_inference: float = 0.0) -> None:
         """(Program) and drift all analog inference layers of a given model.
 

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -79,6 +79,7 @@ class AnalogSequential(Sequential):
         Raises:
             ModuleError: if the device is not a cuda device.
         """
+        # pylint: disable=arguments-differ
         if isinstance(device, torch_device):
             if device.type != 'cuda':
                 raise ModuleError('Analog layer can only be moved to cuda')

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -80,7 +80,7 @@ class AnalogSequential(Sequential):
             ModuleError: if the device is not a cuda device.
         """
         if isinstance(device, torch_device):
-            if device.type == 'cuda':
+            if device.type != 'cuda':
                 raise ModuleError('Analog layer can only be moved to cuda')
 
         super().to(device)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -14,7 +14,7 @@
 
 from unittest import SkipTest
 
-from torch import Tensor
+from torch import Tensor, device
 
 from aihwkit.nn import AnalogSequential
 from aihwkit.simulator.tiles import AnalogTile, CudaAnalogTile
@@ -129,6 +129,27 @@ class AnalogLayerTest(ParametrizedTestCase):
         # Create a container and move to cuda.
         model = AnalogSequential(layer)
         model.cuda()
+
+        # Assert the tile has been moved to cuda.
+        self.assertIsInstance(layer.analog_tile, expected_class)
+
+    def test_sequential_move_to_cuda_via_to(self):
+        """Test sequential cuda, using ``.to()``."""
+        if not cuda.is_compiled():
+            raise SkipTest('not compiled with CUDA support')
+
+        # Map the original tile classes to the expected ones after `cuda()`.
+        tile_classes = {
+            AnalogTile: CudaAnalogTile,
+            CudaAnalogTile: CudaAnalogTile
+        }
+
+        layer = self.get_layer()
+        expected_class = tile_classes[layer.analog_tile.__class__]
+
+        # Create a container and move to cuda.
+        model = AnalogSequential(layer)
+        model = model.to(device('cuda'))
 
         # Assert the tile has been moved to cuda.
         self.assertIsInstance(layer.analog_tile, expected_class)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -149,7 +149,7 @@ class AnalogLayerTest(ParametrizedTestCase):
 
         # Create a container and move to cuda.
         model = AnalogSequential(layer)
-        model = model.to(device('cuda'))
+        model.to(device('cuda'))
 
         # Assert the tile has been moved to cuda.
         self.assertIsInstance(layer.analog_tile, expected_class)


### PR DESCRIPTION
## Related issues

#140 

## Description

First stab at supporting `.to()`:
* add `.to()` method to `AnalogSequential`, as it is the layer where we can cleanly apply functions to analog sub-modules 
* only moving to `cuda` is supported

## Details

<!-- A more elaborate description of the changes, if needed. -->
