### PR TITLE
Use cuda device correctly in AnalogSequential

### DIFF
--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -59,7 +59,7 @@ class AnalogSequential(Sequential):
     ) -> 'AnalogSequential':
         super().cuda(device)
 
-        self._apply_to_analog(lambda m: m.cuda())
+        self._apply_to_analog(lambda m: m.cuda(device))
 
         return self
 


### PR DESCRIPTION
## Related issues

#142 

## Description

Fix the passing of `device` when using `AnalogSequential.cuda()`, as the device was not being received by the children analog layers (and as a result, the default cuda device was used regardless). Additionally, checked the rest of `cuda()` calls to ensure `device` was handled.

## Details

<!-- A more elaborate description of the changes, if needed. -->
