### PR TITLE
Device and configuration presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,11 @@ The format is based on [Keep a Changelog], and this project adheres to
   `ECRamPresetDevice`, `CapacitorPresetDevice`, and device presets
   that are based on models in the literatur,
   e.g. `GokmenVlasovPresetDevice` and `IdealizedPresetDevice`. They
-  can be used defining the device field in the `RPUConfig`. (\#???)
+  can be used defining the device field in the `RPUConfig`. (\#144)
 * Added a library of config presets, such as `ReRamESPreset`,
   `Capacitor2Preset`, `TikiTakaReRamESPreset`, and many more. These can
   be used for tile configration (``rpu_config``). They specify a
-  particular device and optimizer choice. (\#???)
+  particular device and optimizer choice. (\#144)
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Option to automatically scale the digital weights into the full range of the
   simluated crossbar by applying a fixed output global factor in
   digital. (\#129)
+* Added a library of device presets that are calibrated to real
+  hardware data, namely `ReRamESPresetDevice`, `ReRamSBPresetDevice`,
+  `ECRamPresetDevice`, `CapacitorPresetDevice`, and device presets
+  that are based on models in the literatur,
+  e.g. `GokmenVlasovPresetDevice` and `IdealizedPresetDevice`. They
+  can be used defining the device field in the `RPUConfig`. (\#???)
+* Added a library of config presets, such as `ReRamESPreset`,
+  `Capacitor2Preset`, `TikiTakaReRamESPreset`, and many more. These can
+  be used for tile configration (``rpu_config``). They specify a
+  particular device and optimizer choice. (\#???)
 
 #### Fixed
 

--- a/src/aihwkit/simulator/presets/__init__.py
+++ b/src/aihwkit/simulator/presets/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Configurations presets for resistive processing units."""
+
+from .configs import (
+    # Single device configs.
+    ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, IdealizedPreset,
+    # 2-device configs.
+    ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, Idealized2Preset,
+    # 4-device configs.
+    ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset, Idealized4Preset,
+    # Tiki-taka configs.
+    TikiTakaReRamESPreset, TikiTakaReRamSBPreset, TikiTakaCapacitorPreset,
+    TikiTakaEcRamPreset, TikiTakaIdealizedPreset
+)

--- a/src/aihwkit/simulator/presets/configs.py
+++ b/src/aihwkit/simulator/presets/configs.py
@@ -1,0 +1,377 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""RPU configurations presets for resistive processing units."""
+
+from dataclasses import dataclass, field
+
+from aihwkit.simulator.configs.configs import (
+    SingleRPUConfig, UnitCellRPUConfig
+)
+from aihwkit.simulator.configs.devices import (
+    PulsedDevice, TransferCompound, UnitCell, VectorUnitCell
+)
+from aihwkit.simulator.configs.utils import (
+    IOParameters, UpdateParameters, VectorUnitCellUpdatePolicy
+)
+from aihwkit.simulator.presets.devices import (
+    CapacitorPresetDevice, EcRamPresetDevice, IdealizedPresetDevice,
+    ReRamESPresetDevice, ReRamSBPresetDevice, GokmenVlasovPresetDevice
+)
+from aihwkit.simulator.presets.utils import (
+    PresetIOParameters, PresetUpdateParameters
+)
+
+
+# Single device configs.
+
+@dataclass
+class ReRamESPreset(SingleRPUConfig):
+    """Preset configuration using a single ReRam device (based on ExpStep
+    model, see :class:`ReRamESPresetDevice`).
+    """
+
+    device: PulsedDevice = field(default_factory=ReRamESPresetDevice)
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class ReRamSBPreset(SingleRPUConfig):
+    """Preset configuration using a single ReRam device (based on
+    SoftBounds model, see :class:`ReRamSBPresetDevice`).
+    """
+
+    device: PulsedDevice = field(default_factory=ReRamSBPresetDevice)
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class CapacitorPreset(SingleRPUConfig):
+    """Preset configuration using a single capacitor device, see
+    class:`CapacitorPresetDevice`.
+    """
+
+    device: PulsedDevice = field(default_factory=CapacitorPresetDevice)
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class EcRamPreset(SingleRPUConfig):
+    """Preset configuration using a single EcRAM device, see
+    class:`EcRamPresetDevice`.
+    """
+
+    device: PulsedDevice = field(default_factory=EcRamPresetDevice)
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class IdealizedPreset(SingleRPUConfig):
+    """Preset configuration using a single idealized device, see
+    class:`IdealizedPresetDevice`.
+    """
+
+    device: PulsedDevice = field(default_factory=IdealizedPresetDevice)
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class GokmenVlasovPreset(SingleRPUConfig):
+    """Preset configuration using a single device with constant update step size, see
+    :class:`GokmenVlasovPresetDevice`.
+    """
+
+    device: PulsedDevice = field(default_factory=GokmenVlasovPresetDevice)
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+# 2-device configs.
+
+@dataclass
+class ReRamES2Preset(UnitCellRPUConfig):
+    """Preset configuration using two ReRam devices per cross-point
+    (class:`ReRamESPresetDevice`), where both are updated with random
+    selection policy for update.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[ReRamESPresetDevice(), ReRamESPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class ReRamSB2Preset(UnitCellRPUConfig):
+    """Preset configuration using two ReRam devices per cross-point
+    (class:`ReRamSBPresetDevice`), where both are updated with random
+    selection policy for update.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[ReRamSBPresetDevice(), ReRamSBPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class Capacitor2Preset(UnitCellRPUConfig):
+    """Preset configuration using two Capacitor devices per cross-point
+    (class:`CapacitorPresetDevice`), where both are updated with random
+    selection policy for update.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[CapacitorPresetDevice(), CapacitorPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class EcRam2Preset(UnitCellRPUConfig):
+    """Preset configuration using two Capacitor devices per cross-point
+    (class:`CapacitorPresetDevice`), where both are updated with random
+    selection policy for update.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[EcRamPresetDevice(), EcRamPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class Idealized2Preset(UnitCellRPUConfig):
+    """Preset configuration using two Idealized devices per cross-point
+    (class:`IdealizedPresetDevice`), where both are updated with random
+    selection policy for update.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[IdealizedPresetDevice(), IdealizedPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+# 4-device configs.
+
+@dataclass
+class ReRamES4Preset(UnitCellRPUConfig):
+    """Preset configuration using four ReRam devices per cross-point
+    (class:`ReRamESPresetDevice`), where both are updated with random
+    selection policy for update.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[ReRamESPresetDevice(), ReRamESPresetDevice(),
+                           ReRamESPresetDevice(), ReRamESPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class ReRamSB4Preset(UnitCellRPUConfig):
+    """Preset configuration using four ReRam devices per cross-point
+    (class:`ReRamSBPresetDevice`), where both are updated with random
+    selection policy for update.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[ReRamSBPresetDevice(), ReRamSBPresetDevice(),
+                           ReRamSBPresetDevice(), ReRamSBPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class Capacitor4Preset(UnitCellRPUConfig):
+    """Preset configuration using four Capacitor devices per cross-point
+    (class:`CapacitorPresetDevice`), where both are updated with random
+    selection policy for update.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[CapacitorPresetDevice(), CapacitorPresetDevice(),
+                           CapacitorPresetDevice(), CapacitorPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class EcRam4Preset(UnitCellRPUConfig):
+    """Preset configuration using four Capacitor devices per cross-point
+    (class:`CapacitorPresetDevice`), where both are updated with random
+    selection policy for update.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[EcRamPresetDevice(), EcRamPresetDevice(),
+                           EcRamPresetDevice(), EcRamPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class Idealized4Preset(UnitCellRPUConfig):
+    """Preset configuration using four Idealized devices per cross-point
+    (class:`IdealizedPresetDevice`), where both are updated with random
+    selection policy for update.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[IdealizedPresetDevice(), IdealizedPresetDevice(),
+                           IdealizedPresetDevice(), IdealizedPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+# Tiki-taka configs.
+
+@dataclass
+class TikiTakaReRamESPreset(UnitCellRPUConfig):
+    """Configuration using Tiki-taka with
+    class:`ReRamESPresetDevice` and standard ADC/DAC hardware
+    etc configuration.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: TransferCompound(
+            unit_cell_devices=[ReRamESPresetDevice(), ReRamESPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class TikiTakaReRamSBPreset(UnitCellRPUConfig):
+    """Configuration using Tiki-taka with
+    class:`ReRamSBPresetDevice` and standard ADC/DAC hardware
+    etc configuration.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: TransferCompound(
+            unit_cell_devices=[ReRamSBPresetDevice(), ReRamSBPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class TikiTakaCapacitorPreset(UnitCellRPUConfig):
+    """Configuration using Tiki-taka with
+    class:`CapacitorPresetDevice` and standard ADC/DAC hardware
+    etc configuration.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: TransferCompound(
+            unit_cell_devices=[CapacitorPresetDevice(), CapacitorPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class TikiTakaEcRamPreset(UnitCellRPUConfig):
+    """Configuration using Tiki-taka with
+    class:`EcRamPresetDevice` and standard ADC/DAC hardware
+    etc configuration.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: TransferCompound(
+            unit_cell_devices=[EcRamPresetDevice(), EcRamPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class TikiTakaIdealizedPreset(UnitCellRPUConfig):
+    """Configuration using Tiki-taka with
+    class:`IdealizedPresetDevice` and standard ADC/DAC hardware
+    etc configuration.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: TransferCompound(
+            unit_cell_devices=[IdealizedPresetDevice(), IdealizedPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)

--- a/src/aihwkit/simulator/presets/devices.py
+++ b/src/aihwkit/simulator/presets/devices.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Device configurations presets for resistive processing units."""
+
+# pylint: disable=too-many-instance-attributes
+
+from dataclasses import dataclass
+
+from aihwkit.simulator.configs.devices import (
+    ConstantStepDevice, ExpStepDevice, LinearStepDevice, SoftBoundsDevice
+)
+
+
+@dataclass
+class ReRamESPresetDevice(ExpStepDevice):
+    """Preset configuration for a single RRAM analog resistive processing
+    unit based on exp. step device.
+
+    Fit of the model :class:`ExpStepDevice` to  `Gong & al., Nat. Commun., 2018`_.
+
+    .. _`Gong & al., Nat. Commun., 2018` https://www.nature.com/articles/s41467-018-04485-1
+    """
+    # pylint: disable=invalid-name
+
+    dw_min: float = 0.00135
+    up_down: float = 0.259359
+
+    w_min: float = -1.
+    w_max: float = 1.
+
+    a: float = -0.5
+    b: float = -0.5
+    gamma_up: float = 5.
+    gamma_down: float = 5.
+    A_up: float = -1.18445
+    A_down: float = -0.081404
+
+    # Device-to-device var.
+    dw_min_dtod: float = 0.2  # a little reduced compared to SB because of non-linearity
+    w_min_dtod: float = 0.1
+    w_max_dtod: float = 0.1
+    up_down_dtod: float = 0.05
+
+    # Cycle-to_cycle.
+    dw_min_std: float = 5.0
+
+    write_noise_std: float = 75.0
+
+
+@dataclass
+class ReRamSBPresetDevice(SoftBoundsDevice):
+    """Preset configuration for a single ReRAM analog resistive processing
+    unit based on soft bounds device.
+
+    Loose fit of the model :class:`SoftBoundsDevice` to  `Gong & al., Nat. Commun., 2018`_.
+
+    Note:
+        Here it is assumed that the devices have been calibrated to the symmetry
+        point by subtracting a reference device (which is in this case not
+        explicitly modeled). For a more accurate fit see :class:`ReRamESPresetDevice`.
+
+    .. _`Gong & al., Nat. Commun., 2018` https://www.nature.com/articles/s41467-018-04485-1
+    """
+
+    dw_min: float = 0.0018
+    up_down: float = 0.0
+
+    w_min: float = -1
+    w_max: float = 1
+
+    mult_noise: bool = False
+
+    # Device-to-device var.
+    dw_min_dtod: float = 0.3
+    w_min_dtod: float = 0.3
+    w_max_dtod: float = 0.3
+    up_down_dtod: float = 0.01  # assumes symmetry point corrected.
+
+    # Cycle-to_cycle.
+    dw_min_std: float = 3.75
+
+    write_noise_std: float = 56
+
+
+@dataclass
+class CapacitorPresetDevice(LinearStepDevice):
+    """Preset configuration for a single capacitor resistive processing
+    unit based on linear step device.
+
+    Fit of the model :class:`LinearStepDevice` to  `Li & al., VLSI, 2018`_
+
+    Here some capacitor leakage is assumed as well.
+
+    Caution:
+        Capacitor leakage is applied only once per mini-batch and this
+        the size of the leakage has to be adapted by the user as it
+        depends not only on the size of the leak of the physical
+        capacitor but also on the assumptions how much physical time
+        is required for a full forward and backward cycle through the
+        network (which depends on whether one assumes pipelining or not).
+
+        The parameter ``lifetime`` needs to be adjusted accordingly.
+
+    .. _`Li & al., VLSI, 2018` https://ieeexplore.ieee.org/abstract/document/8510648
+    """
+
+    dw_min: float = 0.005
+    up_down: float = 0.0
+
+    w_min: float = -1.0
+    w_max: float = 1.0
+
+    mult_noise: bool = False
+
+    # gamma_up = slope*w_max/dw_min + 1
+    gamma_up: float = 0.05
+    gamma_down: float = 0.05
+
+    # Device-to-device var.
+    dw_min_dtod: float = 0.1
+    w_min_dtod: float = 0.07
+    w_max_dtod: float = 0.07
+    up_down_dtod: float = 0.06
+
+    gamma_up_dtod: float = 0.01
+    gamma_down_dtod: float = 0.01
+
+    # Cycle-to_cycle.
+    dw_min_std: float = 0.3
+
+    # Slope does not depend on bound.
+    mean_bound_reference: bool = True
+
+    # Leakage (in mini-batches).
+    lifetime: float = 1.0e6
+    lifetime_dtod: float = 0.3
+
+    write_noise_std: float = 0.0
+
+
+@dataclass
+class EcRamPresetDevice(LinearStepDevice):
+    """Preset configuration for a single ECRAM resistive processing
+    unit based on linear step device.
+
+    Fit of the model :class:`LinearStepDevice` to  `Tang & al., IEDM, 2018`_
+
+    .. _`Tang & al., IEDM, 2018` https://ieeexplore.ieee.org/document/8614551
+    """
+
+    dw_min: float = 0.0021
+    up_down: float = -0.0588
+
+    w_min: float = -1.0
+    w_max: float = 1.0
+
+    mult_noise: bool = False
+
+    # gamma_up = slope*w_max/dw_min + 1
+    gamma_up: float = 0.0941
+    gamma_down: float = 0.5882
+
+    # Device-to-device var.
+    dw_min_dtod: float = 0.3
+    w_min_dtod: float = 0.3
+    w_max_dtod: float = 0.3
+    up_down_dtod: float = 0.01
+
+    gamma_up_dtod: float = 0.05
+    gamma_down_dtod: float = 0.05
+
+    # Cycle-to_cycle.
+    dw_min_std: float = 0.3
+
+    # Slope does not depend on bound.
+    mean_bound_reference: bool = True
+
+    write_noise_std: float = 0.0
+
+
+@dataclass
+class IdealizedPresetDevice(ConstantStepDevice):
+    """Preset configuration using an idealized device using
+    :class:`ConstantStepDevice`.
+
+    (On average) perfectly symmetric device with 10000 steps.
+
+    Definitions are from the specifications listed in `Gokmen &
+    Vlasov, Front. Neurosci. 2016`_ (which includes a number of
+    device-to-device and cycle-to-cycle variations, see
+    :class:`PulsedDevice`), however, setting the device-to-device
+    asymmetry term to zero and increasing the number of states by
+    roughly 8 (to 10000 states).
+
+    This is the same device used for
+    `Rasch, Gokmen & Haensch, IEEE Design & Test, 2019`_.
+
+    .. _`Gokmen & Vlasov, Front. Neurosci. 2016` \
+       https://www.frontiersin.org/articles/10.3389/fnins.2016.00333/full
+    .. _`Rasch, Gokmen & Haensch, IEEE Design & Test, 2019`_ https://arxiv.org/abs/1906.02698
+    """
+
+    dw_min: float = 0.0002  # Factor 5 smaller steps.
+    dw_min_dtod: float = 0.3
+    dw_min_std: float = 0.3
+
+    up_down: float = 0.0
+    up_down_dtod: float = 0.0  # Set to zero.
+
+    w_max: float = 1.0  # Increased range.
+    w_min: float = -1.0
+
+    # Device-to-device of range.
+    w_max_dtod: float = 0.3
+    w_min_dtod: float = 0.3
+
+
+@dataclass
+class GokmenVlasovPresetDevice(ConstantStepDevice):
+    """Preset configuration using :class:`ConstantStepDevice`.
+
+    Definitions are (largely) from the specifications listed in `Gokmen &
+    Vlasov, Front. Neurosci. 2016`_ (which includes a number of device-to-device
+    and cycle-to-cycle variations, see :class:`PulsedDevice`).
+
+    Note, however, that we use some of the algorithmic optimization of the
+    follow-up papers as well and here scale everything to the weight range
+    ``-1..1``.
+
+    .. _`Gokmen & Vlasov, Front. Neurosci. 2016` \
+       https://www.frontiersin.org/articles/10.3389/fnins.2016.00333/full
+    """
+
+    dw_min: float = 0.0016  # to keep 1200 states
+    dw_min_dtod: float = 0.3
+    dw_min_std: float = 0.3
+
+    up_down: float = 0.0
+    up_down_dtod: float = 0.01
+
+    w_max: float = 1.0  # Increased range, parameter adjusted
+    w_min: float = -1.0
+
+    # Device-to-device of range.
+    w_max_dtod: float = 0.3
+    w_min_dtod: float = 0.3

--- a/src/aihwkit/simulator/presets/utils.py
+++ b/src/aihwkit/simulator/presets/utils.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utils for configurations presets for resistive processing units."""
+
+# pylint: disable=too-many-instance-attributes
+
+from dataclasses import dataclass
+
+from aihwkit.simulator.configs.utils import (
+    BoundManagementType, IOParameters, NoiseManagementType, PulseType,
+    UpdateParameters, WeightNoiseType
+)
+
+
+@dataclass
+class PresetIOParameters(IOParameters):
+    """Preset for the forward and backward pass parameters."""
+
+    bound_management: BoundManagementType = BoundManagementType.ITERATIVE
+    noise_management: NoiseManagementType = NoiseManagementType.ABS_MAX
+
+    inp_res: float = 1.0 / (2**7 - 2)  # 7 bit DAC.
+    inp_sto_round: bool = False
+
+    out_bound: float = 20.0
+    out_noise: float = 0.1
+    out_res: float = 1.0 / (2**9 - 2)  # 9 bit ADC.
+
+    # No read noise by default.
+    w_noise: float = 0.0
+    w_noise_type: WeightNoiseType = WeightNoiseType.NONE
+
+
+@dataclass
+class PresetUpdateParameters(UpdateParameters):
+    """Preset for the general update behavior.
+
+    Stochastic pulse trains with parallel update by default.
+    """
+
+    desired_bl: int = 31  # Less than 32 preferable (faster implementation).
+    pulse_type: PulseType = PulseType.STOCHASTIC_COMPRESSED
+    update_bl_management: bool = True  # Dynamically adjusts pulse train length (max 31).
+    update_management: bool = True


### PR DESCRIPTION
## Related issues

#133 

## Description

Addition of device and config presets. 

## Details

Device presets (called `XXXPresetDevice`) are parameter settings of devices, implemented by inheriting the underlying device data class. They can be used to configure a tile instead of the base classes like `ConstantStepDevice`.

Config presets (called `XXXPreset`) are parameter settings of the full `rpu_config` and could be used instead of defining ones own. They might specify a particular tile model choice and analog optimizer.  For instance, 

```python 
model = AnalogLinear(4, 2, rpu_config=TikiTakaReRamSBPreset())
```

would use Tiki-taka optimizer (using two ReRAM crossbars with the `ReRamSBPresetDevice` device model) and otherwise default parameters. As before, parameter choices can be adapted by giving keyword arguments or overwriting the field values. 
