### PR TITLE
Add API documentation for presets

### DIFF
--- a/docs/source/api/aihwkit.simulator.presets.configs.rst
+++ b/docs/source/api/aihwkit.simulator.presets.configs.rst
@@ -1,0 +1,8 @@
+aihwkit.simulator.presets.configs module
+========================================
+
+.. automodule:: aihwkit.simulator.presets.configs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: bindings_class

--- a/docs/source/api/aihwkit.simulator.presets.devices.rst
+++ b/docs/source/api/aihwkit.simulator.presets.devices.rst
@@ -1,0 +1,8 @@
+aihwkit.simulator.presets.devices module
+========================================
+
+.. automodule:: aihwkit.simulator.presets.devices
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: bindings_class

--- a/docs/source/api/aihwkit.simulator.presets.rst
+++ b/docs/source/api/aihwkit.simulator.presets.rst
@@ -1,0 +1,17 @@
+aihwkit.simulator.presets package
+=================================
+
+.. automodule:: aihwkit.simulator.presets
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   aihwkit.simulator.presets.configs
+   aihwkit.simulator.presets.devices
+   aihwkit.simulator.presets.utils

--- a/docs/source/api/aihwkit.simulator.presets.utils.rst
+++ b/docs/source/api/aihwkit.simulator.presets.utils.rst
@@ -1,0 +1,8 @@
+aihwkit.simulator.presets.utils module
+======================================
+
+.. automodule:: aihwkit.simulator.presets.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: bindings_class

--- a/docs/source/api/aihwkit.simulator.rst
+++ b/docs/source/api/aihwkit.simulator.rst
@@ -13,6 +13,7 @@ Submodules
    :maxdepth: 4
 
    aihwkit.simulator.configs
+   aihwkit.simulator.noise_models
+   aihwkit.simulator.presets
    aihwkit.simulator.rpu_base
    aihwkit.simulator.tiles
-   aihwkit.simulator.noise_models

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -9,6 +9,7 @@ API Reference
    aihwkit.simulator
    aihwkit.simulator.configs
    aihwkit.simulator.noise_models
+   aihwkit.simulator.presets
    aihwkit.simulator.tiles
    aihwkit.nn
    aihwkit.nn.functions

--- a/src/aihwkit/simulator/presets/configs.py
+++ b/src/aihwkit/simulator/presets/configs.py
@@ -61,7 +61,7 @@ class ReRamSBPreset(SingleRPUConfig):
 @dataclass
 class CapacitorPreset(SingleRPUConfig):
     """Preset configuration using a single capacitor device, see
-    class:`CapacitorPresetDevice`.
+    :class:`CapacitorPresetDevice`.
     """
 
     device: PulsedDevice = field(default_factory=CapacitorPresetDevice)
@@ -73,7 +73,7 @@ class CapacitorPreset(SingleRPUConfig):
 @dataclass
 class EcRamPreset(SingleRPUConfig):
     """Preset configuration using a single EcRAM device, see
-    class:`EcRamPresetDevice`.
+    :class:`EcRamPresetDevice`.
     """
 
     device: PulsedDevice = field(default_factory=EcRamPresetDevice)
@@ -85,7 +85,7 @@ class EcRamPreset(SingleRPUConfig):
 @dataclass
 class IdealizedPreset(SingleRPUConfig):
     """Preset configuration using a single idealized device, see
-    class:`IdealizedPresetDevice`.
+    :class:`IdealizedPresetDevice`.
     """
 
     device: PulsedDevice = field(default_factory=IdealizedPresetDevice)
@@ -111,7 +111,7 @@ class GokmenVlasovPreset(SingleRPUConfig):
 @dataclass
 class ReRamES2Preset(UnitCellRPUConfig):
     """Preset configuration using two ReRam devices per cross-point
-    (class:`ReRamESPresetDevice`), where both are updated with random
+    (:class:`ReRamESPresetDevice`), where both are updated with random
     selection policy for update.
     """
 
@@ -127,7 +127,7 @@ class ReRamES2Preset(UnitCellRPUConfig):
 @dataclass
 class ReRamSB2Preset(UnitCellRPUConfig):
     """Preset configuration using two ReRam devices per cross-point
-    (class:`ReRamSBPresetDevice`), where both are updated with random
+    (:class:`ReRamSBPresetDevice`), where both are updated with random
     selection policy for update.
     """
 
@@ -143,7 +143,7 @@ class ReRamSB2Preset(UnitCellRPUConfig):
 @dataclass
 class Capacitor2Preset(UnitCellRPUConfig):
     """Preset configuration using two Capacitor devices per cross-point
-    (class:`CapacitorPresetDevice`), where both are updated with random
+    (:class:`CapacitorPresetDevice`), where both are updated with random
     selection policy for update.
     """
 
@@ -159,7 +159,7 @@ class Capacitor2Preset(UnitCellRPUConfig):
 @dataclass
 class EcRam2Preset(UnitCellRPUConfig):
     """Preset configuration using two Capacitor devices per cross-point
-    (class:`CapacitorPresetDevice`), where both are updated with random
+    (:class:`CapacitorPresetDevice`), where both are updated with random
     selection policy for update.
     """
 
@@ -175,7 +175,7 @@ class EcRam2Preset(UnitCellRPUConfig):
 @dataclass
 class Idealized2Preset(UnitCellRPUConfig):
     """Preset configuration using two Idealized devices per cross-point
-    (class:`IdealizedPresetDevice`), where both are updated with random
+    (:class:`IdealizedPresetDevice`), where both are updated with random
     selection policy for update.
     """
 
@@ -193,7 +193,7 @@ class Idealized2Preset(UnitCellRPUConfig):
 @dataclass
 class ReRamES4Preset(UnitCellRPUConfig):
     """Preset configuration using four ReRam devices per cross-point
-    (class:`ReRamESPresetDevice`), where both are updated with random
+    (:class:`ReRamESPresetDevice`), where both are updated with random
     selection policy for update.
     """
 
@@ -210,7 +210,7 @@ class ReRamES4Preset(UnitCellRPUConfig):
 @dataclass
 class ReRamSB4Preset(UnitCellRPUConfig):
     """Preset configuration using four ReRam devices per cross-point
-    (class:`ReRamSBPresetDevice`), where both are updated with random
+    (:class:`ReRamSBPresetDevice`), where both are updated with random
     selection policy for update.
     """
 
@@ -227,7 +227,7 @@ class ReRamSB4Preset(UnitCellRPUConfig):
 @dataclass
 class Capacitor4Preset(UnitCellRPUConfig):
     """Preset configuration using four Capacitor devices per cross-point
-    (class:`CapacitorPresetDevice`), where both are updated with random
+    (:class:`CapacitorPresetDevice`), where both are updated with random
     selection policy for update.
     """
 
@@ -244,7 +244,7 @@ class Capacitor4Preset(UnitCellRPUConfig):
 @dataclass
 class EcRam4Preset(UnitCellRPUConfig):
     """Preset configuration using four Capacitor devices per cross-point
-    (class:`CapacitorPresetDevice`), where both are updated with random
+    (:class:`CapacitorPresetDevice`), where both are updated with random
     selection policy for update.
     """
 
@@ -261,7 +261,7 @@ class EcRam4Preset(UnitCellRPUConfig):
 @dataclass
 class Idealized4Preset(UnitCellRPUConfig):
     """Preset configuration using four Idealized devices per cross-point
-    (class:`IdealizedPresetDevice`), where both are updated with random
+    (:class:`IdealizedPresetDevice`), where both are updated with random
     selection policy for update.
     """
 
@@ -280,7 +280,7 @@ class Idealized4Preset(UnitCellRPUConfig):
 @dataclass
 class TikiTakaReRamESPreset(UnitCellRPUConfig):
     """Configuration using Tiki-taka with
-    class:`ReRamESPresetDevice` and standard ADC/DAC hardware
+    :class:`ReRamESPresetDevice` and standard ADC/DAC hardware
     etc configuration.
     """
 
@@ -300,7 +300,7 @@ class TikiTakaReRamESPreset(UnitCellRPUConfig):
 @dataclass
 class TikiTakaReRamSBPreset(UnitCellRPUConfig):
     """Configuration using Tiki-taka with
-    class:`ReRamSBPresetDevice` and standard ADC/DAC hardware
+    :class:`ReRamSBPresetDevice` and standard ADC/DAC hardware
     etc configuration.
     """
 
@@ -320,7 +320,7 @@ class TikiTakaReRamSBPreset(UnitCellRPUConfig):
 @dataclass
 class TikiTakaCapacitorPreset(UnitCellRPUConfig):
     """Configuration using Tiki-taka with
-    class:`CapacitorPresetDevice` and standard ADC/DAC hardware
+    :class:`CapacitorPresetDevice` and standard ADC/DAC hardware
     etc configuration.
     """
 
@@ -340,7 +340,7 @@ class TikiTakaCapacitorPreset(UnitCellRPUConfig):
 @dataclass
 class TikiTakaEcRamPreset(UnitCellRPUConfig):
     """Configuration using Tiki-taka with
-    class:`EcRamPresetDevice` and standard ADC/DAC hardware
+    :class:`EcRamPresetDevice` and standard ADC/DAC hardware
     etc configuration.
     """
 
@@ -360,7 +360,7 @@ class TikiTakaEcRamPreset(UnitCellRPUConfig):
 @dataclass
 class TikiTakaIdealizedPreset(UnitCellRPUConfig):
     """Configuration using Tiki-taka with
-    class:`IdealizedPresetDevice` and standard ADC/DAC hardware
+    :class:`IdealizedPresetDevice` and standard ADC/DAC hardware
     etc configuration.
     """
 

--- a/src/aihwkit/simulator/presets/devices.py
+++ b/src/aihwkit/simulator/presets/devices.py
@@ -28,7 +28,7 @@ class ReRamESPresetDevice(ExpStepDevice):
 
     Fit of the model :class:`ExpStepDevice` to  `Gong & al., Nat. Commun., 2018`_.
 
-    .. _`Gong & al., Nat. Commun., 2018` https://www.nature.com/articles/s41467-018-04485-1
+    .. _`Gong & al., Nat. Commun., 2018`: https://www.nature.com/articles/s41467-018-04485-1
     """
     # pylint: disable=invalid-name
 
@@ -69,7 +69,7 @@ class ReRamSBPresetDevice(SoftBoundsDevice):
         point by subtracting a reference device (which is in this case not
         explicitly modeled). For a more accurate fit see :class:`ReRamESPresetDevice`.
 
-    .. _`Gong & al., Nat. Commun., 2018` https://www.nature.com/articles/s41467-018-04485-1
+    .. _`Gong & al., Nat. Commun., 2018`: https://www.nature.com/articles/s41467-018-04485-1
     """
 
     dw_min: float = 0.0018
@@ -111,7 +111,7 @@ class CapacitorPresetDevice(LinearStepDevice):
 
         The parameter ``lifetime`` needs to be adjusted accordingly.
 
-    .. _`Li & al., VLSI, 2018` https://ieeexplore.ieee.org/abstract/document/8510648
+    .. _`Li & al., VLSI, 2018`: https://ieeexplore.ieee.org/abstract/document/8510648
     """
 
     dw_min: float = 0.005
@@ -155,7 +155,7 @@ class EcRamPresetDevice(LinearStepDevice):
 
     Fit of the model :class:`LinearStepDevice` to  `Tang & al., IEDM, 2018`_
 
-    .. _`Tang & al., IEDM, 2018` https://ieeexplore.ieee.org/document/8614551
+    .. _`Tang & al., IEDM, 2018`: https://ieeexplore.ieee.org/document/8614551
     """
 
     dw_min: float = 0.0021
@@ -205,9 +205,9 @@ class IdealizedPresetDevice(ConstantStepDevice):
     This is the same device used for
     `Rasch, Gokmen & Haensch, IEEE Design & Test, 2019`_.
 
-    .. _`Gokmen & Vlasov, Front. Neurosci. 2016` \
+    .. _`Gokmen & Vlasov, Front. Neurosci. 2016`: \
        https://www.frontiersin.org/articles/10.3389/fnins.2016.00333/full
-    .. _`Rasch, Gokmen & Haensch, IEEE Design & Test, 2019`_ https://arxiv.org/abs/1906.02698
+    .. _`Rasch, Gokmen & Haensch, IEEE Design & Test, 2019`: https://arxiv.org/abs/1906.02698
     """
 
     dw_min: float = 0.0002  # Factor 5 smaller steps.
@@ -237,7 +237,7 @@ class GokmenVlasovPresetDevice(ConstantStepDevice):
     follow-up papers as well and here scale everything to the weight range
     ``-1..1``.
 
-    .. _`Gokmen & Vlasov, Front. Neurosci. 2016` \
+    .. _`Gokmen & Vlasov, Front. Neurosci. 2016`: \
        https://www.frontiersin.org/articles/10.3389/fnins.2016.00333/full
     """
 


### PR DESCRIPTION
## Related issues

#133 

## Description

Follow-up to #144 , adding the documentation stubs for the presets to be shown in the api documentation in sphinx. In the process, fixed some warnings related to the links and the usage of `:class`.

## Details

<!-- A more elaborate description of the changes, if needed. -->
