### PR TITLE
Add test for analog presets

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -346,7 +346,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=get_layer,get_tile,get_rpu_config,bias
+generated-members=get_layer,get_tile,get_rpu_config,bias,preset_cls
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/src/aihwkit/simulator/presets/__init__.py
+++ b/src/aihwkit/simulator/presets/__init__.py
@@ -15,6 +15,7 @@
 from .configs import (
     # Single device configs.
     ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, IdealizedPreset,
+    GokmenVlasovPreset,
     # 2-device configs.
     ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, Idealized2Preset,
     # 4-device configs.

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -345,6 +345,7 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("gamma_down_dtod", &LinearStepParam::ls_decrease_down_dtod)
       .def_readwrite("allow_increasing", &LinearStepParam::ls_allow_increasing_slope)
       .def_readwrite("mean_bound_reference", &LinearStepParam::ls_mean_bound_reference)
+      .def_readwrite("write_noise_std", &LinearStepParam::write_noise_std)
       .def_readwrite("mult_noise", &LinearStepParam::ls_mult_noise)
       .def("__str__", [](LinearStepParam &self) {
         std::stringstream ss;
@@ -355,6 +356,7 @@ void declare_rpu_devices(py::module &m) {
   py::class_<SoftBoundsParam, PySoftBoundsParam, PulsedParam>(
       m, "SoftBoundsResistiveDeviceParameter")
       .def_readwrite("mult_noise", &SoftBoundsParam::ls_mult_noise)
+      .def_readwrite("write_noise_std", &SoftBoundsParam::write_noise_std)
       .def(py::init<>())
       .def("__str__", [](SoftBoundsParam &self) {
         std::stringstream ss;
@@ -370,6 +372,7 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("gamma_down", &ExpStepParam::es_gamma_down)
       .def_readwrite("a", &ExpStepParam::es_a)
       .def_readwrite("b", &ExpStepParam::es_b)
+      .def_readwrite("write_noise_std", &ExpStepParam::write_noise_std)
       .def("__str__", [](ExpStepParam &self) {
         std::stringstream ss;
         self.printToStream(ss);

--- a/tests/helpers/decorators.py
+++ b/tests/helpers/decorators.py
@@ -48,8 +48,8 @@ def parametrize_over_tiles(tiles: List) -> Callable:
 def parametrize_over_layers(layers: List, tiles: List, biases: List) -> Callable:
     """Parametrize a TestCase over different kind of layers.
 
-    The ``TestCase`` will be repeated for each combination of
-    `layer`, `tile` and `bias`.
+    The ``TestCase`` will be repeated for each combination of `layer`, `tile`
+    and `bias`.
 
     Args:
         layers: list of layer descriptions.
@@ -79,4 +79,28 @@ def parametrize_over_layers(layers: List, tiles: List, biases: List) -> Callable
     return parameterized_class(
         [object_to_dict(layer, tile, bias) for
          layer, tile, bias in product(layers, tiles, biases)],
+        class_name_func=class_name)
+
+
+def parametrize_over_presets(presets: List) -> Callable:
+    """Parametrize a TestCase over different kind of presets.
+
+    Note that this decorator expects a list of Presets, as opposed to a list of
+    helper objects.
+
+    Args:
+        presets: list of presets.
+
+    Returns:
+        The decorated TestCase.
+    """
+
+    def class_name(cls, _, params_dict):
+        """Return a user-friendly name for a parametrized test."""
+        return '{}_{}'.format(cls.__name__, params_dict['preset_cls'])
+
+    print(presets)
+
+    return parameterized_class(
+        [{'preset_cls': preset} for preset in presets],
         class_name_func=class_name)

--- a/tests/helpers/decorators.py
+++ b/tests/helpers/decorators.py
@@ -99,8 +99,6 @@ def parametrize_over_presets(presets: List) -> Callable:
         """Return a user-friendly name for a parametrized test."""
         return '{}_{}'.format(cls.__name__, params_dict['preset_cls'])
 
-    print(presets)
-
     return parameterized_class(
         [{'preset_cls': preset} for preset in presets],
         class_name_func=class_name)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -17,6 +17,7 @@ from torch import Tensor
 from aihwkit.simulator.tiles.analog import AnalogTile
 from aihwkit.simulator.presets import (
     ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, IdealizedPreset,
+    GokmenVlasovPreset,
     ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, Idealized2Preset,
     ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset, Idealized4Preset,
     TikiTakaReRamESPreset, TikiTakaReRamSBPreset, TikiTakaCapacitorPreset,
@@ -29,6 +30,7 @@ from .helpers.testcases import AihwkitTestCase
 @parametrize_over_presets(
     [
         ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, IdealizedPreset,
+        GokmenVlasovPreset,
         ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, Idealized2Preset,
         ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset, Idealized4Preset,
         TikiTakaReRamESPreset, TikiTakaReRamSBPreset, TikiTakaCapacitorPreset,

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for analog presets."""
+
+from torch import Tensor
+
+from aihwkit.simulator.tiles.analog import AnalogTile
+from aihwkit.simulator.presets import (
+    ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, IdealizedPreset,
+    ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, Idealized2Preset,
+    ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset, Idealized4Preset,
+    TikiTakaReRamESPreset, TikiTakaReRamSBPreset, TikiTakaCapacitorPreset,
+    TikiTakaEcRamPreset, TikiTakaIdealizedPreset
+)
+from .helpers.decorators import parametrize_over_presets
+from .helpers.testcases import AihwkitTestCase
+
+
+@parametrize_over_presets(
+    [
+        ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, IdealizedPreset,
+        ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, Idealized2Preset,
+        ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset, Idealized4Preset,
+        TikiTakaReRamESPreset, TikiTakaReRamSBPreset, TikiTakaCapacitorPreset,
+        TikiTakaEcRamPreset, TikiTakaIdealizedPreset
+    ]
+)
+class PresetTest(AihwkitTestCase):
+    """Test for analog presets."""
+
+    def test_tile_preset(self):
+        """Test instantiating a tile that uses a preset."""
+        out_size = 2
+        in_size = 3
+
+        rpu_config = self.preset_cls()
+        analog_tile = AnalogTile(out_size, in_size, rpu_config, bias=False)
+
+        learning_rate = 0.123
+
+        # Use [out_size, in_size] weights.
+        weights = Tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+
+        # Set some properties in the simulators.Tile.
+        analog_tile.set_learning_rate(0.123)
+        analog_tile.set_weights(weights)
+
+        # Assert over learning rate.
+        self.assertAlmostEqual(analog_tile.get_learning_rate(), learning_rate)
+        self.assertAlmostEqual(analog_tile.get_learning_rate(),
+                               analog_tile.tile.get_learning_rate())
+
+        # Assert over weights and biases.
+        tile_weights, tile_biases = analog_tile.get_weights()
+        self.assertEqual(tuple(tile_weights.shape), (out_size, in_size))
+        self.assertEqual(tile_biases, None)
+        # TODO: disabled as the comparison needs to take into account noise
+        # self.assertTensorAlmostEqual(tile_weights, weights)


### PR DESCRIPTION
## Related issues

#133 

## Description

Follow-up to #144 adding a parameterized test over the analog presets. The test itself is rather light and focusing on instantiation and the basic operation, as the rest of the functionality should already be covered for `RPUConfig` in general in other tests.

In the process:
* added `write_noise_std` as attributes of the bindings, as they were needed by some presets.
* added a parameterizer decorator
* revised the list of convenience imports

## Details

<!-- A more elaborate description of the changes, if needed. -->
