### PR TITLE
Fix write_noise_std parameter in Devices

### DIFF
--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -445,6 +445,21 @@ class LinearStepDevice(PulsedDevice):
     """Whether to use multiplicative noise instead of additive
     cycle-to-cycle noise"""
 
+    write_noise_std: float = 0.0
+    r"""Whether to use update write noise that is added to the updated
+    devices weight, while the update is done on a hidden persistent weight. The
+    update write noise is then sampled a new when the device is touched
+    again.
+
+    Thus it is:
+
+    .. math::
+       w_\text{apparent}{ij} = w_ij + \sigma_\text{write_noise}\xi
+
+    and the update is done on :math:`w_ij` but the forward sees the
+    :math:`w_\text{apparent}`.
+    """
+
 
 @dataclass
 class SoftBoundsDevice(PulsedDevice):
@@ -518,6 +533,21 @@ class ExpStepDevice(PulsedDevice):
 
     b: float = 0.2425
     """Global offset parameter"""
+
+    write_noise_std: float = 0.0
+    r"""Whether to use update write noise that is added to the updated
+    devices weight, while the update is done on a hidden persistent weight. The
+    update write noise is then sampled a new when the device is touched
+    again.
+
+    Thus it is:
+
+    .. math::
+       w_\text{apparent}{ij} = w_ij + \sigma_\text{write_noise}\xi
+
+    and the update is done on :math:`w_ij` but the forward sees the
+    :math:`w_\text{apparent}`.
+    """
 
 
 ###############################################################################

--- a/tests/helpers/decorators.py
+++ b/tests/helpers/decorators.py
@@ -97,7 +97,7 @@ def parametrize_over_presets(presets: List) -> Callable:
 
     def class_name(cls, _, params_dict):
         """Return a user-friendly name for a parametrized test."""
-        return '{}_{}'.format(cls.__name__, params_dict['preset_cls'])
+        return '{}_{}'.format(cls.__name__, params_dict['preset_cls'].__name__)
 
     return parameterized_class(
         [{'preset_cls': preset} for preset in presets],


### PR DESCRIPTION
## Related issues

#147 

## Description

Fix an oversight during #147 and #133 where the `write_noise_std` was not include in the parent `Device` definition. Additionally, fix an issue in the parametrizer where the class object instead of the class name was used in the name of the tests.

## Details

<!-- A more elaborate description of the changes, if needed. -->
