### PR TITLE
Add .cpu() method to tiles and layers

### DIFF
--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -259,6 +259,7 @@ class AnalogModuleBase(Module):
         Returns:
             This layer with its parameters, buffers and tiles in CPU.
         """
+        # pylint: disable=attribute-defined-outside-init
         super().cpu()
         self.analog_tile = self.analog_tile.cpu()  # type: BaseTile
         self.set_weights(self.weight, self.bias)
@@ -284,7 +285,7 @@ class AnalogModuleBase(Module):
         # pylint: disable=attribute-defined-outside-init
         # Note: this needs to be an in-place function, not a copy
         super().cuda(device)
-        self.analog_tile = self.analog_tile.cuda(device)  # type: BaseTile
+        self.analog_tile = self.analog_tile.cuda(device)  # type: ignore[no-redef]
         self.set_weights(self.weight, self.bias)
         return self
 

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -253,6 +253,17 @@ class AnalogModuleBase(Module):
         current_state['{}analog_tile_state'.format(prefix)] = analog_state
         return current_state
 
+    def cpu(self) -> 'AnalogModuleBase':
+        """Moves all model parameters, buffers and tiles to the CPU.
+
+        Returns:
+            This layer with its parameters, buffers and tiles in CPU.
+        """
+        super().cpu()
+        self.analog_tile = self.analog_tile.cpu()  # type: BaseTile
+        self.set_weights(self.weight, self.bias)
+        return self
+
     def cuda(
             self,
             device: Optional[Union[torch_device, str, int]] = None

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -256,6 +256,10 @@ class AnalogModuleBase(Module):
     def cpu(self) -> 'AnalogModuleBase':
         """Moves all model parameters, buffers and tiles to the CPU.
 
+        Note:
+            Please be aware that moving analog layers from GPU to CPU is
+            currently not supported.
+
         Returns:
             This layer with its parameters, buffers and tiles in CPU.
         """

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -79,7 +79,8 @@ class AnalogSequential(Sequential):
         """Moves and/or casts the parameters, buffers and analog tiles.
 
         Note:
-            TODO
+            Please be aware that moving analog layers from GPU to CPU is
+            currently not supported.
 
         Args:
             device: the desired device of the parameters, buffers and analog

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -53,6 +53,15 @@ class AnalogSequential(Sequential):
 
         return self
 
+    def cpu(
+            self
+    ) -> 'AnalogSequential':
+        super().cpu()
+
+        self._apply_to_analog(lambda m: m.cpu())
+
+        return self
+
     def cuda(
             self,
             device: Optional[Union[torch_device, str, int]] = None
@@ -69,24 +78,25 @@ class AnalogSequential(Sequential):
     ) -> 'AnalogSequential':
         """Moves and/or casts the parameters, buffers and analog tiles.
 
+        Note:
+            TODO
+
         Args:
             device: the desired device of the parameters, buffers and analog
                 tiles in this module.
 
         Returns:
             This module in the specified device.
-
-        Raises:
-            ModuleError: if the device is not a cuda device.
         """
         # pylint: disable=arguments-differ
-        if isinstance(device, torch_device):
-            if device.type != 'cuda':
-                raise ModuleError('Analog layer can only be moved to cuda')
+        device = torch_device(device)
 
         super().to(device)
 
-        self._apply_to_analog(lambda m: m.cuda(device))
+        if device.type == 'cuda':
+            self._apply_to_analog(lambda m: m.cuda(device))
+        elif device.type == 'cpu':
+            self._apply_to_analog(lambda m: m.cpu())
 
         return self
 

--- a/src/aihwkit/simulator/tiles/analog.py
+++ b/src/aihwkit/simulator/tiles/analog.py
@@ -194,6 +194,10 @@ class AnalogTile(BaseTile):
         rpu_config = rpu_config or SingleRPUConfig(device=ConstantStepDevice())
         super().__init__(out_size, in_size, rpu_config, bias, in_trans, out_trans)
 
+    def cpu(self) -> 'BaseTile':
+        """Return a copy of this tile in CPU memory."""
+        return self
+
     def cuda(
             self,
             device: Optional[Union[torch_device, str, int]] = None
@@ -267,6 +271,10 @@ class CudaAnalogTile(AnalogTile):
         # Set the cuda properties
         self.stream = current_stream()
         self.device = torch_device(current_device())
+
+    def cpu(self) -> 'BaseTile':
+        """Return a copy of this tile in CPU memory."""
+        raise CudaError('CUDA tiles cannot be moved to CPU')
 
     def cuda(
             self,

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -413,6 +413,10 @@ class BaseTile(Generic[RPUConfigGeneric]):
         """
         return self.tile.reset_columns(start_column_idx, num_columns, reset_prob)
 
+    def cpu(self) -> 'BaseTile':
+        """Return a copy of this tile in CPU memory."""
+        raise NotImplementedError
+
     def cuda(
             self,
             device: Optional[Union[torch_device, str, int]] = None

--- a/src/aihwkit/simulator/tiles/floating_point.py
+++ b/src/aihwkit/simulator/tiles/floating_point.py
@@ -112,6 +112,10 @@ class FloatingPointTile(BaseTile):
         rpu_config = rpu_config or FloatingPointRPUConfig()
         super().__init__(out_size, in_size, rpu_config, bias, in_trans, out_trans)
 
+    def cpu(self) -> 'BaseTile':
+        """Return a copy of this tile in CPU memory."""
+        return self
+
     def cuda(
             self,
             device: Optional[Union[torch_device, str, int]] = None
@@ -184,6 +188,10 @@ class CudaFloatingPointTile(FloatingPointTile):
         # Set the cuda properties
         self.stream = current_stream()
         self.device = torch_device(current_device())
+
+    def cpu(self) -> 'BaseTile':
+        """Return a copy of this tile in CPU memory."""
+        raise CudaError('CUDA tiles cannot be moved to CPU')
 
     def cuda(
             self,

--- a/src/aihwkit/simulator/tiles/inference.py
+++ b/src/aihwkit/simulator/tiles/inference.py
@@ -170,6 +170,10 @@ class InferenceTile(AnalogTile):
             weight_clip_params = parameters_to_bindings(self.rpu_config.clip)
             self.tile.clip_weights(weight_clip_params)
 
+    def cpu(self) -> 'BaseTile':
+        """Return a copy of this tile in CPU memory."""
+        return self
+
     def cuda(
             self,
             device: Optional[Union[torch_device, str, int]] = None
@@ -231,6 +235,10 @@ class CudaInferenceTile(InferenceTile):
         # Set the cuda properties
         self.stream = current_stream()
         self.device = torch_device(current_device())
+
+    def cpu(self) -> 'BaseTile':
+        """Return a copy of this tile in CPU memory."""
+        raise CudaError('CUDA tiles cannot be moved to CPU')
 
     def cuda(
             self,

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -113,7 +113,7 @@ class AnalogLayerTest(ParametrizedTestCase):
             self.assertTensorAlmostEqual(gotten_biases, tile_biases)
 
     def test_sequential_move_to_cuda(self):
-        """Test sequential cuda."""
+        """Test moving AnalogSequential to cuda (from CPU)."""
         if not cuda.is_compiled():
             raise SkipTest('not compiled with CUDA support')
 
@@ -134,7 +134,7 @@ class AnalogLayerTest(ParametrizedTestCase):
         self.assertIsInstance(layer.analog_tile, expected_class)
 
     def test_sequential_move_to_cuda_via_to(self):
-        """Test sequential cuda, using ``.to()``."""
+        """Test moving AnalogSequential to cuda (from CPU), using ``.to()``."""
         if not cuda.is_compiled():
             raise SkipTest('not compiled with CUDA support')
 
@@ -153,3 +153,34 @@ class AnalogLayerTest(ParametrizedTestCase):
 
         # Assert the tile has been moved to cuda.
         self.assertIsInstance(layer.analog_tile, expected_class)
+
+
+@parametrize_over_layers(
+    layers=[Linear, Conv2d],
+    tiles=[ConstantStep],
+    biases=[True, False]
+)
+class CpuAnalogLayerTest(ParametrizedTestCase):
+    """Analog layers tests using CPU tiles as the source."""
+
+    def test_sequential_move_to_cpu(self):
+        """Test moving AnalogSequential to CPU (from CPU)."""
+        layer = self.get_layer()
+
+        # Create a container and move to cuda.
+        model = AnalogSequential(layer)
+        model.cpu()
+
+        # Assert the tile is still on CPU.
+        self.assertIsInstance(layer.analog_tile, AnalogTile)
+
+    def test_sequential_move_to_cpu_via_to(self):
+        """Test moving AnalogSequential to CPU (from CPU), using ``.to()``."""
+        layer = self.get_layer()
+
+        # Create a container and move to cuda.
+        model = AnalogSequential(layer)
+        model.to(device('cpu'))
+
+        # Assert the tile is still on CPU.
+        self.assertIsInstance(layer.analog_tile, AnalogTile)


### PR DESCRIPTION
## Related issues

#140 

## Description

Incremental update to #140:
* add `.cpu()` methods to `Tiles`
* add `.cpu()` methods to analog layers
* update `AnalogSequential.to()`

Please note that moving tiles from GPU to CPU is still not supported with this change - an exception will be raised upon such operation. This PR attempts to get the semantics of `.to()` and `.cpu()` closer to pytorch in preparation for implementing the GPU to CPU moving logic.

## Details

<!-- A more elaborate description of the changes, if needed. -->
