### PR TITLE
Fix print call when using RPU_DEBUG

### DIFF
--- a/src/rpucuda/cuda/pulsed_weight_updater.cu
+++ b/src/rpucuda/cuda/pulsed_weight_updater.cu
@@ -169,7 +169,7 @@ void PulsedWeightUpdater<T>::tuneUpdate(
   DEBUG_OUT(
       "UpdateTuner: Using " << opt_kernel_pars->getName() << " for PWU [" << opt_kernel_pars->timing
                             << "].\n");
-  DEBUG_CALL(opt_kernel_pars.print());
+  DEBUG_CALL(opt_kernel_pars->print());
 }
 
 template <typename T>


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Small fix for allowing compilation to succeed when using the `RPU_DEBUG` flag. Credit to @maljoras actually!

## Details

<!-- A more elaborate description of the changes, if needed. -->
