### PR TITLE
Optional power-law drift during training

### DIFF
--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -80,7 +80,7 @@ class UnitCellRPUConfig(_PrintableMixin):
     """Input-output parameter setting for the backward direction."""
 
     update: UpdateParameters = field(default_factory=UpdateParameters)
-    """Parameter for the update behavior."""
+    """Parameter for the parallel analog update behavior."""
 
     def as_bindings(self) -> devices.AnalogTileParameter:
         """Return a representation of this instance as a simulator bindings object."""

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -228,7 +228,8 @@ void declare_rpu_devices(py::module &m) {
           })
       // Properties from this class.
       .def_readwrite("diffusion", &RPU::SimpleMetaParameter<T>::diffusion)
-      .def_readwrite("lifetime", &RPU::SimpleMetaParameter<T>::lifetime);
+      .def_readwrite("lifetime", &RPU::SimpleMetaParameter<T>::lifetime)
+      .def_readwrite("drift", &RPU::SimpleMetaParameter<T>::drift);
 
   py::class_<RPU::PulsedMetaParameter<T>>(m, "AnalogTileParameter")
       .def(py::init<>())
@@ -281,6 +282,20 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("out_sto_round", &RPU::IOMetaParameter<T>::out_sto_round)
       .def_readwrite("w_noise", &RPU::IOMetaParameter<T>::w_noise)
       .def_readwrite("w_noise_type", &RPU::IOMetaParameter<T>::w_noise_type);
+
+  py::class_<RPU::DriftParameter<T>>(m, "DriftParameter")
+      .def(py::init<>())
+      .def_readwrite("nu", &RPU::DriftParameter<T>::nu)
+      .def_readwrite("nu_dtod", &RPU::DriftParameter<T>::nu_dtod)
+      .def_readwrite("nu_std", &RPU::DriftParameter<T>::nu_std)
+      .def_readwrite("wg_ratio", &RPU::DriftParameter<T>::wg_ratio)
+      .def_readwrite("g_offset", &RPU::DriftParameter<T>::g_offset)
+      .def_readwrite("w_offset", &RPU::DriftParameter<T>::w_offset)
+      .def_readwrite("nu_k", &RPU::DriftParameter<T>::nu_k)
+      .def_readwrite("log_g0", &RPU::DriftParameter<T>::logG0)
+      .def_readwrite("t_0", &RPU::DriftParameter<T>::t0)
+      .def_readwrite("reset_tol", &RPU::DriftParameter<T>::reset_tol)
+      .def_readwrite("w_noise_std", &RPU::DriftParameter<T>::w_read_std);
 
   // device params
   py::class_<AbstractParam, PyAbstractParam, RPU::SimpleMetaParameter<T>>(

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
@@ -248,6 +248,24 @@ void declare_rpu_tiles(py::module &m) {
                alpha: decay scale
            )pbdoc")
       .def(
+          "drift_weights", [](Class &self, float time_since_last_call) { self.driftWeights(time_since_last_call); },
+      py::arg("time_since_last_call"),
+          R"pbdoc(
+           Drift weights according to a power law::
+
+              W = W0*(delta_t/t0)^(-nu_actual)
+
+           Applies the weight drift to all unchanged weight elements
+           (judged by ``reset_tol``) and resets the drift for those
+           that have changed (nu is not re-drawn, however). Each
+           device might have a different version of this drift.
+
+           Args:
+               time_since_last_call: This is the time between the calls (``delta_t``),
+                   typically the time to process a mini-batch for the
+                   network.
+           )pbdoc")
+      .def(
           "clip_weights",
           [](Class &self, ::RPU::WeightClipParameter &wclip_par) { self.clipWeights(wclip_par); },
           py::arg("weight_clipper_params"),

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -365,8 +365,9 @@ class BaseTile(Generic[RPUConfigGeneric]):
         """
         return self.tile.get_learning_rate()
 
+    @no_grad()
     def decay_weights(self, alpha: float = 1.0) -> None:
-        """Decays the weights once.
+        """Decays the weights once according to the decay parameters of the tile.
 
         Args:
            alpha: additional decay scale (such as LR). The base decay
@@ -377,8 +378,25 @@ class BaseTile(Generic[RPUConfigGeneric]):
         """
         return self.tile.decay_weights(alpha)
 
+    @no_grad()
+    def drift_weights(self, delta_t: float = 1.0) -> None:
+        """Drifts the weights once according to the drift parameters of the
+        tile.
+
+        See also :class:`~aihwkit.simulator.configs.utils.DriftParameter`.
+
+        Args:
+            delta_t: Time since last drift call.
+
+        Returns:
+            None.
+        """
+        return self.tile.drift_weights(delta_t)
+
+    @no_grad()
     def diffuse_weights(self) -> None:
-        """Diffuses the weights once.
+        """Diffuses the weights once according to the diffusion parameters of
+        the tile.
 
         The base diffusion rate is set during tile init.
 
@@ -387,13 +405,14 @@ class BaseTile(Generic[RPUConfigGeneric]):
         """
         return self.tile.diffuse_weights()
 
+    @no_grad()
     def reset_columns(
             self,
             start_column_idx: int = 0,
             num_columns: int = 1,
             reset_prob: float = 1.0
     ) -> None:
-        r"""Reset (a number of) columns.
+        r"""Reset (a number of) columns according to the reset parameters of the tile.
 
         Resets the weights with device-to-device and cycle-to-cycle
         variability (depending on device type), typically:

--- a/src/aihwkit/simulator/tiles/inference.py
+++ b/src/aihwkit/simulator/tiles/inference.py
@@ -131,6 +131,7 @@ class InferenceTile(AnalogTile):
                 where the devices might drift and accumulate noise. See
                 noise model used for details.
         """
+        # pylint: disable=arguments-differ
         if self.programmed_weights is None:
             self.program_weights()
 


### PR DESCRIPTION
## Related issues
#155 

## Description

Enables (optional) power-law drift during analog training, which can be conductance dependent and have device-to-device variability. If present, the drift will be applied once per minibatch only, just like the optional device-to-device variable diffusion or decay. 

## Details
The drift model is based on Oh et al (2019), see https://ieeexplore.ieee.org/document/8753712