### PR TITLE
Mixed precision compound

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -285,7 +285,8 @@ good-names=i,
            z,
            d,
            t,
-           fn
+           fn,
+           nu,
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ The format is based on [Keep a Changelog], and this project adheres to
   particular device and optimizer choice. (\#144)
 * Utility for visualization the pulse response properties of a given
   device configuration. (\#146)
+* Optional power-law drift during analog training (\#158)
+* A new abstract device (`MixedPrecisionCompound`) implementing an SGD 
+  optimizer that computes the rank update in digital (assuming digital 
+  high precision storage) and then transfers the matrix sequentually to 
+  the anlog device, instead of using the default fully parallel pulsed 
+  update. (#159)  
 
 #### Fixed
 

--- a/src/aihwkit/simulator/configs/__init__.py
+++ b/src/aihwkit/simulator/configs/__init__.py
@@ -14,5 +14,5 @@
 
 from .configs import (
     FloatingPointRPUConfig, InferenceRPUConfig, SingleRPUConfig,
-    UnitCellRPUConfig
+    UnitCellRPUConfig, DigitalRankUpdateRPUConfig
 )

--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -17,7 +17,7 @@ from typing import ClassVar, Type
 
 from aihwkit.simulator.configs.devices import (
     ConstantStepDevice, FloatingPointDevice, IdealDevice, PulsedDevice,
-    UnitCell
+    UnitCell, DigitalRankUpdateCell
 )
 from aihwkit.simulator.configs.helpers import (
     _PrintableMixin, tile_parameters_to_bindings
@@ -135,6 +135,37 @@ class InferenceRPUConfig(_PrintableMixin):
         init=False
     )
     """Parameter for the update behavior: ``NONE`` pulse type."""
+
+    def as_bindings(self) -> devices.AnalogTileParameter:
+        """Return a representation of this instance as a simulator bindings object."""
+        return tile_parameters_to_bindings(self)
+
+
+@dataclass
+class DigitalRankUpdateRPUConfig(_PrintableMixin):
+    """Configuration for an analog (unit cell) resistive processing unit
+    where the rank update is done in digital.
+
+    Note that for forward and backward, an analog crossbar is still
+    used, and during update the digitally computed rank update is
+    transferred to the analog crossbar using pulses.
+    """
+
+    bindings_class: ClassVar[Type] = devices.AnalogTileParameter
+
+    device: DigitalRankUpdateCell = field(default_factory=DigitalRankUpdateCell)
+    """Parameters that modify the behavior of the pulsed device."""
+
+    forward: IOParameters = field(default_factory=IOParameters)
+    """Input-output parameter setting for the forward direction."""
+
+    backward: IOParameters = field(default_factory=IOParameters)
+    """Input-output parameter setting for the backward direction."""
+
+    update: UpdateParameters = field(default_factory=UpdateParameters)
+    """Parameter for the analog part of the update, that is the transfer
+    from the digital buffer to the devices.
+    """
 
     def as_bindings(self) -> devices.AnalogTileParameter:
         """Return a representation of this instance as a simulator bindings object."""

--- a/src/aihwkit/simulator/configs/helpers.py
+++ b/src/aihwkit/simulator/configs/helpers.py
@@ -25,9 +25,8 @@ def parameters_to_bindings(params: Any) -> Any:
     result = params.bindings_class()
     for field, value in params.__dict__.items():
         # Convert enums to the bindings enums.
-        if field == 'unit_cell_devices':
-            # Exclude `unit_cell_devices`, as it is a special field that is not
-            # present in the bindings.
+        if field in ('unit_cell_devices', 'device'):
+            # Exclude special fields that are not present in the bindings.
             continue
 
         if isinstance(value, Enum):

--- a/src/aihwkit/simulator/presets/configs.py
+++ b/src/aihwkit/simulator/presets/configs.py
@@ -15,10 +15,11 @@
 from dataclasses import dataclass, field
 
 from aihwkit.simulator.configs.configs import (
-    SingleRPUConfig, UnitCellRPUConfig
+    SingleRPUConfig, UnitCellRPUConfig, DigitalRankUpdateRPUConfig
 )
 from aihwkit.simulator.configs.devices import (
-    PulsedDevice, TransferCompound, UnitCell, VectorUnitCell
+    PulsedDevice, TransferCompound, UnitCell, VectorUnitCell,
+    DigitalRankUpdateCell, MixedPrecisionCompound
 )
 from aihwkit.simulator.configs.utils import (
     IOParameters, UpdateParameters, VectorUnitCellUpdatePolicy
@@ -372,6 +373,98 @@ class TikiTakaIdealizedPreset(UnitCellRPUConfig):
             transfer_every=1.0,
             units_in_mbatch=True,
             ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+# Mixed precision presets
+
+@dataclass
+class MixedPrecisionReRamESPreset(DigitalRankUpdateRPUConfig):
+    """Configuration using Mixed-precision with
+    class:`ReRamESPresetDevice` and standard ADC/DAC hardware
+    etc configuration."""
+
+    device: DigitalRankUpdateCell = field(
+        default_factory=lambda: MixedPrecisionCompound(
+            device=ReRamESPresetDevice(),
+        ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class MixedPrecisionReRamSBPreset(DigitalRankUpdateRPUConfig):
+    """Configuration using Mixed-precision with
+    class:`ReRamSBPresetDevice` and standard ADC/DAC hardware
+    etc configuration."""
+
+    device: DigitalRankUpdateCell = field(
+        default_factory=lambda: MixedPrecisionCompound(
+            device=ReRamSBPresetDevice(),
+        ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class MixedPrecisionCapacitorPreset(DigitalRankUpdateRPUConfig):
+    """Configuration using Mixed-precision with
+    class:`CapacitorPresetDevice` and standard ADC/DAC hardware
+    etc configuration."""
+
+    device: DigitalRankUpdateCell = field(
+        default_factory=lambda: MixedPrecisionCompound(
+            device=CapacitorPresetDevice(),
+        ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class MixedPrecisionEcRamPreset(DigitalRankUpdateRPUConfig):
+    """Configuration using Mixed-precision with
+    class:`EcRamPresetDevice` and standard ADC/DAC hardware
+    etc configuration."""
+
+    device: DigitalRankUpdateCell = field(
+        default_factory=lambda: MixedPrecisionCompound(
+            device=EcRamPresetDevice(),
+        ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class MixedPrecisionIdealizedPreset(DigitalRankUpdateRPUConfig):
+    """Configuration using Mixed-precision with
+    class:`IdealizedPresetDevice` and standard ADC/DAC hardware
+    etc configuration."""
+
+    device: DigitalRankUpdateCell = field(
+        default_factory=lambda: MixedPrecisionCompound(
+            device=IdealizedPresetDevice(),
+        ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class MixedPrecisionGokmenVlasovPreset(DigitalRankUpdateRPUConfig):
+    """Configuration using Mixed-precision with
+    class:`GokmenVlasovPresetDevice` and standard ADC/DAC hardware
+    etc configuration."""
+
+    device: DigitalRankUpdateCell = field(
+        default_factory=lambda: MixedPrecisionCompound(
+            device=GokmenVlasovPresetDevice(),
+        ))
     forward: IOParameters = field(default_factory=PresetIOParameters)
     backward: IOParameters = field(default_factory=PresetIOParameters)
     update: UpdateParameters = field(default_factory=PresetUpdateParameters)

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base.h
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base.h
@@ -15,6 +15,8 @@
 #include "rpu_difference_device.h"
 #include "rpu_expstep_device.h"
 #include "rpu_linearstep_device.h"
+#include "rpu_mixedprec_device.h"
+#include "rpu_mixedprec_device_base.h"
 #include "rpu_pulsed.h"
 #include "rpu_simple_device.h"
 #include "rpu_transfer_device.h"

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
@@ -249,7 +249,7 @@ void declare_rpu_tiles(py::module &m) {
            )pbdoc")
       .def(
           "drift_weights", [](Class &self, float time_since_last_call) { self.driftWeights(time_since_last_call); },
-      py::arg("time_since_last_call"),
+          py::arg("time_since_last_call"),
           R"pbdoc(
            Drift weights according to a power law::
 

--- a/tests/test_rpu_configurations.py
+++ b/tests/test_rpu_configurations.py
@@ -20,9 +20,9 @@ from .helpers.decorators import parametrize_over_tiles
 from .helpers.testcases import ParametrizedTestCase
 from .helpers.tiles import (
     FloatingPoint, Ideal, ConstantStep, LinearStep,
-    ExpStep, Vector, Difference, Transfer,
+    ExpStep, Vector, Difference, Transfer, MixedPrecision,
     FloatingPointCuda, IdealCuda, ConstantStepCuda, LinearStepCuda,
-    ExpStepCuda, VectorCuda, DifferenceCuda, TransferCuda
+    ExpStepCuda, VectorCuda, DifferenceCuda, TransferCuda, MixedPrecisionCuda,
 )
 
 
@@ -64,6 +64,7 @@ class RPUConfigurationsFloatingPointTest(ParametrizedTestCase):
     Vector,
     Difference,
     Transfer,
+    MixedPrecision,
     IdealCuda,
     ConstantStepCuda,
     LinearStepCuda,
@@ -71,6 +72,7 @@ class RPUConfigurationsFloatingPointTest(ParametrizedTestCase):
     VectorCuda,
     DifferenceCuda,
     TransferCuda,
+    MixedPrecisionCuda,
 ])
 class RPUConfigurationsTest(ParametrizedTestCase):
     """Tests related to resistive processing unit configurations."""

--- a/tests/test_simulator_tiles.py
+++ b/tests/test_simulator_tiles.py
@@ -26,10 +26,10 @@ from .helpers.decorators import parametrize_over_tiles
 from .helpers.testcases import ParametrizedTestCase
 from .helpers.tiles import (
     FloatingPoint, Ideal, ConstantStep, LinearStep, SoftBounds,
-    ExpStep, Vector, Difference, Transfer, Inference,
+    ExpStep, Vector, Difference, Transfer, MixedPrecision, Inference, Reference,
     FloatingPointCuda, IdealCuda, ConstantStepCuda, LinearStepCuda,
     SoftBoundsCuda, ExpStepCuda, VectorCuda, DifferenceCuda, TransferCuda,
-    InferenceCuda, Reference, ReferenceCuda
+    InferenceCuda, ReferenceCuda, MixedPrecisionCuda
 )
 
 
@@ -43,6 +43,7 @@ from .helpers.tiles import (
     Vector,
     Difference,
     Transfer,
+    MixedPrecision,
     Inference,
     Reference,
     FloatingPointCuda,
@@ -54,6 +55,7 @@ from .helpers.tiles import (
     VectorCuda,
     DifferenceCuda,
     TransferCuda,
+    MixedPrecisionCuda,
     InferenceCuda,
     ReferenceCuda,
 ])


### PR DESCRIPTION
## Related issues

## Description

A new abstract device that implements an SGD optimizer that does *not* do the update step in fully analog mode, but instead computes the outer product in digital (assuming a high precision storage of the result) and then transfers it to the analog tile.  For details, see Nandakumar et al. (2020) https://doi.org/10.3389/fnins.2020.00406

## Details

To use this tile, one specifies it in the `rpu_config`, e.g. 
```python
rpu_config = DigitalRankUpdateRPUConfig(
device = MixedPrecisionCompound(device=ReRamESPresetDevice())
```
Presets are available as well. The mixed precision compound also supports quantization of activation and error as well as sequential transfer to the analog tile.   
