### PR TITLE
Documentation updates for simulator.configs

### DIFF
--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -164,8 +164,7 @@ class DigitalRankUpdateRPUConfig(_PrintableMixin):
 
     update: UpdateParameters = field(default_factory=UpdateParameters)
     """Parameter for the analog part of the update, that is the transfer
-    from the digital buffer to the devices.
-    """
+    from the digital buffer to the devices."""
 
     def as_bindings(self) -> devices.AnalogTileParameter:
         """Return a representation of this instance as a simulator bindings object."""

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -128,8 +128,8 @@ class PulsedDevice(_PrintableMixin):
     bindings_class: ClassVar[Type] = devices.PulsedResistiveDeviceParameter
 
     construction_seed: int = 0
-    """If not equal 0, will set a unique seed for hidden parameters
-    during construction."""
+    """If not equal 0, will set a unique seed for hidden parameters during
+    construction."""
 
     corrupt_devices_prob: float = 0.0
     """Probability for devices to be corrupt (weights fixed to random value
@@ -151,26 +151,27 @@ class PulsedDevice(_PrintableMixin):
     """Mean of the minimal update step sizes across devices and directions."""
 
     dw_min_dtod: float = 0.3
-    """Device-to-device std deviation of dw_min (in relative units to ``dw_min``)."""
+    """Device-to-device std deviation of dw_min (in relative units to
+    ``dw_min``)."""
 
     dw_min_std: float = 0.3
     r"""Cycle-to-cycle variation size of the update step (related to
     :math:`\sigma_\text{c-to-c}` above) in relative units to ``dw_min``.
 
     Note:
-        Many spread (device-to-device variation) parameters are
-        given in relative units. For instance e.g. a setting of
-        ``dw_min_std`` of 0.1 would mean 10% spread around the
-        mean and thus a resulting standard deviation
-        (:math:`\sigma_\text{c-to-c}`) of ``dw_min`` *
-        ``dw_min_std``.
+        Many spread (device-to-device variation) parameters are given in
+        relative units. For instance e.g. a setting of ``dw_min_std`` of 0.1
+        would mean 10% spread around the mean and thus a resulting standard
+        deviation (:math:`\sigma_\text{c-to-c}`) of ``dw_min`` * ``dw_min_std``.
     """
 
     enforce_consistency: bool = True
-    """Whether to enforce during initialization that max weight bounds cannot
-    be smaller than min weight bounds, and up direction step size is positive
-    and down negative. Switches the opposite values if encountered during
-    init."""
+    """Whether to enforce weight bounds consistency during initialization.
+
+    Whether to enforce that max weight bounds cannot be smaller than min
+    weight bounds, and up direction step size is positive and down negative.
+    Switches the opposite values if encountered during init.
+    """
 
     lifetime: float = 0.0
     r"""One over `decay_rate`, ie :math:`1/r_\text{decay}`."""
@@ -183,8 +184,8 @@ class PulsedDevice(_PrintableMixin):
     for the devices in the bias row."""
 
     reset: float = 0.01
-    """The reset values and spread per cross-point ``ij`` when using reset functionality
-    of the device."""
+    """The reset values and spread per cross-point ``ij`` when using reset
+    functionality of the device."""
 
     reset_dtod: float = 0.0
     """See ``reset``."""
@@ -193,18 +194,20 @@ class PulsedDevice(_PrintableMixin):
     """See ``reset``."""
 
     up_down: float = 0.0
-    r"""Up and down direction step sizes can be systematically different and also
-    vary across devices.
-    :math:`\Delta w_{ij}^d` is set during RPU initialization (for each cross-point `ij`):
+    r"""Up and down direction step sizes can be systematically different and
+    also vary across devices.
+
+    :math:`\Delta w_{ij}^d` is set during RPU initialization (for each
+    cross-point `ij`):
 
     .. math::
 
         \Delta w_{ij}^d = d\; \Delta w_\text{min}\, \left(
         1 + d \beta_{ij} + \sigma_\text{d-to-d}\xi\right)
 
-    where \xi is again a standard Gaussian. :math:`\beta_{ij}`
-    is the directional up `versus` down bias.  At initialization
-    ``up_down_dtod`` and ``up_down`` defines this bias term:
+    where \xi is again a standard Gaussian. :math:`\beta_{ij}` is the
+    directional up `versus` down bias.  At initialization ``up_down_dtod`` and
+    ``up_down`` defines this bias term:
 
     .. math::
 
@@ -212,9 +215,8 @@ class PulsedDevice(_PrintableMixin):
         \sigma_\text{up-down-dtod}
 
     where \xi is again a standard Gaussian number and
-    :math:`\beta_\text{up-down}` corresponds to
-    ``up_down``. Note that ``up_down_dtod`` is again given in
-    relative units to ``dw_min``.
+    :math:`\beta_\text{up-down}` corresponds to ``up_down``. Note that
+    ``up_down_dtod`` is again given in relative units to ``dw_min``.
     """
 
     up_down_dtod: float = 0.01
@@ -227,8 +229,10 @@ class PulsedDevice(_PrintableMixin):
     """See ``w_min_dtod``."""
 
     w_min: float = -0.6
-    """Mean of hard bounds across device cross-point `ij`. The parameters
-    ``w_min`` and ``w_max`` are used to set the min/max bounds independently.
+    """Mean of hard bounds across device cross-point `ij`.
+
+    The parameters ``w_min`` and ``w_max`` are used to set the min/max bounds
+    independently.
 
     Note:
         For this abstract device, we assume that weights can have
@@ -238,9 +242,12 @@ class PulsedDevice(_PrintableMixin):
     """
 
     w_min_dtod: float = 0.3
-    """Device-to-device variation of the hard bounds, of min and max value,
+    """Device-to-device variation of the hard bounds.
+
+    Device-to-device variation of the hard bounds, of min and max value,
     respectively. All are given in relative units to ``w_min``, or ``w_max``,
-    respectively."""
+    respectively.
+    """
 
     def as_bindings(self) -> devices.PulsedResistiveDeviceParameter:
         """Return a representation of this instance as a simulator bindings object."""
@@ -293,8 +300,8 @@ class IdealDevice(_PrintableMixin):
     bindings_class: ClassVar[Type] = devices.IdealResistiveDeviceParameter
 
     construction_seed: int = 0
-    """If not equal 0, will set a unique seed for hidden parameters
-    during construction."""
+    """If not ``0``, set a unique seed for hidden parameters during
+    construction."""
 
     diffusion: float = 0.0
     """Standard deviation of diffusion process."""
@@ -418,37 +425,35 @@ class LinearStepDevice(PulsedDevice):
     gamma_up: float = 0.0
     r"""The value of :math:`\gamma^+`.
 
-    Intuitively, a value of 0.1 means that the update step size in up
-    direction at the weight bounds is 10% decreased relative to that
-    origin :math:`w=0`.
+    Intuitively, a value of 0.1 means that the update step size in up direction
+    at the weight bounds is 10% decreased relative to that origin :math:`w=0`.
 
     Note:
-       In principle one could fix :math:`\gamma=\gamma^-=\gamma^+` since
-       up/down variation can be given by ``up_down_dtod``, see
-       :class:`~ConstantStepResistiveDevice`.
+        In principle one could fix :math:`\gamma=\gamma^-=\gamma^+` since
+        up/down variation can be given by ``up_down_dtod``, see
+        :class:`~ConstantStepResistiveDevice`.
 
     Note:
-       The hard-bounds are still observed, so that the weight cannot
-       grow beyond its bounds.
+        The hard-bounds are still observed, so that the weight cannot
+        grow beyond its bounds.
     """
 
     gamma_down: float = 0.0
-    r"""The value of :math:`\gamma^-`.
-    """
+    r"""The value of :math:`\gamma^-`."""
 
     gamma_up_dtod: float = 0.05
-    r"""Device-to-device variation for :math:`\gamma^+`, i.e. the
-    value of :math:`\gamma_\text{d-to-d}^+`.
-    """
+    r"""Device-to-device variation for :math:`\gamma^+`, i.e. the value of
+    :math:`\gamma_\text{d-to-d}^+`."""
 
     gamma_down_dtod: float = 0.05
-    r"""Device-to-device variation for :math:`\gamma^-`, i.e. the
-    value of :math:`\gamma_\text{d-to-d}^-`.
-    """
+    r"""Device-to-device variation for :math:`\gamma^-`, i.e. the value of
+    :math:`\gamma_\text{d-to-d}^-`."""
 
     allow_increasing: bool = False
-    """Whether to allow the situation where update sizes increase
-    towards the bound instead of saturating (and thus becoming smaller).
+    """Whether to allow increasing of update sizes.
+
+    Whether to allow the situation where update sizes increase towards the
+    bound instead of saturating (and thus becoming smaller).
     """
 
     mean_bound_reference: bool = True
@@ -460,17 +465,18 @@ class LinearStepDevice(PulsedDevice):
 
         \gamma_{ij}^- &=& - |\gamma^- + \gamma_\text{d-to-d}^- \xi|/b^\text{min}
 
-    where :math:`b^\text{max}` and :math:`b^\text{max}` are the
-    values given by ``w_max`` and ``w_min``, see
-    :class:`~ConstantStepResistiveDevice`.
+    where :math:`b^\text{max}` and :math:`b^\text{max}` are the values given by
+    ``w_max`` and ``w_min``, see :class:`~ConstantStepResistiveDevice`.
     """
 
     mult_noise: bool = True
-    """Whether to use multiplicative noise instead of additive
-    cycle-to-cycle noise."""
+    """Whether to use multiplicative noise instead of additive cycle-to-cycle
+    noise."""
 
     write_noise_std: float = 0.0
-    r"""Whether to use update write noise that is added to the updated
+    r"""Whether to use update write noise.
+
+    Whether to use update write noise that is added to the updated
     devices weight, while the update is done on a hidden persistent weight. The
     update write noise is then sampled a new when the device is touched
     again.
@@ -500,8 +506,8 @@ class SoftBoundsDevice(PulsedDevice):
     bindings_class: ClassVar[Type] = devices.SoftBoundsResistiveDeviceParameter
 
     mult_noise: bool = True
-    """Whether to use multiplicative noise instead of additive
-    cycle-to-cycle noise."""
+    """Whether to use multiplicative noise instead of additive cycle-to-cycle
+    noise."""
 
 
 @dataclass
@@ -559,7 +565,9 @@ class ExpStepDevice(PulsedDevice):
     """Global offset parameter"""
 
     write_noise_std: float = 0.0
-    r"""Whether to use update write noise that is added to the updated
+    r"""Whether to use update write noise.
+
+    Whether to use update write noise that is added to the updated
     devices weight, while the update is done on a hidden persistent weight. The
     update write noise is then sampled a new when the device is touched
     again.
@@ -591,8 +599,8 @@ class VectorUnitCell(UnitCell):
     bindings_class: ClassVar[Type] = devices.VectorResistiveDeviceParameter
 
     update_policy: VectorUnitCellUpdatePolicy = VectorUnitCellUpdatePolicy.ALL
-    """The update policy of which if the devices will be receiving the
-    update of a mini-batch."""
+    """The update policy of which if the devices will be receiving the update
+    of a mini-batch."""
 
     first_update_idx: int = 0
     """Device that receives the first mini-batch.
@@ -601,7 +609,6 @@ class VectorUnitCell(UnitCell):
     """
 
     gamma_vec: List[float] = field(default_factory=list, metadata={'hide_if': []})
-
     """Weighting of the unit cell devices to reduce to final weight.
 
     User-defined weightening can be given as a list if factors. If not
@@ -665,9 +672,8 @@ class ReferenceUnitCell(UnitCell):
     """Weighting of the unit cell devices to reduce to final weight.
 
     Note:
-        While user-defined weighting can be given it is suggested to
-        keep it to the default ``[1, -1]`` to implement the reference
-        device subtraction.
+        While user-defined weighting can be given it is suggested to keep it to
+        the default ``[1, -1]`` to implement the reference device subtraction.
     """
 
     def as_bindings(self) -> devices.VectorResistiveDeviceParameter:
@@ -788,72 +794,82 @@ class TransferCompound(UnitCell):
     bindings_class: ClassVar[Type] = devices.TransferResistiveDeviceParameter
 
     gamma: float = 0.0
-    r"""Weighting factor to compute the effective SGD weight from the
-    hidden matrices. The default scheme is:
+    r"""Weighting factor to compute the effective SGD weight from the hidden
+    matrices.
+
+    The default scheme is:
 
     .. math:: g^{n-1} W_0 + g^{n-2} W_1 + \ldots + g^0  W_{n-1}
     """
 
     gamma_vec: List[float] = field(default_factory=list,
                                    metadata={'hide_if': []})
-    """User-defined weightening can be given as a list if weights in
-    which case the default weightening scheme with ``gamma`` is not
-    used.
+    """User-defined weightening.
+
+    User-defined weightening can be given as a list if weights in which case
+    the default weightening scheme with ``gamma`` is not used.
     """
 
     transfer_every: float = 0.0
-    """Transfers every :math:`n` mat-vec operations (rounded to
-    multiples/ratios of m_batch for CUDA). If ``units_in_mbatch`` is
-    set, then the units are in ``m_batch`` instead of mat-vecs, which
-    is equal to the overall the weight re-use during a while
-    mini-batch.
+    """Transfers every :math:`n` mat-vec operations.
+
+    Transfers every :math:`n` mat-vec operations (rounded to multiples/ratios
+    of ``m_batch`` for CUDA). If ``units_in_mbatch`` is set, then the units are
+    in ``m_batch`` instead of mat-vecs, which is equal to the overall the
+    weight re-use during a while mini-batch.
 
     If 0 it is set to ``x_size / n_cols_per_transfer``.
 
-    The higher transfer cycles are geometrically scaled, the first is
-    set to transfer_every. Each next transfer cycle is multiplied by
-    by ``x_size / n_cols_per_transfer``.
+    The higher transfer cycles are geometrically scaled, the first is set to
+    transfer_every. Each next transfer cycle is multiplied by
+    ``x_size / n_cols_per_transfer``.
     """
 
     no_self_transfer: bool = True
-    """Whether to set the transfer rate of the last device (which is
-    applied to itself) to zero.
-    """
+    """Whether to set the transfer rate of the last device (which is applied to
+    itself) to zero."""
 
     transfer_every_vec: List[float] = field(default_factory=list,
                                             metadata={'hide_if': []})
-    """A list of :math:`n` entries, to explicitly set the transfer
-    cycles lengths. In this case, the above defaults are ignored.
+    """Transfer cycles lengths.
+
+    A list of :math:`n` entries, to explicitly set the transfer cycles lengths.
+    In this case, the above defaults are ignored.
     """
 
     units_in_mbatch: bool = True
-    """If set, then the cycle length units of ``transfer_every`` are
-    in ``m_batch`` instead of mat-vecs, which is equal to the overall
-    the weight re-use during a while mini-batch.
+    """Units for ``transfer_every``.
+
+    If set, then the cycle length units of ``transfer_every`` are in
+    ``m_batch`` instead of mat-vecs, which is equal to the overall of the
+    weight re-use during a while mini-batch.
     """
 
     n_cols_per_transfer: int = 1
-    """How many consecutive columns to read (from one tile) and write
-    (to the next tile) every transfer event. For read, the input is a
-    1-hot vector. Once the final column is reached, reading starts
-    again from the first.
+    """Number of consecutive columns to use during transfer events.
+
+    How many consecutive columns to read (from one tile) and write (to the next
+    tile) every transfer event. For read, the input is a 1-hot vector. Once the
+    final column is reached, reading starts again from the first.
     """
 
     with_reset_prob: float = 0.0
-    """Whether to apply reset of the columns that were transferred
-    with a given probability."""
+    """Whether to apply reset of the columns that were transferred with a given
+    probability."""
 
     random_column: bool = False
-    """Whether to select a random starting column for each transfer
-    event and not take the next column that was previously not
-    transferred as a starting column (the default).
+    """Whether to select a random starting column.
+
+    Whether to select a random starting column for each transfer event and not
+    take the next column that was previously not transferred as a starting
+    column (the default).
     """
 
     transfer_lr: float = 1.0
-    """Learning rate (LR) for the update step of the transfer
-    event. Per default all learning rates are identical. If
-    ``scale_transfer_lr`` is set, the transfer LR is scaled by current
-    learning rate of the SGD.
+    """Learning rate (LR) for the update step of the transfer event.
+
+    Per default all learning rates are identical. If ``scale_transfer_lr`` is
+    set, the transfer LR is scaled by current learning rate of the SGD.
 
     Note:
         LR is always a positive number, sign will be correctly
@@ -862,25 +878,30 @@ class TransferCompound(UnitCell):
 
     transfer_lr_vec: List[float] = field(default_factory=list,
                                          metadata={'hide_if': []})
-    """Transfer LR for each individual transfer in the device chain
-    can be given.
-    """
+    """Transfer LR for each individual transfer in the device chain can be
+    given."""
 
     scale_transfer_lr: bool = True
-    """Whether to give the transfer_lr in relative units, ie whether
-    to scale the transfer LR with the current LR of the SGD.
+    """Whether to give the transfer_lr in relative units.
+
+    ie. whether to scale the transfer LR with the current LR of the SGD.
     """
 
     transfer_forward: IOParameters = field(
         default_factory=IOParameters)
-    """Input-output parameters
+    """Input-output parameters that define the read of a transfer event.
+
     :class:`~AnalogTileInputOutputParameters` that define the read
     (forward) of an transfer event. For instance the amount of noise
-    or whether transfer is done using a ADC/DAC etc."""
+    or whether transfer is done using a ADC/DAC etc.
+    """
 
     transfer_update: UpdateParameters = field(
         default_factory=UpdateParameters)
-    """Update parameters :class:`~AnalogTileUpdateParameters` that
+    """Update parameters that define the type of update used for each transfer
+    event.
+
+    Update parameters :class:`~AnalogTileUpdateParameters` that
     define the type of update used for each transfer event.
     """
 
@@ -969,27 +990,34 @@ class MixedPrecisionCompound(DigitalRankUpdateCell):
     bindings_class: ClassVar[Type] = devices.MixedPrecResistiveDeviceParameter
 
     transfer_every: int = 1
-    """Transfers every :math:`n` mat-vec operations (rounded to
-    multiples/ratios of m_batch).
+    """Transfers every :math:`n` mat-vec operations.
+    Transfers every :math:`n` mat-vec operations (rounded to multiples/ratios
+    of ``m_batch``).
 
     Standard setting is 1.0 for mixed precision, but it could potentially be
     reduced to get better run time estimates.
     """
 
     n_rows_per_transfer: int = -1
-    r"""How many consecutive rows to write to the tile from the
-    :math:`\chi` matrix. -1 means full matrix read each transfer event.
+    r"""How many consecutive rows to write to the tile from the :math:`\chi`
+    matrix.
+
+    ``-1`` means full matrix read each transfer event.
     """
 
     random_row: bool = False
-    """Whether to select a random starting row for each transfer
-    event and not take the next row that was previously not
-    transferred as a starting row (the default).
+    """Whether to select a random starting row.
+
+    Whether to select a random starting row for each transfer event and not
+    take the next row that was previously not transferred as a starting row
+    (the default).
     """
 
     granularity: float = 0.0
-    r"""Granularity of the device that is used to calculate the number of
-    pulses transferred from :math:`\chi` to analog.
+    r"""Granularity of the device.
+
+    Granularity of the device that is used to calculate the number of pulses
+    transferred from :math:`\chi` to analog.
 
     If 0, it will take ``dw_min`` from the analog device used.
     """

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -107,13 +107,13 @@ class PulsedDevice(_PrintableMixin):
     .. math:: w_{ij} \leftarrow w_{ij} + \rho_{ij} \, \xi;
 
     where :math:`xi` is a standard Gaussian variable and :math:`\rho_{ij}` the
-    diffusion rate for a cross-point `ij`
+    diffusion rate for a cross-point `ij`.
 
     Note:
        If diffusion happens to move the weight beyond the hard bounds of the
        weight it is ensured to be clipped appropriately.
 
-    ** Drift **:
+    **Drift**:
 
     Optional power-law drift setting, as described in
     :class:`~aihwkit.similar.configs.utils.DriftParameter`.
@@ -963,7 +963,7 @@ class MixedPrecisionCompound(DigitalRankUpdateCell):
         details, see discussion in `Nandakumar et al. Front. in
         Neurosci. (2020)`_.
 
-    .. _`Nandakumar et al. Front. in Neurosci. (2020)`_: https://doi.org/10.3389/fnins.2020.00406
+    .. _`Nandakumar et al. Front. in Neurosci. (2020)`: https://doi.org/10.3389/fnins.2020.00406
     """
 
     bindings_class: ClassVar[Type] = devices.MixedPrecResistiveDeviceParameter

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -521,6 +521,7 @@ class SimpleDriftParameter(_PrintableMixin):
 
     It computes:
     .. math::
+
         w_{ij}*\left(\frac{t + \Delta t}{t_0}\right)^(-\nu)
     """
 
@@ -554,10 +555,11 @@ class SimpleDriftParameter(_PrintableMixin):
 class DriftParameter(SimpleDriftParameter):
     r"""Parameter for a power law drift.
 
-    The drift is based on the model described by `Oh et al (2019)`_
+    The drift is based on the model described by `Oh et al (2019)`_.
 
     It computes:
     .. math::
+
         w_{ij}*\left(\frac{t + \Delta t}{t_0}\right)^(-\nu^\text{actual}_{ij})
 
     where the drift coefficient is drawn once at the beginning and
@@ -577,19 +579,19 @@ class DriftParameter(SimpleDriftParameter):
     Gaussian noise.
 
     Note:
-       If the weight has changed from the last drift call (determined
-       by the ``reset_tol`` parameter), for instance due to update,
-       decay or noise, then the drift time :math:`t` will be reset and start
-       from new, however, the drift coefficients :math:`\nu_{ij}` are
-       *not* changed. On the other hand, if the weights has not
-       changed since last call, :math:`t` will accumulate the time.
+        If the weight has changed from the last drift call (determined
+        by the ``reset_tol`` parameter), for instance due to update,
+        decay or noise, then the drift time :math:`t` will be reset and start
+        from new, however, the drift coefficients :math:`\nu_{ij}` are
+        *not* changed. On the other hand, if the weights has not
+        changed since last call, :math:`t` will accumulate the time.
 
     Caution:
-       Note that the drift coefficient does *not* depend on the initially
-       programmed weight value at :math:`t=0` in the current
-       implementation (ie G0 is a constant for all devices), but
-       instead on the actual weight. In some materials (e.g. phase
-       changed materials), that might be not accurate.
+        Note that the drift coefficient does *not* depend on the initially
+        programmed weight value at :math:`t=0` in the current
+        implementation (ie G0 is a constant for all devices), but
+        instead on the actual weight. In some materials (e.g. phase
+        changed materials), that might be not accurate.
 
     .. _`Oh et al (2019)`: https://ieeexplore.ieee.org/document/8753712
     """

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -41,25 +41,24 @@ class BoundManagementType(Enum):
     ITERATIVE = 'Iterative'
     r"""Iteratively recomputes input scale set to :math:`\alpha\leftarrow\alpha/2`.
 
-    It iteratively recomputes the bounds up to limit of passes (given
-    by ``max_bm_factor`` or ``max_bm_res``).
+    It iteratively recomputes the bounds up to limit of passes (given by
+    ``max_bm_factor`` or ``max_bm_res``).
     """
 
     ITERATIVE_WORST_CASE = 'IterativeWorstCase'
     """Worst case bound management.
 
-    Uses ``AbsMax`` noise management for the first pass and only when
-    output bound is hit, the ``AbsMaxNPSum`` for the second. Thus, at
-    most 2 passes are computed.
+    Uses ``AbsMax`` noise management for the first pass and only when output
+    bound is hit, the ``AbsMaxNPSum`` for the second. Thus, at most 2 passes
+    are computed.
     """
 
     SHIFT = 'Shift'
     """Shift bound management.
 
-    Shifts the output by adding the difference ``output_bound -
-    max_output`` to the analog output value. This is only useful to
-    increase the dynamic range before the softmax, where the max can
-    be safely.
+    Shifts the output by adding the difference ``output_bound - max_output`` to
+    the analog output value. This is only useful to increase the dynamic range
+    before the softmax, where the max can be safely.
 
     Note:
         Shifting needs hardware implementations.
@@ -81,9 +80,12 @@ class NoiseManagementType(Enum):
     r"""Use :math:`\alpha\equiv\max{|\mathbf{x}|}`."""
 
     ABS_MAX_NP_SUM = 'AbsMaxNPSum'
-    """Takes a worst case scenario of the weight matrix to calculate the
-    input scale to ensure that output is not clipping. Assumed weight
-    value is constant and given by ``nm_assumed_wmax``."""
+    """Assume weight value is constant and given by ``nm_assumed_wmax``.
+
+    Takes a worst case scenario of the weight matrix to calculate the input
+    scale to ensure that output is not clipping. Assumed weight value is
+    constant and given by ``nm_assumed_wmax``.
+    """
 
     MAX = 'Max'
     r"""Use :math:`\alpha\equiv\max{\mathbf{x}}`."""
@@ -92,14 +94,15 @@ class NoiseManagementType(Enum):
     r"""A constant value (given by parameter ``nm_thres``)."""
 
     AVERAGE_ABS_MAX = 'AverageAbsMax'
-    """Moment-based scale input scale estimation. Computes the average
-    abs max over the mini-batch and applies ``nm_decay`` to update the
-    value with the history.
+    """Moment-based scale input scale estimation.
+
+    Computes the average abs max over the mini-batch and applies ``nm_decay``
+    to update the value with the history.
 
     Note:
-        ``nm_decay`` is ``1-momentum`` and always given in
-        mini-batches. However, the CUDA implementation does not discount
-        values within mini-batches, wheras the CPU implementation does.
+        ``nm_decay`` is ``1-momentum`` and always given in mini-batches.
+        However, the CUDA implementation does not discount values within
+        mini-batches, whereas the CPU implementation does.
     """
 
 
@@ -116,18 +119,20 @@ class WeightNoiseType(Enum):
     """No weight noise."""
 
     ADDITIVE_CONSTANT = 'AdditiveConstant'
-    r"""
-    The :math:`\xi\sim{\cal N}(0,\sigma)` thus all are Gaussian distributed.
+    r"""The :math:`\xi\sim{\cal N}(0,\sigma)` thus all are Gaussian distributed.
+
     :math:`\sigma` is determined by ``w_noise``.
     """
 
     PCM_READ = 'PCMRead'
-    """Output-referred PCM-like read noise that scales with the amount of
-    current generated for each output line and thus scales with both
-    conductance values and input strength.
+    """Output-referred PCM-like read noise.
 
-    The same general for is taken as for PCM-like statistical model of
-    the 1/f noise during inference, see
+    Output-referred PCM-like read noise that scales with the amount of current
+    generated for each output line and thus scales with both conductance values
+    and input strength.
+
+    The same general for is taken as for PCM-like statistical model of the 1/f
+    noise during inference, see
     :class:`aihwkit.simulator.noise_models.PCMLikeNoiseModel`.
     """
 
@@ -139,13 +144,17 @@ class PulseType(Enum):
     """Floating point update instead of pulses."""
 
     STOCHASTIC_COMPRESSED = 'StochasticCompressed'
-    """Generates actual stochastic bit lines. Plus and minus pulses are taken in the same pass."""
+    """Generates actual stochastic bit lines.
+
+    Plus and minus pulses are taken in the same pass.
+    """
 
     STOCHASTIC = 'Stochastic'
     """Two passes for plus and minus (only CPU)."""
 
     NONE_WITH_DEVICE = 'NoneWithDevice'
-    """Floating point like ``None``, but with analog devices (e.g. weight clipping)."""
+    """Floating point like ``None``, but with analog devices (e.g. weight
+    clipping)."""
 
     MEAN_COUNT = 'MeanCount'
     """Coincidence based in prob (:math:`p_a p_b`)."""
@@ -153,12 +162,12 @@ class PulseType(Enum):
     DETERMINISTIC_IMPLICIT = 'DeterministicImplicit'
     r"""Coincidences are computed in deterministic manner.
 
-    Coincidences are calculated by :math:`b_l x_q d_q` where ``BL`` is
-    the desired bit length (possibly subject to dynamic adjustments
-    using ``update_bl_management``) and :math:`x_q` and :math:`d_q`
-    are the quantized input and error values, respectively, normalized
-    to the range :math:`0,\ldots,1`. It can be shown that explicit bit
-    lines exist that generate these coincidences.
+    Coincidences are calculated by :math:`b_l x_q d_q` where ``BL`` is the
+    desired bit length (possibly subject to dynamic adjustments using
+    ``update_bl_management``) and :math:`x_q` and :math:`d_q` are the quantized
+    input and error values, respectively, normalized to the range
+    :math:`0,\ldots,1`. It can be shown that explicit bit lines exist that
+    generate these coincidences.
     """
 
 
@@ -172,7 +181,7 @@ class WeightModifierType(Enum):
     """Quantize the weights."""
 
     MULT_NORMAL = 'MultNormal'
-    """Mutiplicative Gaussian noise."""
+    """Multiplicative Gaussian noise."""
 
     ADD_NORMAL = 'AddNormal'
     """Additive Gaussian noise."""
@@ -206,13 +215,11 @@ class WeightClipType(Enum):
 
     LAYER_GAUSSIAN = 'LayerGaussian'
     """Calculates the second moment of the whole weight matrix and clips
-    at ``sigma`` times the result symmetrically around zero.
-    """
+    at ``sigma`` times the result symmetrically around zero."""
 
     AVERAGE_CHANNEL_MAX = 'AverageChannelMax'
     """Calculates the abs max of each output channel (row of the weight
-    matrix) and takes the average as clipping value for all.
-    """
+    matrix) and takes the average as clipping value for all."""
 
 
 class VectorUnitCellUpdatePolicy(Enum):
@@ -254,9 +261,11 @@ class IOParameters(_PrintableMixin):
     """Input bound and ranges for the digital-to-analog converter (DAC)."""
 
     inp_noise: float = 0.0
-    r"""Std deviation of Gaussian input noise (:math:`\sigma_\text{inp}`),
+    r"""Std deviation of Gaussian input noise (:math:`\sigma_\text{inp}`).
+
     i.e. noisiness of the analog input (at the stage after DAC and
-    before the multiplication)."""
+    before the multiplication).
+    """
 
     inp_res: float = 1 / (2**7 - 2)
     r"""Number of discretization steps for DAC (:math:`\le0` means infinite steps)
@@ -266,25 +275,31 @@ class IOParameters(_PrintableMixin):
     """Whether to enable stochastic rounding of DAC."""
 
     is_perfect: bool = False
-    """Short-cut to compute a perfect forward pass. If ``True``, it assumes an
-    ideal forward pass (e.g. no bound, ADC etc...). Will disregard all other
-    settings in this case."""
+    """Short-cut to compute a perfect forward pass.
+
+    If ``True``, it assumes an ideal forward pass (e.g. no bound, ADC etc...).
+    Will disregard all other settings in this case.
+    """
 
     max_bm_factor: int = 1000
-    """Maximal bound management factor. If this factor is reached then the
-    iterative process is stopped."""
+    """Maximal bound management factor.
+
+    If this factor is reached then the iterative process is stopped.
+    """
 
     max_bm_res: float = 0.25
-    """Another way to limit the maximal number of iterations of the bound
-    management. The max effective resolution number of the inputs, e.g.
-    use :math:`1/4` for 2 bits."""
+    """Limit the maximal number of iterations of the bound management.
+
+    Another way to limit the maximal number of iterations of the bound
+    management. The max effective resolution number of the inputs, e.g. use
+    :math:`1/4` for 2 bits.
+    """
 
     nm_thres: float = 0.0
     r"""Constant noise management value for ``type`` ``Constant``.
 
-    In other cases, this is a upper threshold :math:`\theta` above
-    which the noise management factor is saturated. E.g. for
-    `AbsMax`:
+    In other cases, this is a upper threshold :math:`\theta` above which the
+    noise management factor is saturated. E.g. for `AbsMax`:
 
     .. math::
         :nowrap:
@@ -294,9 +309,9 @@ class IOParameters(_PrintableMixin):
         \text{otherwise}\end{cases} \end{equation*}
 
     Caution:
-        If ``nm_thres`` is set (and type is not ``Constant``), the
-        noise management will clip some large input values, in
-        favor of having a better SNR for smaller input values.
+        If ``nm_thres`` is set (and type is not ``Constant``), the noise
+        management will clip some large input values, in favor of having a
+        better SNR for smaller input values.
     """
 
     noise_management: NoiseManagementType = NoiseManagementType.ABS_MAX
@@ -306,12 +321,17 @@ class IOParameters(_PrintableMixin):
     """Output bound and ranges for analog-to-digital converter (ADC)."""
 
     out_noise: float = 0.06
-    r"""Std deviation of Gaussian output noise (:math:`\sigma_\text{out}`),
-    i.e. noisiness of device summation at the output."""
+    r"""Std deviation of Gaussian output noise (:math:`\sigma_\text{out}`).
+
+    i.e. noisiness of device summation at the output.
+    """
 
     out_res: float = 1 / (2**9 - 2)
-    """Number of discretization steps for ADC (:math:`<=0` means infinite steps)
-    or resolution (1/steps)."""
+    """Number of discretization steps for ADC or resolution.
+
+    Number of discretization steps for ADC (:math:`<=0` means infinite steps)
+    or resolution (1/steps).
+    """
 
     out_scale: float = 1.0
     """Additional fixed scalar factor."""
@@ -341,13 +361,18 @@ class UpdateParameters(_PrintableMixin):
     bindings_class: ClassVar[Type] = devices.AnalogTileUpdateParameter
 
     desired_bl: int = 31
-    """Desired length of the pulse trains. For update BL management, it is the
-    maximal pulse train length."""
+    """Desired length of the pulse trains.
+
+    For update BL management, it is the maximal pulse train length.
+    """
 
     fixed_bl: bool = True
-    """Whether to fix the length of the pulse trains (however, see ``update_bl_management``).
+    """Whether to fix the length of the pulse trains.
 
-    In case of ``True`` (where ``dw_min`` is the mean minimal weight change step size) it is::
+    See also ``update_bl_management``.
+
+    In case of ``True`` (where ``dw_min`` is the mean minimal weight change
+    step size) it is::
 
         BL = desired_BL
         A = B =  sqrt(learning_rate / (dw_min * BL));
@@ -362,28 +387,37 @@ class UpdateParameters(_PrintableMixin):
     """
 
     pulse_type: PulseType = PulseType.STOCHASTIC_COMPRESSED
-    """Switching between different pulse types. See :class:`PulseTypeMap` for details.
+    """Switching between different pulse types.
+
+    See also :class:`PulseTypeMap` for details.
 
     Important:
-        Pulsing can also be turned off in which case
-        the update is done as if in floating point and all
-        other update related parameter are ignored.
+        Pulsing can also be turned off in which case the update is done as if
+        in floating point and all other update related parameter are ignored.
     """
 
     res: float = 0
-    """Resolution ie. bin width in ``0..1``) of the update probability for
-    the stochastic bit line generation.  Use -1 for turning discretization
-    off. Can be given as number of steps as well.
+    """Resolution of the update probability for the stochastic bit line
+    generation.
+
+    Resolution ie. bin width in ``0..1``) of the update probability for the
+    stochastic bit line generation. Use -1 for turning discretization off. Can
+    be given as number of steps as well.
     """
 
     x_res_implicit: float = 0
-    """Resolution (ie. bin width) of each quantization step for the inputs ``x`` in case
-    of ``DeterministicImplicit`` pulse trains. See :class:`PulseTypeMap` for details.
+    """Resolution of each quantization step for the inputs ``x``.
+
+    Resolution (ie. bin width) of each quantization step for the inputs ``x``
+    in case of ``DeterministicImplicit`` pulse trains. See
+    :class:`PulseTypeMap` for details.
     """
 
     d_res_implicit: float = 0
-    """Resolution (ie. bin width) of each quantization step for the error
-    ``d`` in case of `DeterministicImplicit` pulse trains. qSee
+    """Resolution of each quantization step for the error ``d``.
+
+    Resolution (ie. bin width) of each quantization step for the error ``d``
+    in case of `DeterministicImplicit` pulse trains. See
     :class:`PulseTypeMap` for details.
     """
 
@@ -399,15 +433,17 @@ class UpdateParameters(_PrintableMixin):
     """
 
     update_management: bool = True
-    r"""After the above setting an additional scaling (always on when using
-    `update_bl_management``) is applied to account for the different input strengths.
+    r"""Whether to apply additional scaling.
+
+    After the above setting an additional scaling (always on when using
+    `update_bl_management``) is applied to account for the different input
+    strengths.
     If
 
     .. math:: \gamma \equiv \max_i |x_i| / \max_j |d_j|
 
-    is the ratio between the two maximal inputs, then ``A`` is
-    additionally scaled by :math:`\gamma` and ``B`` is scaled by
-    :math:`1/\gamma`.
+    is the ratio between the two maximal inputs, then ``A`` is additionally
+    scaled by :math:`\gamma` and ``B`` is scaled by :math:`1/\gamma`.
     """
 
 
@@ -420,14 +456,14 @@ class WeightModifierParameter(_PrintableMixin):
     std_dev: float = 0.0
     """Standard deviation of the added noise to the weight matrix.
 
-    This parameter affects the modifier types ``AddNormal``,
-    ``MultNormal`` and ``DiscretizeAddNormal``.
+    This parameter affects the modifier types ``AddNormal``, ``MultNormal`` and
+    ``DiscretizeAddNormal``.
 
     Note:
-        If the parameter ``rel_to_actual_wmax`` is set then the
-        ``std_dev`` is computed in relative terms to the abs max of the
-        given weight matrix, otherwise it in relative terms to the
-        assumed max, which is set by ``assumed_wmax``.
+        If the parameter ``rel_to_actual_wmax`` is set then the ``std_dev`` is
+        computed in relative terms to the abs max of the given weight matrix,
+        otherwise it in relative terms to the assumed max, which is set by
+        ``assumed_wmax``.
     """
 
     res: float = 0.0
@@ -438,8 +474,8 @@ class WeightModifierParameter(_PrintableMixin):
     :math:`a_\text{max}` is either given by the abs max (if
     ``rel_to_actual_wmax`` is set) or ``assumed_wmax`` otherwise.
 
-    ``res`` is only used in the modifier types ``DoReFa``,
-    ``Discretize``, and ``DiscretizeAddNormal``.
+    ``res`` is only used in the modifier types ``DoReFa``, ``Discretize``, and
+    ``DiscretizeAddNormal``.
     """
 
     sto_round: bool = False
@@ -455,7 +491,8 @@ class WeightModifierParameter(_PrintableMixin):
     pdrop: float = 0.0
     """Drop connect probability.
 
-    Drop connect sets weights to zero with the given probability. This implements drop connect.
+    Drop connect sets weights to zero with the given probability. This
+    implements drop connect.
 
     Important:
         Drop connect can be used with any other modifier type in combination.
@@ -470,7 +507,8 @@ class WeightModifierParameter(_PrintableMixin):
     """
 
     rel_to_actual_wmax: bool = True
-    """Whether to calculate the abs max of the weight and apply noise relative to this number.
+    """Whether to calculate the abs max of the weight and apply noise relative
+    to this number.
 
     If set to False, ``assumed_wmax`` is taken as relative units.
     """
@@ -483,14 +521,16 @@ class WeightModifierParameter(_PrintableMixin):
     """
 
     copy_last_column: bool = False
-    """Whether to not apply noise to the last column (which usually
-    contains the bias values)."""
+    """Whether to not apply noise to the last column (which usually contains
+    the bias values)."""
 
     coeff0: float = 0.26348 / 25.0
     coeff1: float = 0.0768
     coeff2: float = -0.001877 * 25.0
-    """Coefficients for the ``POLY`` weight modifier type. See
-    :class:`WeightModifierType` for details"""
+    """Coefficients for the ``POLY`` weight modifier type.
+
+    See :class:`WeightModifierType` for details.
+    """
 
     type: WeightModifierType = WeightModifierType.COPY
     """Type of the weight modification."""
@@ -528,7 +568,10 @@ class SimpleDriftParameter(_PrintableMixin):
     bindings_class: ClassVar[Type] = devices.DriftParameter
 
     nu: float = 0.0
-    r"""Average drift :math:`\nu` value. Need to non-zero to actually use the drift."""
+    r"""Average drift :math:`\nu` value.
+
+    Need to non-zero to actually use the drift.
+    """
 
     t_0: float = 1.0
     """Time between write and first read.
@@ -540,14 +583,13 @@ class SimpleDriftParameter(_PrintableMixin):
     reset_tol: float = 1e-7
     """Reset tolerance.
 
-    This should a number smaller than the expected weight change as it
-    is used to detect any changes in the weight from the last drift
-    call. Every change to the weight above this tolerance will reset
-    the drift time.
+    This should a number smaller than the expected weight change as it is used
+    to detect any changes in the weight from the last drift call. Every change
+    to the weight above this tolerance will reset the drift time.
 
     Caution:
-       Any write noise or diffusion on the weight might thus
-       interfere with the drift.
+        Any write noise or diffusion on the weight might thus
+        interfere with the drift.
    """
 
 


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Revise the docstrings of `simulator.configs` in order to homogenize them:
* use 80 chars where possible
* convert very long one-line docstrings into multi-line
* indent tweaks
* use always "`"""` appended to the second line" for long one-line docstrings
* fix other warnings

## Details

<!-- A more elaborate description of the changes, if needed. -->
