### PR TITLE
Move constructor, forward to _AnalogConvNd

### DIFF
--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -65,6 +65,11 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
             weight_scaling_omega: float = 0.0
     ):
         # pylint: disable=too-many-arguments
+        if groups != 1:
+            raise ValueError('Only one group is supported')
+        if padding_mode != 'zeros':
+            raise ValueError('Only "zeros" padding mode is supported')
+
         # Create the tile and set the analog.
         self.in_features = self.get_tile_size(in_channels, groups, kernel_size)
         self.out_features = out_channels
@@ -180,6 +185,9 @@ class AnalogConv1d(_AnalogConvNd):
         stride = _single(stride)
         padding = _single(padding)
         dilation = _single(dilation)
+
+        if dilation != _single(1):
+            raise ValueError('Only dilation = 1 is supported')
 
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,  # type: ignore
@@ -390,6 +398,9 @@ class AnalogConv3d(_AnalogConvNd):
         stride = _triple(stride)
         padding = _triple(padding)
         dilation = _triple(dilation)
+
+        if dilation != _triple(1):
+            raise ValueError('Only dilation = 1 is supported')
 
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,  # type: ignore


### PR DESCRIPTION
## Related issues

#127 

## Description

Continuing #156 , refactor more bits into `_AnalogConvNd`:

* constructor (including the creation of the tile)
* `forward()`
* inheritance - `_AnalogConvNd` is now a child of `_ConvNd` directly

Two new methods to be specialized by the subclasses are added, in order to help the refactoring:
* `get_tile_size()` for computing the size for the analog tile
* `recalculate_indexes()` for the setting of `self.fold_indices` and `self.input_size` based on the input for the forward method.

## Details

<!-- A more elaborate description of the changes, if needed. -->
