### PR TITLE
Fix copyright year in examples

### DIFF
--- a/examples/10_plot_presets.py
+++ b/examples/10_plot_presets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# (C) Copyright 2020 IBM. All Rights Reserved.
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/examples/11_vgg8_training.py
+++ b/examples/11_vgg8_training.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2020 IBM. All Rights Reserved.
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Small follow-up to #162 fixing the copyright header.

## Details

<!-- A more elaborate description of the changes, if needed. -->
