### PR TITLE
Add note for visualization in sphinx, other tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Utility for visualization the pulse response properties of a given
   device configuration. (\#146)
 * Optional power-law drift during analog training. (\#158)
-* A new abstract device (`MixedPrecisionCompound`) implementing an SGD 
-  optimizer that computes the rank update in digital (assuming digital 
-  high precision storage) and then transfers the matrix sequentially to 
-  the analog device, instead of using the default fully parallel pulsed 
-  update. (#159)  
+* A new abstract device (`MixedPrecisionCompound`) implementing an SGD
+  optimizer that computes the rank update in digital (assuming digital
+  high precision storage) and then transfers the matrix sequentially to
+  the analog device, instead of using the default fully parallel pulsed
+  update. (#159)
 
 #### Fixed
 

--- a/docs/source/api/aihwkit.nn.modules.container.rst
+++ b/docs/source/api/aihwkit.nn.modules.container.rst
@@ -1,0 +1,8 @@
+aihwkit.nn.modules.container module
+===================================
+
+.. automodule:: aihwkit.nn.modules.container
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: randn, zeros, from_numpy

--- a/docs/source/api/aihwkit.nn.modules.rst
+++ b/docs/source/api/aihwkit.nn.modules.rst
@@ -14,5 +14,6 @@ Submodules
    :maxdepth: 4
 
    aihwkit.nn.modules.base
+   aihwkit.nn.modules.container
    aihwkit.nn.modules.conv
    aihwkit.nn.modules.linear

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -15,6 +15,7 @@ API Reference
    aihwkit.nn.functions
    aihwkit.nn.modules
    aihwkit.nn.modules.base
+   aihwkit.nn.modules.container
    aihwkit.nn.modules.conv
    aihwkit.nn.modules.linear
    aihwkit.optim

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-The preferred way to install this package is by using the Python package index::
+The preferred way to install this package is by using the `Python package index`_::
 
     pip install aihwkit
 
@@ -58,3 +58,4 @@ section.
 .. _CUDA Toolkit: https://developer.nvidia.com/accelerated-computing-toolkit
 .. _issue tracker: https://github.com/IBM/aihwkit/issues
 .. _issue: https://github.com/IBM/aihwkit/issues/52
+.. _Python package index: https://pypi.org/project/aihwkit/

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -28,6 +28,15 @@ system:
     version. More details about the ``PyTorch`` compatibility can be found in
     this `issue`_.
 
+Optional features
+-----------------
+
+The package contains optional functionality that is not installed as part of
+the default installed. In order to install the extra dependencies, the
+recommended way is by specifying the extra ``visualization`` dependencies::
+
+    pip install aihwkit[visualization]
+
 Verifying the installation
 --------------------------
 

--- a/docs/source/using_pytorch.rst
+++ b/docs/source/using_pytorch.rst
@@ -21,19 +21,19 @@ Analog layers
 An **analog layer** is a neural network module that stores its weights in an
 analog tile. The library current includes the following analog layers:
 
-* :class:`~aihwkit.nn.layers.linear.AnalogLinear`:
+* :class:`~aihwkit.nn.modules.linear.AnalogLinear`:
   applies a linear transformation to the input data. It is the counterpart
   of PyTorch `nn.Linear`_ layer.
 
-* :class:`~aihwkit.nn.layers.conv.AnalogConv1d`:
+* :class:`~aihwkit.nn.modules.conv.AnalogConv1d`:
   applies a 1D convolution over an input signal composed of several input
   planes. It is the counterpart of PyTorch `nn.Conv1d`_ layer.
 
-* :class:`~aihwkit.nn.layers.conv.AnalogConv2d`:
+* :class:`~aihwkit.nn.modules.conv.AnalogConv2d`:
   applies a 2D convolution over an input signal composed of several input
   planes. It is the counterpart of PyTorch `nn.Conv2d`_ layer.
 
-* :class:`~aihwkit.nn.layers.conv.AnalogConv3d`:
+* :class:`~aihwkit.nn.modules.conv.AnalogConv3d`:
   applies a 3D convolution over an input signal composed of several input
   planes. It is the counterpart of PyTorch `nn.Conv3d`_ layer.
 
@@ -115,7 +115,7 @@ tile.
     some of the features require manually performing them on the analog layers
     directly (instead of only on the parent module).
     Please check the rest of the document for more information about using
-    :class:`~aihwkit.nn.layers.container.AnalogSequential` as the parent class
+    :class:`~aihwkit.nn.modules.container.AnalogSequential` as the parent class
     instead of ``nn.Sequential``, for convenience.
 
 Optimizers
@@ -194,7 +194,7 @@ directly to the analog layers themselves (as opposed to applying the parent
 container).
 
 In order to bypass the need of applying the functions to the analog layers,
-you can use the :class:`~aihwkit.nn.layers.container.AnalogSequential` as both
+you can use the :class:`~aihwkit.nn.modules.container.AnalogSequential` as both
 a compatible replacement for ``nn.Sequential``, and as the superclass in case
 of custom analog modules. By using this convenience module, the operations are
 guaranteed to be applied correctly to its children. For example::

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -26,6 +26,7 @@ class AnalogSequential(Sequential):
 
     Specialization of torch ``nn.Sequential`` with extra functionality for
     handling analog layers:
+
     * correct handling of ``.cuda()`` for children modules.
     * apply analog-specific functions to all its children (drift and program
       weights).

--- a/src/aihwkit/utils/visualization.py
+++ b/src/aihwkit/utils/visualization.py
@@ -10,7 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Visualization utilities."""
+"""Visualization utilities.
+
+This module includes plotting and visualization utilities for ``aihwkit``.
+Using this module has extra dependencies that can be installed via the
+extras mechanism::
+
+    pip install aihwkit[visualization]
+"""
 
 from typing import Tuple, Any
 from copy import deepcopy


### PR DESCRIPTION
## Related issues

#141 

## Description

Add a note about installing the visualization dependencies, ie:
```
pip install aihwkit[visualization]
```
to the Sphinx documentation, and fix other small documentation issues all around.


## Details

<!-- A more elaborate description of the changes, if needed. -->
