### PR TITLE
TransferCompound CUDA floating point and memory exception fix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,17 +66,17 @@ The format is based on [Keep a Changelog], and this project adheres to
   network size and batch size cases for CUDA, in particular for
   `TransferCompound`. (\#132)
 * Fixed wrong update for `TransferCompound` in case of `transfer_every` smaller
-  than the batch size. (\#132, \#???)
+  than the batch size. (\#132, \#174)
 * Period in the modulus of `TransferCompound` could become zero which
-  caused a floating point exception. (\#???)
+  caused a floating point exception. (\174)
 * Ceil instead of round for very small transfers in `TransferCompound`
-  (to avoid zero transfer for extreme settings). (\#???)
+  (to avoid zero transfer for extreme settings). (\#174)
   
 #### Removed
 * The legacy `NumpyAnalogTile` and `NumpyFloatingPointTile` tiles have been
   finally removed. The regular, tensor-powered `aihwkit.simulator.tiles` tiles
   contain all their functionality and numerous additions. (\#122)
-* Default value for TransferCompound for `transfer_every=0` (\#???).
+* Default value for TransferCompound for `transfer_every=0` (\#174).
 
 ## [0.2.1] - 2020/11/26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,13 +66,17 @@ The format is based on [Keep a Changelog], and this project adheres to
   network size and batch size cases for CUDA, in particular for
   `TransferCompound`. (\#132)
 * Fixed wrong update for `TransferCompound` in case of `transfer_every` smaller
-  than the batch size. (\#132)
-
+  than the batch size. (\#132, \#???)
+* Period in the modulus of `TransferCompound` could become zero which
+  caused a floating point exception. (\#???)
+* Ceil instead of round for very small transfers in `TransferCompound`
+  (to avoid zero transfer for extreme settings). (\#???)
+  
 #### Removed
-
 * The legacy `NumpyAnalogTile` and `NumpyFloatingPointTile` tiles have been
   finally removed. The regular, tensor-powered `aihwkit.simulator.tiles` tiles
   contain all their functionality and numerous additions. (\#122)
+* Default value for TransferCompound for `transfer_every=0` (\#???).
 
 ## [0.2.1] - 2020/11/26
 

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -810,19 +810,21 @@ class TransferCompound(UnitCell):
     the default weightening scheme with ``gamma`` is not used.
     """
 
-    transfer_every: float = 0.0
-    """Transfers every :math:`n` mat-vec operations.
+    transfer_every: float = 1.0
+    """Transfers every :math:`n` mat-vec operations or :math:`n` batches.
 
     Transfers every :math:`n` mat-vec operations (rounded to multiples/ratios
     of ``m_batch`` for CUDA). If ``units_in_mbatch`` is set, then the units are
     in ``m_batch`` instead of mat-vecs, which is equal to the overall the
     weight re-use during a while mini-batch.
 
-    If 0 it is set to ``x_size / n_cols_per_transfer``.
+    Note:
+        If ``transfer_every`` is 0.0 *no transfer* will be made.
 
-    The higher transfer cycles are geometrically scaled, the first is set to
-    transfer_every. Each next transfer cycle is multiplied by
-    ``x_size / n_cols_per_transfer``.
+    If not given explicitely with ``transfer_every_vec``, then the higher
+    transfer cycles are geometrically scaled, the first is set to
+    transfer_every. Each next transfer cycle is multiplied by ``x_size
+    / n_cols_per_transfer``.
     """
 
     no_self_transfer: bool = True

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
@@ -248,7 +248,8 @@ void declare_rpu_tiles(py::module &m) {
                alpha: decay scale
            )pbdoc")
       .def(
-          "drift_weights", [](Class &self, float time_since_last_call) { self.driftWeights(time_since_last_call); },
+          "drift_weights",
+          [](Class &self, float time_since_last_call) { self.driftWeights(time_since_last_call); },
           py::arg("time_since_last_call"),
           R"pbdoc(
            Drift weights according to a power law::

--- a/src/rpucuda/cuda/rpucuda_vector_device.h
+++ b/src/rpucuda/cuda/rpucuda_vector_device.h
@@ -101,7 +101,7 @@ protected:
   std::vector<std::unique_ptr<CudaContext>> context_vec_;
   std::vector<std::unique_ptr<PulsedRPUDeviceCudaBase<T>>> rpucuda_device_vec_;
   int current_device_idx_ = 0;
-  unsigned long int current_update_idx_ = 0;
+  uint64_t current_update_idx_ = 0;
   std::unique_ptr<CudaArray<T>> dev_reduce_weightening_ = nullptr;
 
 private:

--- a/src/rpucuda/rpu_transfer_device.cpp
+++ b/src/rpucuda/rpu_transfer_device.cpp
@@ -161,9 +161,7 @@ void TransferRPUDeviceMetaParameter<T>::initializeWithSize(int x_size, int d_siz
     RPU_WARNING("too many transfers in one shot. Use x_size instead.");
   }
 
-  if (!transfer_every) {
-    transfer_every = (T)x_size / n_cols_per_transfer;
-  }
+  // TODO: make an default value, where the value of the transfer depends on  x_size
 
   if (transfer_every_vec.size() == 0) {
     T n = transfer_every;
@@ -343,9 +341,9 @@ template <typename T>
 int TransferRPUDevice<T>::getTransferEvery(int from_device_idx, int m_batch) const {
 
   if (getPar().units_in_mbatch) {
-    return MAX(RPU_ROUNDFUN(transfer_every_[from_device_idx] * m_batch), 0);
+    return MAX(ceil(transfer_every_[from_device_idx] * m_batch), 0);
   } else {
-    return MAX(RPU_ROUNDFUN(transfer_every_[from_device_idx]), 0);
+    return MAX(round(transfer_every_[from_device_idx]), 0);
   }
 }
 


### PR DESCRIPTION
## Related issues

Issue with `TransferCompound` for CUDA if `transfer_every` is smaller than 1 (in case of `units_in_mbatch`) or smaller than the re-use factor.  

## Description

* BUGFIX: For `TransferCompound` in case of CUDA and transfer every that was smaller than the batch size, the size of the update memory was wrong
* Ceil instead of round for small fractional numbers of the `transfer_every` to not skip small transfers
* Removed the `transfer_every=0` default setting, which made no sense. Now the default setting is 1 for the `TransferCompound`
* BUGFIX: period in the modulus could become zero which caused a floating point exception in some cases

