### PR TITLE
Bump minimal torch version to 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,14 +81,14 @@ jobs:
     stage: Test multiple python versions
     python: "3.8"
 
-  - name: "Compile and test. Python 3.6, Torch 1.5"
+  - name: "Compile and test. Python 3.6, Torch 1.7.1"
     <<: *job_compile_common
     stage: Test multiple python versions
     python: "3.6"
     install:
       # Set the python executable, to force cmake picking the right one.
       - PYTHON_EXECUTABLE=~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python$TRAVIS_PYTHON_VERSION
-      - pip install "torch==1.5.1"
+      - pip install "torch==1.7.1"
       - pip install -r requirements.txt pytest
       # Install the package in editable mode.
       - VERBOSE=1 pip install -v -e ".[visualization]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,12 @@ The format is based on [Keep a Changelog], and this project adheres to
   update. (\#159)
 * A new `aihwkit.experiments` module has been added that allows creating and
   running specific high-level use cases (for example, neural network training)
-  conveniently. (\#171, \#172) 
+  conveniently. (\#171, \#172)
+
+#### Changed
+
+* The minimal PyTorch version has been bumped to `1.7+`. Please recompile your
+  library and update the dependencies accordingly. (\#176)
 
 #### Fixed
 
@@ -71,8 +76,9 @@ The format is based on [Keep a Changelog], and this project adheres to
   caused a floating point exception. (\174)
 * Ceil instead of round for very small transfers in `TransferCompound`
   (to avoid zero transfer for extreme settings). (\#174)
-  
+
 #### Removed
+
 * The legacy `NumpyAnalogTile` and `NumpyFloatingPointTile` tiles have been
   finally removed. The regular, tensor-powered `aihwkit.simulator.tiles` tiles
   contain all their functionality and numerous additions. (\#122)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx==3.1.2
 sphinx-rtd-theme==0.5.0
 recommonmark==0.6.0
-torch>=1.5
+torch>=1.7
 matplotlib

--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -35,7 +35,7 @@ C++11 compatible compiler
 `scikit-build`_                  0.11.0+
 `Python 3 development headers`_  3.6+
 BLAS implementation                        `OpenBLAS`_ or `Intel MKL`_
-`PyTorch`_                       1.5+      The libtorch library and headers are needed [#f1]_
+`PyTorch`_                       1.7+      The libtorch library and headers are needed [#f1]_
 `OpenMP`_                        11.0.0+   Optional, OpenMP library and headers [#f2]_
 CUDA                             9.0+      Optional, for GPU-enabled simulator
 `Nvidia CUB`_                    1.8.0     Optional, for GPU-enabled simulator [#f4]_

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cmake>=3.18
 scikit-build>=0.11.1
 pybind11>=2.6.2
 # Runtime dependencies.
-torch>=1.5
+torch>=1.7
 torchvision
 scipy
 requests>=2.25,<3

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import find_packages
 from skbuild import setup
 
 INSTALL_REQUIRES = [
-    'torch{}'.format(os.getenv('TORCH_VERSION_SPECIFIER', '>=1.5')),
+    'torch{}'.format(os.getenv('TORCH_VERSION_SPECIFIER', '>=1.7')),
     'torchvision',
     'scipy',
     'requests>=2.25,<3',


### PR DESCRIPTION
## Related issues

#52 

## Description

Preparing for the next release, bump the minimal torch version to `1.7` instead of `1.5`. The latest torch release is `1.8`, and `1.5` is lagging behind and causing some issues with the new dependencies (`torchvision`) - while `1.6` is still compatible, bumping the minimal requirements to the latests two torch releases seems like a reasonable compromise.

## Details

<!-- A more elaborate description of the changes, if needed. -->
