### PR TITLE
Show inherited members for presets in sphinx

### DIFF
--- a/docs/source/api/aihwkit.simulator.presets.devices.rst
+++ b/docs/source/api/aihwkit.simulator.presets.devices.rst
@@ -6,3 +6,4 @@ aihwkit.simulator.presets.devices module
    :undoc-members:
    :show-inheritance:
    :exclude-members: bindings_class
+   :inherited-members:

--- a/docs/source/api/aihwkit.simulator.presets.utils.rst
+++ b/docs/source/api/aihwkit.simulator.presets.utils.rst
@@ -6,3 +6,4 @@ aihwkit.simulator.presets.utils module
    :undoc-members:
    :show-inheritance:
    :exclude-members: bindings_class
+   :inherited-members:


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Adjust the sphinx apidoc in order to show inherited members for `presets.devices` and `presets.utils`, as those classes contain a number of parameters (some from their parent class) that are convenient to view at a glance.

## Details

<!-- A more elaborate description of the changes, if needed. -->
