### PR TITLE
Rename decorator for experiment, template

### DIFF
--- a/tests/helpers/decorators.py
+++ b/tests/helpers/decorators.py
@@ -104,7 +104,7 @@ def parametrize_over_presets(presets: List) -> Callable:
         class_name_func=class_name)
 
 
-def parametrize_over_models(models: List) -> Callable:
+def parametrize_over_experiments(models: List) -> Callable:
     """Parametrize a TestCase over different kind of experiments.
 
     Args:

--- a/tests/helpers/experiments.py
+++ b/tests/helpers/experiments.py
@@ -250,8 +250,8 @@ class Vgg8SVHN:
         )
 
 
-class Vgg8SVHNScaling:
-    """Vgg8; with SVHN (and weight scaling)."""
+class Vgg8SVHNTikiTaka:
+    """Vgg8; with SVHN (and Tiki-Taka)."""
 
     def get_experiment(
             self,

--- a/tests/test_experiment_runners.py
+++ b/tests/test_experiment_runners.py
@@ -20,7 +20,7 @@ from torch import device as torch_device
 from aihwkit.experiments.runners.local import LocalRunner
 from aihwkit.simulator.rpu_base import cuda
 
-from .helpers.decorators import parametrize_over_models
+from .helpers.decorators import parametrize_over_experiments
 from .helpers.experiments import (
     FullyConnectedFashionMNIST, FullyConnectedFashionMNISTTikiTaka,
     LeNet5FashionMNIST,
@@ -29,7 +29,7 @@ from .helpers.experiments import (
 from .helpers.testcases import AihwkitTestCase
 
 
-@parametrize_over_models([
+@parametrize_over_experiments([
     FullyConnectedFashionMNIST, FullyConnectedFashionMNISTTikiTaka,
     LeNet5FashionMNIST,
     Vgg8SVHN, Vgg8SVHNScaling

--- a/tests/test_experiment_runners.py
+++ b/tests/test_experiment_runners.py
@@ -24,7 +24,7 @@ from .helpers.decorators import parametrize_over_experiments
 from .helpers.experiments import (
     FullyConnectedFashionMNIST, FullyConnectedFashionMNISTTikiTaka,
     LeNet5FashionMNIST,
-    Vgg8SVHN, Vgg8SVHNScaling
+    Vgg8SVHN, Vgg8SVHNTikiTaka
 )
 from .helpers.testcases import AihwkitTestCase
 
@@ -32,7 +32,7 @@ from .helpers.testcases import AihwkitTestCase
 @parametrize_over_experiments([
     FullyConnectedFashionMNIST, FullyConnectedFashionMNISTTikiTaka,
     LeNet5FashionMNIST,
-    Vgg8SVHN, Vgg8SVHNScaling
+    Vgg8SVHN, Vgg8SVHNTikiTaka
 ])
 class TestLocalRunner(AihwkitTestCase):
     """Test LocalRunner."""

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -15,7 +15,7 @@
 from aihwkit.cloud.converter.v1.training import BasicTrainingConverter
 from aihwkit.nn.modules.base import AnalogModuleBase
 
-from .helpers.decorators import parametrize_over_models
+from .helpers.decorators import parametrize_over_experiments
 from .helpers.experiments import (
     FullyConnectedFashionMNIST, FullyConnectedFashionMNISTTikiTaka,
     LeNet5FashionMNIST,
@@ -24,7 +24,7 @@ from .helpers.experiments import (
 from .helpers.testcases import AihwkitTestCase
 
 
-@parametrize_over_models([
+@parametrize_over_experiments([
     FullyConnectedFashionMNIST, FullyConnectedFashionMNISTTikiTaka,
     LeNet5FashionMNIST,
     Vgg8SVHN, Vgg8SVHNScaling

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -19,7 +19,7 @@ from .helpers.decorators import parametrize_over_experiments
 from .helpers.experiments import (
     FullyConnectedFashionMNIST, FullyConnectedFashionMNISTTikiTaka,
     LeNet5FashionMNIST,
-    Vgg8SVHN, Vgg8SVHNScaling
+    Vgg8SVHN, Vgg8SVHNTikiTaka
 )
 from .helpers.testcases import AihwkitTestCase
 
@@ -27,7 +27,7 @@ from .helpers.testcases import AihwkitTestCase
 @parametrize_over_experiments([
     FullyConnectedFashionMNIST, FullyConnectedFashionMNISTTikiTaka,
     LeNet5FashionMNIST,
-    Vgg8SVHN, Vgg8SVHNScaling
+    Vgg8SVHN, Vgg8SVHNTikiTaka
 ])
 class TestBasicTraining(AihwkitTestCase):
     """Test BasicTraining Experiment."""


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Rename the `parametrize_over_models` decorator to a more accurate `parametrize_over_experiments`. Rename one of the example experiments introduced in #178 to better reflect its contents.

## Details

<!-- A more elaborate description of the changes, if needed. -->
