### PR TITLE
Include experiments cloud runner

### DIFF
--- a/src/aihwkit/experiments/experiments/training.py
+++ b/src/aihwkit/experiments/experiments/training.py
@@ -39,6 +39,12 @@ class BasicTraining(Experiment):
       items have getters that are used by the ``Workers`` that execute the
       experiments and by the training loop.
     * the training algorithm, with the main entry point being ``train()``.
+
+    Note:
+        When executing a ``BasicTraining`` in the cloud, additional constraints
+        are applied to the data. For example, the model is restricted to
+        sequential layers of specific types; the dataset choices are limited,
+        etc. Please check the ``CloudRunner`` documentation.
     """
 
     def __init__(

--- a/src/aihwkit/experiments/runners/__init__.py
+++ b/src/aihwkit/experiments/runners/__init__.py
@@ -14,4 +14,5 @@
 
 # Convenience imports for easier access to the classes.
 
+from aihwkit.experiments.runners.cloud import CloudRunner
 from aihwkit.experiments.runners.local import LocalRunner

--- a/src/aihwkit/experiments/runners/cloud.py
+++ b/src/aihwkit/experiments/runners/cloud.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Base class for an Experiment Runner."""
+
+from typing import Any, List, Optional
+
+from aihwkit.cloud.client.entities import CloudExperiment
+from aihwkit.cloud.client.exceptions import CredentialsError
+from aihwkit.cloud.client.session import ApiSession
+from aihwkit.cloud.client.utils import ClientConfiguration
+from aihwkit.cloud.client.v1.api_client import ApiClient
+from aihwkit.experiments import BasicTraining
+from aihwkit.experiments.runners.base import Runner
+
+
+class CloudRunner(Runner):
+    """Runner that executes Experiments in the AIHW Composer cloud.
+
+    Class that allows executing Experiments in the cloud.
+    """
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self,
+                 api_url: Optional[str] = None,
+                 api_token: Optional[str] = None):
+        """CloudRunner constructor.
+
+        Note:
+            If no ``api_token`` or ``api_url`` is provided, this class will
+            attempt to read them from the local configuration file (by default,
+            at ``~/.config/aihwkit/aihwkit.conf`` or  environment variables
+            (``AIHW_API_TOKEN``).
+
+        Args:
+            api_url: the URL of the AIHW Composer API.
+            api_token: the API token for authentication.
+
+        Raises:
+            CredentialsError: if no credentials could be found.
+        """
+        # Attempt to load credentials if not present.
+        if not api_url or not api_token:
+            config = ClientConfiguration()
+            api_url = api_url or config.url
+            api_token = api_token or config.token
+
+            if not api_url or not api_token:
+                raise CredentialsError('No credentials could be found')
+
+        self.api_url = api_url
+        self.api_token = api_token
+
+        # Authenticate.
+        self.session = ApiSession(self.api_url, self.api_token)
+        self.api_client = ApiClient(self.session)
+
+    def get_cloud_experiment(self, id_: str) -> CloudExperiment:
+        """Return a single cloud experiment by id.
+
+        Args:
+            id_: the identifier of the cloud experiment.
+
+        Returns:
+            A ``CloudExperiment``.
+        """
+        return self.api_client.experiment_get(id_)
+
+    def list_cloud_experiments(self) -> List[CloudExperiment]:
+        """Return a list of cloud experiments.
+
+        Returns:
+            A list of ``CloudExperiments``.
+        """
+        return self.api_client.experiments_list()
+
+    def run(  # type: ignore[override]
+            self,
+            experiment: BasicTraining,
+            name: str = '',
+            **_: Any
+    ) -> CloudExperiment:
+        """Run a single Experiment.
+
+        Starts the execution of an Experiment in the cloud. Upon successful
+        invocation, this method will return a ``CloudExperiment`` object that
+        can be used for inspecting the status of the remote execution.
+
+        Note:
+            Please be aware that the ``experiment`` is subjected to some
+            constraints compared to local running of experiments.
+
+        Args:
+            experiment: the experiment to be executed.
+            name: an optional name for the experiment.
+            _: extra arguments for the runner.
+
+        Returns:
+            A ``CloudExperiment`` which represents the remote experiment.
+        """
+        # pylint: disable=arguments-differ
+        # Generate an experiment name if not given.
+        if not name:
+            name = 'aihwkit cloud experiment ({}, {} layers)'.format(
+                experiment.dataset.__name__,
+                len(experiment.model)
+            )
+
+        return self.api_client.experiment_create(experiment, name=name)

--- a/tests/test_cloud_runner.py
+++ b/tests/test_cloud_runner.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the AIHW Composer cloud runner."""
+
+import os
+from unittest import SkipTest
+
+from aihwkit.cloud.client.entities import CloudExperiment, CloudJobStatus
+from aihwkit.cloud.client.utils import ClientConfiguration
+from aihwkit.experiments.experiments.training import BasicTraining
+from aihwkit.experiments.runners.cloud import CloudRunner
+
+from .helpers.decorators import parametrize_over_experiments
+from .helpers.experiments import FullyConnectedFashionMNIST
+from .helpers.testcases import AihwkitTestCase
+
+
+class CloudRunnerTest(AihwkitTestCase):
+    """Tests for the AIHW Composer CloudRunner."""
+
+    def setUp(self) -> None:
+        config = ClientConfiguration()
+        if not config.token:
+            raise SkipTest('API token not found')
+
+        self.api_url = config.url
+        self.api_token = config.token
+
+    def test_list_cloud_experiments(self):
+        """Test listing cloud experiments."""
+        cloud_runner = CloudRunner(self.api_url, self.api_token)
+        cloud_experiments = cloud_runner.list_cloud_experiments()
+
+        self.assertIsInstance(cloud_experiments, list)
+        self.assertTrue(all(isinstance(experiment, CloudExperiment)
+                            for experiment in cloud_experiments))
+
+    def test_get_cloud_experiment(self):
+        """Test getting an experiment from an execution."""
+        cloud_runner = CloudRunner(self.api_url, self.api_token)
+        experiments = cloud_runner.list_cloud_experiments()
+        if len(experiments) == 0:
+            raise SkipTest('No executions found')
+
+        listed_experiment = experiments[0]
+        cloud_experiment = cloud_runner.get_cloud_experiment(listed_experiment.id_)
+
+        self.assertIsInstance(cloud_experiment, CloudExperiment)
+        self.assertEqual(cloud_experiment.id_, listed_experiment.id_)
+
+    def test_get_cloud_experiment_experiment(self):
+        """Test getting an experiment from a cloud experiment."""
+        cloud_runner = CloudRunner(self.api_url, self.api_token)
+        experiments = cloud_runner.list_cloud_experiments()
+        if len(experiments) == 0:
+            raise SkipTest('No executions found')
+
+        cloud_experiment = experiments[-1].get_experiment()
+        self.assertIsInstance(cloud_experiment, BasicTraining)
+
+    def test_get_cloud_experiment_result(self):
+        """Test getting the result from a cloud experiment."""
+        cloud_runner = CloudRunner(self.api_url, self.api_token)
+        cloud_experiments = cloud_runner.list_cloud_experiments()
+        if len(cloud_experiments) == 0:
+            raise SkipTest('No executions found')
+
+        for experiment in cloud_experiments:
+            if experiment.job.status == CloudJobStatus.COMPLETED:
+                output = experiment.get_result()
+                self.assertIsInstance(output, list)
+                break
+        else:
+            raise SkipTest('No completed executions found')
+
+
+@parametrize_over_experiments([
+    FullyConnectedFashionMNIST
+])
+class CloudRunnerCreateTest(AihwkitTestCase):
+    """Tests for the AIHW Composer CloudRunner involving experiment creation."""
+
+    def setUp(self) -> None:
+        if not os.getenv('TEST_CREATE'):
+            raise SkipTest('TEST_CREATE not set')
+
+        config = ClientConfiguration()
+        if not config.token:
+            raise SkipTest('API token not found')
+
+        self.api_url = config.url
+        self.api_token = config.token
+
+    def test_create_experiment(self):
+        """Test creating a new experiment."""
+        cloud_runner = CloudRunner(self.api_url, self.api_token)
+        cloud_experiment = self.get_experiment()
+
+        api_experiment = cloud_runner.run(cloud_experiment)
+        self.assertIsInstance(api_experiment, CloudExperiment)
+
+        # Assert the experiment shows in the list.
+        api_experiments = cloud_runner.list_cloud_experiments()
+        api_experiment_ids = [item.id_ for item in api_experiments]
+        self.assertIn(api_experiment.id_, api_experiment_ids)


### PR DESCRIPTION
## Related issues

#169 

## Description

Add a `CloudRunner` that allows for executing experiments in the cloud, in a similar way to `LocalRunner`.

## Details

<!-- A more elaborate description of the changes, if needed. -->
