### PR TITLE
Documentation: using cloud experiments, apidoc

### DIFF
--- a/docs/source/api/aihwkit.experiments.runners.cloud.rst
+++ b/docs/source/api/aihwkit.experiments.runners.cloud.rst
@@ -1,0 +1,7 @@
+aihwkit.experiments.runners.cloud module
+========================================
+
+.. automodule:: aihwkit.experiments.runners.cloud
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/aihwkit.experiments.runners.rst
+++ b/docs/source/api/aihwkit.experiments.runners.rst
@@ -13,5 +13,6 @@ Submodules
    :maxdepth: 4
 
    aihwkit.experiments.runners.base
+   aihwkit.experiments.runners.cloud
    aihwkit.experiments.runners.local
    aihwkit.experiments.runners.metrics

--- a/docs/source/using_experiments.rst
+++ b/docs/source/using_experiments.rst
@@ -64,6 +64,7 @@ The following types of Runners are available:
 Tile class                                                Description
 ========================================================  ========
 :class:`~aihwkit.experiments.runners.local.LocalRunner`   Runner for executing experiments locally
+:class:`~aihwkit.experiments.runners.cloud.CloudRunner`   Runner for executing experiments in the cloud
 ========================================================  ========
 
 Running an Experiment Locally
@@ -132,4 +133,95 @@ session, as a way of tracking progress). This can be turned off by the
     ``dataset_root`` argument to indicate the location of the data files::
 
         result = my_runner.run(my_experiment, dataset_root='/some/path')
+
+Cloud Runner
+------------
+
+Experiments can also be run in the cloud at our companion ``AIHW Composer``
+application, that allows for executing the experiments remotely using hardware
+acceleration and inspect the experiments and their results visually, along
+other features.
+
+Setting up your account
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The integration is provided by a Python client included in ``aihwkit`` that
+allows connecting to the ``AIHW Composer`` platform. In order to be able to
+run experiments in the cloud:
+
+1. Register in the platform and generate an ``API token`` in your user page.
+   This token acts as the credentials for connecting with the application.
+
+2. Store your credentials by creating a ``~/.config/aihwkit.conf`` file with
+   the following contents, replacing ``YOUR_API_TOKEN`` with the string
+   from the previous step::
+
+    [cloud]
+    api_token = YOUR_API_TOKEN
+
+
+Running an Experiment in the cloud
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once your credentials are configured, running experiments in the cloud can
+be performed by using the ``CloudRunner``, in an analogous way as running
+experiments locally::
+
+    from aihwkit.experiments.runners import CloudRunner
+
+    my_cloud_runner = CloudRunner()
+    cloud_experiment = my_cloud_runner.run(my_experiment)
+
+Instead of waiting for the experiment to be completed, the ``run()`` method
+returns an object that represents a job in the cloud. As such, it has several
+convenience methods:
+
+Checking the status of a cloud experiment
+"""""""""""""""""""""""""""""""""""""""""
+
+The status of a cloud experiment can be retrieved via::
+
+    cloud_experiment.status()
+
+The response will provide information about the cloud experiment:
+    * ``WAITING``: if the experiment is waiting to be processed.
+    * ``RUNNING``: when the experiment is being executed in the cloud.
+    * ``COMPLETED``: if the experiment was executed successfully.
+    * ``FAILED``: if there was an error during the execution of the experiment.
+
+.. note::
+
+    Some actions are only possible if the cloud experiment has finished
+    successfully, for example, retrieving its results. Please also be mindful
+    that some experiments can take a sizeable amount of time to be executed,
+    specially during the initial versions of the platform.
+
+Retrieving the results of a cloud experiment
+""""""""""""""""""""""""""""""""""""""""""""
+
+Once the cloud experiment completes its execution, its results can be retrieved
+using::
+
+    result = cloud_experiment.get_result()
+
+This will display the result of executing the experiment, in a similar form as
+the output of running an Experiment locally.
+
+Retrieving the content of the experiment
+""""""""""""""""""""""""""""""""""""""""
+
+The Experiment can be retrieved using::
+
+    experiment = cloud_experiment.get_experiment()
+
+This will return a local Experiment (for example, a ``BasicTraining``) that
+can be used locally and their properties inspected. In particular, the weights
+of the model will reflect the results of the experiment.
+
+Retrieving a previous cloud experiment
+""""""""""""""""""""""""""""""""""""""
+
+The list of experiments previously executed in the cloud can be retrieved via::
+
+    cloud_experiments = my_cloud_runner.list_experiments()
 

--- a/src/aihwkit/cloud/client/v1/api_client.py
+++ b/src/aihwkit/cloud/client/v1/api_client.py
@@ -91,13 +91,15 @@ class ApiClient:
     def experiment_create(
             self,
             input_: BasicTraining,
-            name: str
+            name: str,
+            device: str = 'gpu'
     ) -> CloudExperiment:
         """Create a new experiment, queuing its execution.
 
         Args:
             input_: the experiment to be executed.
             name: the name of the experiment.
+            device: the desired device.
 
         Returns:
             A ``CloudExperiment``.
@@ -111,7 +113,8 @@ class ApiClient:
         experiment = ExperimentParser.parse_experiment(response, self)
 
         # Create the input.
-        response = self.inputs.post({'experiment': experiment.id_})
+        response = self.inputs.post({'experiment': experiment.id_,
+                                     'device': device})
         object_storage_url = response['url']
         _ = self.object_storage_session.put(url=object_storage_url, data=payload)
 

--- a/src/aihwkit/experiments/runners/cloud.py
+++ b/src/aihwkit/experiments/runners/cloud.py
@@ -87,6 +87,7 @@ class CloudRunner(Runner):
             self,
             experiment: BasicTraining,
             name: str = '',
+            device: str = 'gpu',
             **_: Any
     ) -> CloudExperiment:
         """Run a single Experiment.
@@ -102,6 +103,7 @@ class CloudRunner(Runner):
         Args:
             experiment: the experiment to be executed.
             name: an optional name for the experiment.
+            device: the desired device.
             _: extra arguments for the runner.
 
         Returns:
@@ -115,4 +117,4 @@ class CloudRunner(Runner):
                 len(experiment.model)
             )
 
-        return self.api_client.experiment_create(experiment, name=name)
+        return self.api_client.experiment_create(experiment, name, device)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -100,7 +100,9 @@ class ApiClientCreateTest(AihwkitTestCase):
         """Test creating a new experiment."""
         experiment = self.get_experiment()
         api_experiment = self.api_client.experiment_create(
-            experiment, name='test_create_experiment')
+            experiment, name='test_create_experiment',
+            device='cpu'
+        )
         self.assertIsInstance(api_experiment, CloudExperiment)
 
         # Assert the experiment shows in the list.

--- a/tests/test_cloud_runner.py
+++ b/tests/test_cloud_runner.py
@@ -106,7 +106,8 @@ class CloudRunnerCreateTest(AihwkitTestCase):
         cloud_runner = CloudRunner(self.api_url, self.api_token)
         cloud_experiment = self.get_experiment()
 
-        api_experiment = cloud_runner.run(cloud_experiment)
+        api_experiment = cloud_runner.run(cloud_experiment,
+                                          device='cpu')
         self.assertIsInstance(api_experiment, CloudExperiment)
 
         # Assert the experiment shows in the list.


### PR DESCRIPTION
## Related issues

Follow-up to #184 

## Description

* Update the `using_experiments.rst` documentation page, expanding it in order to accommodate basic usage of the `CloudRunner`
* Add apidoc stub for `CloudRunner`
* Include a fix for allowing selecting the device when running cloud experiments

## Details

<!-- A more elaborate description of the changes, if needed. -->
