### PR TITLE
Refresh apidoc stubs

### DIFF
--- a/docs/source/api/aihwkit.cloud.converter.rst
+++ b/docs/source/api/aihwkit.cloud.converter.rst
@@ -6,6 +6,15 @@ aihwkit.cloud.converter package
    :undoc-members:
    :show-inheritance:
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   aihwkit.cloud.converter.definitions
+   aihwkit.cloud.converter.v1
+
 Submodules
 ----------
 
@@ -13,5 +22,3 @@ Submodules
    :maxdepth: 4
 
    aihwkit.cloud.converter.exceptions
-   aihwkit.cloud.converter.definitions
-   aihwkit.cloud.converter.v1

--- a/docs/source/api/aihwkit.cloud.rst
+++ b/docs/source/api/aihwkit.cloud.rst
@@ -6,8 +6,8 @@ aihwkit.cloud package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
+Subpackages
+-----------
 
 .. toctree::
    :maxdepth: 4

--- a/docs/source/api/aihwkit.experiments.rst
+++ b/docs/source/api/aihwkit.experiments.rst
@@ -6,8 +6,8 @@ aihwkit.experiments package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
+Subpackages
+-----------
 
 .. toctree::
    :maxdepth: 4

--- a/docs/source/api/aihwkit.nn.modules.rst
+++ b/docs/source/api/aihwkit.nn.modules.rst
@@ -1,5 +1,5 @@
-aihwkit.nn.modules module
-=========================
+aihwkit.nn.modules package
+==========================
 
 .. automodule:: aihwkit.nn.modules
    :members:

--- a/docs/source/api/aihwkit.nn.rst
+++ b/docs/source/api/aihwkit.nn.rst
@@ -6,6 +6,14 @@ aihwkit.nn package
    :undoc-members:
    :show-inheritance:
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   aihwkit.nn.modules
+
 Submodules
 ----------
 
@@ -13,4 +21,3 @@ Submodules
    :maxdepth: 4
 
    aihwkit.nn.functions
-   aihwkit.nn.modules

--- a/docs/source/api/aihwkit.optim.analog_sgd.rst
+++ b/docs/source/api/aihwkit.optim.analog_sgd.rst
@@ -1,5 +1,5 @@
-aihwkit.optim.analog_sgd module
-===============================
+aihwkit.optim.analog\_sgd module
+================================
 
 .. automodule:: aihwkit.optim.analog_sgd
    :members:

--- a/docs/source/api/aihwkit.rst
+++ b/docs/source/api/aihwkit.rst
@@ -13,9 +13,16 @@ Subpackages
    :maxdepth: 4
 
    aihwkit.cloud
-   aihwkit.exceptions
    aihwkit.experiments
-   aihwkit.simulator
    aihwkit.nn
    aihwkit.optim
+   aihwkit.simulator
    aihwkit.utils
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   aihwkit.exceptions

--- a/docs/source/api/aihwkit.simulator.configs.helpers.rst
+++ b/docs/source/api/aihwkit.simulator.configs.helpers.rst
@@ -1,0 +1,7 @@
+aihwkit.simulator.configs.helpers module
+========================================
+
+.. automodule:: aihwkit.simulator.configs.helpers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/aihwkit.simulator.configs.rst
+++ b/docs/source/api/aihwkit.simulator.configs.rst
@@ -14,4 +14,5 @@ Submodules
 
    aihwkit.simulator.configs.configs
    aihwkit.simulator.configs.devices
+   aihwkit.simulator.configs.helpers
    aihwkit.simulator.configs.utils

--- a/docs/source/api/aihwkit.simulator.noise_models.rst
+++ b/docs/source/api/aihwkit.simulator.noise_models.rst
@@ -1,5 +1,5 @@
-aihwkit.simulator.noise_models module
-=====================================
+aihwkit.simulator.noise\_models module
+======================================
 
 .. automodule:: aihwkit.simulator.noise_models
    :members:

--- a/docs/source/api/aihwkit.simulator.rst
+++ b/docs/source/api/aihwkit.simulator.rst
@@ -6,14 +6,21 @@ aihwkit.simulator package
    :undoc-members:
    :show-inheritance:
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   aihwkit.simulator.configs
+   aihwkit.simulator.presets
+   aihwkit.simulator.rpu_base
+   aihwkit.simulator.tiles
+
 Submodules
 ----------
 
 .. toctree::
    :maxdepth: 4
 
-   aihwkit.simulator.configs
    aihwkit.simulator.noise_models
-   aihwkit.simulator.presets
-   aihwkit.simulator.rpu_base
-   aihwkit.simulator.tiles

--- a/docs/source/api/aihwkit.simulator.tiles.floating_point.rst
+++ b/docs/source/api/aihwkit.simulator.tiles.floating_point.rst
@@ -1,5 +1,5 @@
-aihwkit.simulator.tiles.floating_point module
-=============================================
+aihwkit.simulator.tiles.floating\_point module
+==============================================
 
 .. automodule:: aihwkit.simulator.tiles.floating_point
    :members:


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Refresh the stubs used for apidoc for rendering the API documentation in Sphinx, as some of them had incorrect headings for packages / modules and other misc oversights.

## Details

<!-- A more elaborate description of the changes, if needed. -->
