### PR TITLE
Allow skipping tests that download datasets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ jobs:
     <<: *job_compile_common
     stage: Test and lint
     python: "3.6"
+    env:
+      - TEST_DATASET=true
 
   - name: "Compile and lint. Python 3.6"
     <<: *job_compile_common

--- a/docs/source/development_conventions.rst
+++ b/docs/source/development_conventions.rst
@@ -49,6 +49,17 @@ We rely on the result of those checks to help reviewing pull requests: when
 contributing, please make sure of reviewing the result of the continuous
 integration in order to help fixing potential issues.
 
+Testing
+-------
+
+The following environment variables can be used for selecting the subset of
+tests to be performed:
+
+* ``TEST_DATASET``: if set, the tests that involve using datasets will be
+  executed (involves downloading the datasets).
+* ``TEST_CREATE``: if set, the tests that involve remote experiment creation
+  will be executed.
+
 Branches and releases
 ---------------------
 

--- a/tests/test_experiment_runners.py
+++ b/tests/test_experiment_runners.py
@@ -12,8 +12,9 @@
 
 """Tests for Experiment Runners."""
 
+import os
 from io import StringIO
-from unittest import skipIf
+from unittest import SkipTest, skipIf
 from unittest.mock import patch
 
 from torch import device as torch_device
@@ -36,6 +37,10 @@ from .helpers.testcases import AihwkitTestCase
 ])
 class TestLocalRunner(AihwkitTestCase):
     """Test LocalRunner."""
+
+    def setUp(self) -> None:
+        if not os.getenv('TEST_DATASET'):
+            raise SkipTest('TEST_DATASET not set')
 
     def test_run_example_cpu(self):
         """Test running the example using a local runner."""

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -12,6 +12,9 @@
 
 """Tests for Experiments."""
 
+import os
+from unittest import SkipTest
+
 from aihwkit.cloud.converter.v1.training import BasicTrainingConverter
 from aihwkit.nn.modules.base import AnalogModuleBase
 
@@ -31,6 +34,10 @@ from .helpers.testcases import AihwkitTestCase
 ])
 class TestBasicTraining(AihwkitTestCase):
     """Test BasicTraining Experiment."""
+
+    def setUp(self) -> None:
+        if not os.getenv('TEST_DATASET'):
+            raise SkipTest('TEST_DATASET not set')
 
     def test_conversion_roundtrip(self):
         """Test roundtrip conversion of examples."""


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Allow easy skipping of the tests that involve downloading the datasets, as it can be time-consuming and not desirable in some environments. This can now be controlled via the `TEST_DATASET` environment variable (defaulting to skipping the tests), which has been added to the docs as well.

The main travis compile job has been set to use this flag, for providing assurances that the tests are executed by the CI at least once per PR.

## Details

<!-- A more elaborate description of the changes, if needed. -->
