### PR TITLE
Alternative SoftBounds parameterization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ The format is based on [Keep a Changelog], and this project adheres to
       the simulated crossbar by applying a fixed output global factor in
       digital. (\#129)
     * Optional power-law drift during analog training. (\#158)
+	* New parameterization of the ``SoftBoundsDevice`` called
+      ``SoftBoundsPmaxDevice`` (\#???)
+	  
 * PyTorch interface improvements:
     * Two new convolution layers have been added: `AnalogConv1d` and
       `AnalogConv3d`, mimicking their digital counterparts. (\#102, \#103)

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 
 # (C) Copyright 2020, 2021 IBM. All Rights Reserved.
@@ -569,12 +570,6 @@ class SoftBoundsPmaxDevice(SoftBoundsDevice):
 
     range_max: float = 1.0
     """Value of the weight for :math:`P_max` number of up pulses."""
-
-    w_min_dtod: float = 0.0
-    w_max_dtod: float = 0.0
-    up_down_dtod: float = 0.0
-    dw_min_std: float = 0.3
-    dw_min_dtod: float = 0.0
 
     #  these values will be set from the above, so we hide it.
     w_min: float = field(default_factory=lambda: None, metadata={'hide_if': None})  # type: ignore

--- a/src/aihwkit/utils/visualization.py
+++ b/src/aihwkit/utils/visualization.py
@@ -267,7 +267,7 @@ def get_tile_for_plotting(
 
     analog_tile = AnalogTile(n_traces, 1, config)  # type: BaseTile
     analog_tile.set_learning_rate(1)
-    weights = config.device.w_min*ones((n_traces, 1))
+    weights = config.device.as_bindings().w_min * ones((n_traces, 1))
     analog_tile.set_weights(weights)
 
     if use_cuda and cuda.is_compiled():
@@ -290,9 +290,10 @@ def estimate_n_steps(rpu_config: SingleRPUConfig) -> int:
     Returns:
         Guessed number of steps
     """
-    dw_min = rpu_config.device.dw_min
-    w_min = rpu_config.device.w_min
-    w_max = rpu_config.device.w_max
+    device_binding = rpu_config.device.as_bindings()
+    dw_min = device_binding.dw_min
+    w_min = device_binding.w_min
+    w_max = device_binding.w_max
 
     n_steps = int(np.round((w_max - w_min) / dw_min))
     return n_steps

--- a/tests/helpers/tiles.py
+++ b/tests/helpers/tiles.py
@@ -21,6 +21,7 @@ from aihwkit.simulator.configs.devices import (
     LinearStepDevice,
     ExpStepDevice,
     SoftBoundsDevice,
+    SoftBoundsPmaxDevice,
     IOParameters,
     DifferenceUnitCell,
     VectorUnitCell,
@@ -108,6 +109,21 @@ class SoftBounds:
 
     def get_rpu_config(self):
         return SingleRPUConfig(device=SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
+        rpu_config = rpu_config or self.get_rpu_config()
+        return AnalogTile(out_size, in_size, rpu_config, **kwargs)
+
+
+class SoftBoundsPmax:
+    """AnalogTile with SoftBoundsPmaxDevice."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = 'max_bound'
+    use_cuda = False
+
+    def get_rpu_config(self):
+        return SingleRPUConfig(device=SoftBoundsPmaxDevice(w_max_dtod=0, w_min_dtod=0))
 
     def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
         rpu_config = rpu_config or self.get_rpu_config()
@@ -312,6 +328,21 @@ class SoftBoundsCuda:
 
     def get_rpu_config(self):
         return SingleRPUConfig(device=SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0))
+
+    def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
+        rpu_config = rpu_config or self.get_rpu_config()
+        return AnalogTile(out_size, in_size, rpu_config, **kwargs).cuda()
+
+
+class SoftBoundsPmaxCuda:
+    """AnalogTile with SoftBoundsPmaxDevice."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = 'max_bound'
+    use_cuda = True
+
+    def get_rpu_config(self):
+        return SingleRPUConfig(device=SoftBoundsPmaxDevice(w_max_dtod=0, w_min_dtod=0))
 
     def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
         rpu_config = rpu_config or self.get_rpu_config()

--- a/tests/test_rpu_configurations.py
+++ b/tests/test_rpu_configurations.py
@@ -20,9 +20,10 @@ from .helpers.decorators import parametrize_over_tiles
 from .helpers.testcases import ParametrizedTestCase
 from .helpers.tiles import (
     FloatingPoint, Ideal, ConstantStep, LinearStep,
-    ExpStep, Vector, Difference, Transfer, MixedPrecision,
+    ExpStep, SoftBounds, SoftBoundsPmax, Vector, Difference, Transfer, MixedPrecision,
     FloatingPointCuda, IdealCuda, ConstantStepCuda, LinearStepCuda,
-    ExpStepCuda, VectorCuda, DifferenceCuda, TransferCuda, MixedPrecisionCuda,
+    ExpStepCuda, SoftBoundsCuda, SoftBoundsPmaxCuda, VectorCuda,
+    DifferenceCuda, TransferCuda, MixedPrecisionCuda,
 )
 
 
@@ -61,6 +62,8 @@ class RPUConfigurationsFloatingPointTest(ParametrizedTestCase):
     ConstantStep,
     LinearStep,
     ExpStep,
+    SoftBounds,
+    SoftBoundsPmax,
     Vector,
     Difference,
     Transfer,
@@ -69,6 +72,8 @@ class RPUConfigurationsFloatingPointTest(ParametrizedTestCase):
     ConstantStepCuda,
     LinearStepCuda,
     ExpStepCuda,
+    SoftBoundsCuda,
+    SoftBoundsPmaxCuda,
     VectorCuda,
     DifferenceCuda,
     TransferCuda,


### PR DESCRIPTION
## Related issues

#170 

## Description

New `SoftBoundPmaxDevice` which is a new parameterization of the softbounds acccording to the dicussion in Issue #170

## Details

The base class remains identical to that of `SoftBoundsDevice`, only the parameter names (and a simple transformation) changes. For parameter names refer to the documentation (search for SoftBoundsPmaxDevice)
    