### PR TITLE
Fix test_post_forward_modifier_types, doc fix

### DIFF
--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -533,8 +533,8 @@ class SoftBoundsPmaxDevice(SoftBoundsDevice):
     where :math:`B=\frac{r_\text{max} -
     r_\text{min}}{1 - e^{-\alpha p_\text{max}}}`.
 
-    Here :math:`p_max` is the number of pulses that were applied to get the
-    device from the minimum conductance (minimum of range,
+    Here :math:`p_\text{max}` is the number of pulses that were applied to get
+    the device from the minimum conductance (minimum of range,
     :math:`r_\text{min}`) to the maximum (maximum of range,
     :math:`r_\text{max}`).
 

--- a/tests/test_inference_tiles.py
+++ b/tests/test_inference_tiles.py
@@ -127,7 +127,7 @@ class InferenceTileTest(ParametrizedTestCase):
         """Tests whether post update diffusion is performed."""
         rpu_config = self.get_rpu_config()
         rpu_config.drift_compensation = None
-        rpu_config.forward.w_noise = 0.0
+        rpu_config.forward.is_perfect = True
         rpu_config.forward.out_noise = 0.0
         rpu_config.forward.inp_noise = 0.0
 


### PR DESCRIPTION
## Related issues

Closes #138 

## Description

* Revise `test_post_forward_modifier_types` to avoid sporadic failures when using the `mult_normal` modifier type.
* Fix a documentation issue in a math expression changed during #193

Credit to Malte for both!

## Details

<!-- A more elaborate description of the changes, if needed. -->
