### PR TITLE
Prepare build system for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,8 @@ jobs:
     if: branch =~ /^release\/.*$/
     env:
       # Use a specific torch version.
-      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
-      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install -r requirements.txt"
+      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.8.1'"
+      - CIBW_BEFORE_BUILD="pip install torch==1.8.1 && pip install -r requirements.txt"
       - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
       - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64"
     before_install:
@@ -136,8 +136,8 @@ jobs:
         update: true
     env:
       # Use a specific torch version.
-      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
-      - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install ./delocate && pip install -r requirements.txt"
+      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.8.1'"
+      - CIBW_BEFORE_BUILD="pip install torch==1.8.1 && pip install ./delocate && pip install -r requirements.txt"
       - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64 cp39-macosx_x86_64"
     before_install:
       - git clone -b aihwkit https://github.com/aihwkit-bot/delocate.git
@@ -155,8 +155,8 @@ jobs:
     if: branch =~ /^release\/win.*$/
     env:
       # Use a specific torch version.
-      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
-      - CIBW_BEFORE_BUILD="pip install torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html && pip install -r requirements.txt"
+      - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.8.1'"
+      - CIBW_BEFORE_BUILD="pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html && pip install -r requirements.txt"
       - CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64 cp39-win_amd64"
       # Use unzipped OpenBLAS.
       - OPENBLAS_ROOT=C:\\BLAS

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,11 +114,11 @@ jobs:
       - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
       - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install -r requirements.txt"
       - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
-      - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64"
+      - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64"
     before_install:
       - docker pull aihwkit/manylinux2014_x86_64_aihwkit
     install:
-      - python3 -m pip install cibuildwheel==1.6.0
+      - python3 -m pip install cibuildwheel==1.10.0
     script:
       # Build the wheels into './wheelhouse'.
       - python3 -m cibuildwheel --output-dir wheelhouse
@@ -138,11 +138,11 @@ jobs:
       # Use a specific torch version.
       - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
       - CIBW_BEFORE_BUILD="pip install torch==1.6.0 && pip install ./delocate && pip install -r requirements.txt"
-      - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64"
+      - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64 cp39-macosx_x86_64"
     before_install:
       - git clone -b aihwkit https://github.com/aihwkit-bot/delocate.git
     install:
-      - python3 -m pip install cibuildwheel==1.6.0
+      - python3 -m pip install cibuildwheel==1.10.0
     script:
       # Build the wheels into './wheelhouse'.
       - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
@@ -157,7 +157,7 @@ jobs:
       # Use a specific torch version.
       - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.6.0'"
       - CIBW_BEFORE_BUILD="pip install torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html && pip install -r requirements.txt"
-      - CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64"
+      - CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64 cp39-win_amd64"
       # Use unzipped OpenBLAS.
       - OPENBLAS_ROOT=C:\\BLAS
       - OPENBLAS_ROOT_DIR=C:\\BLAS


### PR DESCRIPTION
## Related issues

#52 , #111 

## Description

Prepare the build system for the upcoming release wheels:
* bump `cibuildwheel` version to the most recent one
* set the default `torch` version for the wheels to `1.8.1`
* add python 3.9 wheels

## Details

<!-- A more elaborate description of the changes, if needed. -->
