### PR TITLE
Optional TLS verification

### DIFF
--- a/src/aihwkit/cloud/client/session.py
+++ b/src/aihwkit/cloud/client/session.py
@@ -15,6 +15,8 @@
 from typing import Any, Optional, Text, Union
 
 from requests import HTTPError, Session
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
 
 from aihwkit.version import __version__
 from aihwkit.cloud.client.exceptions import ApiResponseError, ResponseError
@@ -70,12 +72,17 @@ class ApiSession(Session):
     def __init__(
             self,
             api_url: str,
-            api_token: str
+            api_token: str,
+            verify: bool = True
     ):
         super().__init__()
 
         self.api_url = api_url
         self.api_token = api_token
+        self.verify = verify
+        if not verify:
+            urllib3.disable_warnings(InsecureRequestWarning)
+
         self.jwt_token = None  # type: Optional[str]
 
         self.headers.update({'User-Agent': 'aihwkit/{}'.format(__version__)})

--- a/src/aihwkit/experiments/runners/cloud.py
+++ b/src/aihwkit/experiments/runners/cloud.py
@@ -32,7 +32,8 @@ class CloudRunner(Runner):
 
     def __init__(self,
                  api_url: Optional[str] = None,
-                 api_token: Optional[str] = None):
+                 api_token: Optional[str] = None,
+                 verify: bool = True):
         """CloudRunner constructor.
 
         Note:
@@ -44,6 +45,7 @@ class CloudRunner(Runner):
         Args:
             api_url: the URL of the AIHW Composer API.
             api_token: the API token for authentication.
+            verify: if ``False``, disable the remote server TLS verification.
 
         Raises:
             CredentialsError: if no credentials could be found.
@@ -61,7 +63,7 @@ class CloudRunner(Runner):
         self.api_token = api_token
 
         # Authenticate.
-        self.session = ApiSession(self.api_url, self.api_token)
+        self.session = ApiSession(self.api_url, self.api_token, verify)
         self.api_client = ApiClient(self.session)
 
     def get_cloud_experiment(self, id_: str) -> CloudExperiment:


### PR DESCRIPTION
## Related issues

#184 

## Description

Update `CloudRunner` (and `ApiSession`) in order to accept an argument for optionally disabling TLS verification when connecting to the API. While (strongly) not recommended, it provides a temporary solution for communicating with the API on environments where the right SSL root certificates might not be present or installable.

## Details

<!-- A more elaborate description of the changes, if needed. -->
