### PR TITLE
Weight granularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog], and this project adheres to
     the simulated crossbar by applying a fixed output global factor in
     digital. (\#129)
   * Optional power-law drift during analog training. (\#158)
+  * Cleaner setting of `dw_min` using device granularity. (\#200)
 * PyTorch interface improvements:
   * Two new convolution layers have been added: `AnalogConv1d` and
     `AnalogConv3d`, mimicking their digital counterparts. (\#102, \#103)

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -427,9 +427,11 @@ class UpdateParameters(_PrintableMixin):
     update_bl_management: bool = True
     """Whether to enable dynamical adjustment of ``A``,``B``,and ``BL``::
 
-        BL = ceil(learning_rate * abs(x_j) * abs(d_i) / dw_min);
+        BL = ceil(learning_rate * abs(x_j) * abs(d_i) / weight_granularity);
         BL  = min(BL,desired_BL);
-        A = B = sqrt(learning_rate / (dw_min * BL));
+        A = B = sqrt(learning_rate / (weight_granularity * BL));
+
+    The ``weight_granularity`` is usually equal to ``dw_min``.
     """
 
     update_management: bool = True

--- a/src/aihwkit/simulator/presets/__init__.py
+++ b/src/aihwkit/simulator/presets/__init__.py
@@ -22,5 +22,8 @@ from .configs import (
     ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset, Idealized4Preset,
     # Tiki-taka configs.
     TikiTakaReRamESPreset, TikiTakaReRamSBPreset, TikiTakaCapacitorPreset,
-    TikiTakaEcRamPreset, TikiTakaIdealizedPreset
+    TikiTakaEcRamPreset, TikiTakaIdealizedPreset,
+    # MixedPrecision configs.
+    MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset, MixedPrecisionCapacitorPreset,
+    MixedPrecisionEcRamPreset, MixedPrecisionIdealizedPreset, MixedPrecisionGokmenVlasovPreset
 )

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -82,6 +82,9 @@ void declare_rpu_devices(py::module &m) {
       PYBIND11_OVERLOAD_PURE(
           RPU::PulsedRPUDeviceBase<T> *, PulsedBaseParam, createDevice, x_size, d_size, rng);
     }
+    T calcWeightGranularity() const {
+      PYBIND11_OVERLOAD(T, PulsedBaseParam, calcWeightGranularity, );
+    }
   };
 
   class PyPulsedParam : public PulsedParam {
@@ -97,6 +100,9 @@ void declare_rpu_devices(py::module &m) {
     createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
       PYBIND11_OVERLOAD_PURE(
           RPU::PulsedRPUDevice<T> *, PulsedParam, createDevice, x_size, d_size, rng);
+    }
+    T calcWeightGranularity() const override {
+      PYBIND11_OVERLOAD(T, PulsedParam, calcWeightGranularity, );
     }
   };
 
@@ -116,6 +122,9 @@ void declare_rpu_devices(py::module &m) {
       PYBIND11_OVERLOAD(
           RPU::ConstantStepRPUDevice<T> *, ConstantStepParam, createDevice, x_size, d_size, rng);
     }
+    T calcWeightGranularity() const override {
+      PYBIND11_OVERLOAD(T, ConstantStepParam, calcWeightGranularity, );
+    }
   };
 
   class PyLinearStepParam : public LinearStepParam {
@@ -134,6 +143,9 @@ void declare_rpu_devices(py::module &m) {
       PYBIND11_OVERLOAD(
           RPU::LinearStepRPUDevice<T> *, LinearStepParam, createDevice, x_size, d_size, rng);
     }
+    T calcWeightGranularity() const override {
+      PYBIND11_OVERLOAD(T, LinearStepParam, calcWeightGranularity, );
+    }
   };
 
   class PySoftBoundsParam : public SoftBoundsParam {
@@ -143,6 +155,9 @@ void declare_rpu_devices(py::module &m) {
     }
     SoftBoundsParam *clone() const override {
       PYBIND11_OVERLOAD(SoftBoundsParam *, SoftBoundsParam, clone, );
+    }
+    T calcWeightGranularity() const override {
+      PYBIND11_OVERLOAD(T, SoftBoundsParam, calcWeightGranularity, );
     }
   };
 
@@ -162,6 +177,9 @@ void declare_rpu_devices(py::module &m) {
       PYBIND11_OVERLOAD(
           RPU::ExpStepRPUDevice<T> *, ExpStepParam, createDevice, x_size, d_size, rng);
     }
+    T calcWeightGranularity() const override {
+      PYBIND11_OVERLOAD(T, ExpStepParam, calcWeightGranularity, );
+    }
   };
 
   class PyVectorParam : public VectorParam {
@@ -174,6 +192,9 @@ void declare_rpu_devices(py::module &m) {
     RPU::VectorRPUDevice<T> *
     createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
       PYBIND11_OVERLOAD(RPU::VectorRPUDevice<T> *, VectorParam, createDevice, x_size, d_size, rng);
+    }
+    T calcWeightGranularity() const override {
+      PYBIND11_OVERLOAD(T, VectorParam, calcWeightGranularity, );
     }
   };
 
@@ -193,6 +214,9 @@ void declare_rpu_devices(py::module &m) {
       PYBIND11_OVERLOAD(
           RPU::DifferenceRPUDevice<T> *, DifferenceParam, createDevice, x_size, d_size, rng);
     }
+    T calcWeightGranularity() const override {
+      PYBIND11_OVERLOAD(T, DifferenceParam, calcWeightGranularity, );
+    }
   };
 
   class PyTransferParam : public TransferParam {
@@ -210,6 +234,9 @@ void declare_rpu_devices(py::module &m) {
     createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
       PYBIND11_OVERLOAD(
           RPU::TransferRPUDevice<T> *, TransferParam, createDevice, x_size, d_size, rng);
+    }
+    T calcWeightGranularity() const override {
+      PYBIND11_OVERLOAD(T, TransferParam, calcWeightGranularity, );
     }
   };
 
@@ -246,6 +273,9 @@ void declare_rpu_devices(py::module &m) {
     createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
       PYBIND11_OVERLOAD(
           RPU::PowStepRPUDevice<T> *, PowStepParam, createDevice, x_size, d_size, rng);
+    }
+    T calcWeightGranularity() const override {
+      PYBIND11_OVERLOAD(T, PowStepParam, calcWeightGranularity, );
     }
   };
 
@@ -383,11 +413,21 @@ void declare_rpu_devices(py::module &m) {
   py::class_<ConstantStepParam, PyConstantStepParam, PulsedParam>(
       m, "ConstantStepResistiveDeviceParameter")
       .def(py::init<>())
-      .def("__str__", [](ConstantStepParam &self) {
-        std::stringstream ss;
-        self.printToStream(ss);
-        return ss.str();
-      });
+      .def(
+          "__str__",
+          [](ConstantStepParam &self) {
+            std::stringstream ss;
+            self.printToStream(ss);
+            return ss.str();
+          })
+      .def(
+          "calc_weight_granularity", &ConstantStepParam::calcWeightGranularity,
+          R"pbdoc(
+        Calculates the granularity of the weights (typically ``dw_min``)
+
+        Returns:
+           float: weight granularity
+        )pbdoc");
 
   py::class_<LinearStepParam, PyLinearStepParam, PulsedParam>(
       m, "LinearStepResistiveDeviceParameter")
@@ -400,22 +440,42 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("mean_bound_reference", &LinearStepParam::ls_mean_bound_reference)
       .def_readwrite("write_noise_std", &LinearStepParam::write_noise_std)
       .def_readwrite("mult_noise", &LinearStepParam::ls_mult_noise)
-      .def("__str__", [](LinearStepParam &self) {
-        std::stringstream ss;
-        self.printToStream(ss);
-        return ss.str();
-      });
+      .def(
+          "__str__",
+          [](LinearStepParam &self) {
+            std::stringstream ss;
+            self.printToStream(ss);
+            return ss.str();
+          })
+      .def(
+          "calc_weight_granularity", &LinearStepParam::calcWeightGranularity,
+          R"pbdoc(
+        Calculates the granularity of the weights (typically ``dw_min``)
+
+        Returns:
+           float: weight granularity
+        )pbdoc");
 
   py::class_<SoftBoundsParam, PySoftBoundsParam, PulsedParam>(
       m, "SoftBoundsResistiveDeviceParameter")
       .def_readwrite("mult_noise", &SoftBoundsParam::ls_mult_noise)
       .def_readwrite("write_noise_std", &SoftBoundsParam::write_noise_std)
       .def(py::init<>())
-      .def("__str__", [](SoftBoundsParam &self) {
-        std::stringstream ss;
-        self.printToStream(ss);
-        return ss.str();
-      });
+      .def(
+          "__str__",
+          [](SoftBoundsParam &self) {
+            std::stringstream ss;
+            self.printToStream(ss);
+            return ss.str();
+          })
+      .def(
+          "calc_weight_granularity", &SoftBoundsParam::calcWeightGranularity,
+          R"pbdoc(
+        Calculates the granularity of the weights (typically ``dw_min``)
+
+        Returns:
+           float: weight granularity
+        )pbdoc");
 
   py::class_<ExpStepParam, PyExpStepParam, PulsedParam>(m, "ExpStepResistiveDeviceParameter")
       .def(py::init<>())
@@ -426,11 +486,21 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("a", &ExpStepParam::es_a)
       .def_readwrite("b", &ExpStepParam::es_b)
       .def_readwrite("write_noise_std", &ExpStepParam::write_noise_std)
-      .def("__str__", [](ExpStepParam &self) {
-        std::stringstream ss;
-        self.printToStream(ss);
-        return ss.str();
-      });
+      .def(
+          "__str__",
+          [](ExpStepParam &self) {
+            std::stringstream ss;
+            self.printToStream(ss);
+            return ss.str();
+          })
+      .def(
+          "calc_weight_granularity", &ExpStepParam::calcWeightGranularity,
+          R"pbdoc(
+        Calculates the granularity of the weights (typically ``dw_min``)
+
+        Returns:
+           float: weight granularity
+        )pbdoc");
 
   py::class_<VectorParam, PyVectorParam, PulsedBaseParam>(m, "VectorResistiveDeviceParameter")
       .def(py::init<>())
@@ -446,20 +516,40 @@ void declare_rpu_devices(py::module &m) {
           R"pbdoc(
            Adds a pulsed base device parameter to the vector device.
            )pbdoc")
-      .def("__str__", [](VectorParam &self) {
-        std::stringstream ss;
-        self.printToStream(ss);
-        return ss.str();
-      });
+      .def(
+          "__str__",
+          [](VectorParam &self) {
+            std::stringstream ss;
+            self.printToStream(ss);
+            return ss.str();
+          })
+      .def(
+          "calc_weight_granularity", &VectorParam::calcWeightGranularity,
+          R"pbdoc(
+        Calculates the granularity of the weights (typically ``dw_min``)
+
+        Returns:
+           float: weight granularity
+        )pbdoc");
 
   py::class_<DifferenceParam, PyDifferenceParam, VectorParam>(
       m, "DifferenceResistiveDeviceParameter")
       .def(py::init<>())
-      .def("__str__", [](DifferenceParam &self) {
-        std::stringstream ss;
-        self.printToStream(ss);
-        return ss.str();
-      });
+      .def(
+          "__str__",
+          [](DifferenceParam &self) {
+            std::stringstream ss;
+            self.printToStream(ss);
+            return ss.str();
+          })
+      .def(
+          "calc_weight_granularity", &DifferenceParam::calcWeightGranularity,
+          R"pbdoc(
+        Calculates the granularity of the weights (typically ``dw_min``)
+
+        Returns:
+           float: weight granularity
+        )pbdoc");
 
   py::class_<TransferParam, PyTransferParam, VectorParam>(m, "TransferResistiveDeviceParameter")
       .def(py::init<>())
@@ -477,11 +567,21 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("scale_transfer_lr", &TransferParam::scale_transfer_lr)
       .def_readwrite("transfer_forward", &TransferParam::transfer_io)
       .def_readwrite("transfer_update", &TransferParam::transfer_up)
-      .def("__str__", [](TransferParam &self) {
-        std::stringstream ss;
-        self.printToStream(ss);
-        return ss.str();
-      });
+      .def(
+          "__str__",
+          [](TransferParam &self) {
+            std::stringstream ss;
+            self.printToStream(ss);
+            return ss.str();
+          })
+      .def(
+          "calc_weight_granularity", &TransferParam::calcWeightGranularity,
+          R"pbdoc(
+        Calculates the granularity of the weights (typically ``dw_min``)
+
+        Returns:
+           float: weight granularity
+        )pbdoc");
 
   py::class_<MixedPrecParam, PyMixedPrecParam, SimpleParam>(m, "MixedPrecResistiveDeviceParameter")
       .def(py::init<>())
@@ -514,11 +614,21 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("pow_up_down", &PowStepParam::ps_gamma_up_down)
       .def_readwrite("pow_up_down_dtod", &PowStepParam::ps_gamma_up_down_dtod)
       .def_readwrite("write_noise_std", &PowStepParam::write_noise_std)
-      .def("__str__", [](PowStepParam &self) {
-        std::stringstream ss;
-        self.printToStream(ss);
-        return ss.str();
-      });
+      .def(
+          "__str__",
+          [](PowStepParam &self) {
+            std::stringstream ss;
+            self.printToStream(ss);
+            return ss.str();
+          })
+      .def(
+          "calc_weight_granularity", &PowStepParam::calcWeightGranularity,
+          R"pbdoc(
+        Calculates the granularity of the weights (typically ``dw_min``)
+
+        Returns:
+           float: weight granularity
+        )pbdoc");
 
   /**
    * Helper enums.

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -499,6 +499,22 @@ class BaseTile(Generic[RPUConfigGeneric]):
     def set_hidden_parameters(self, ordered_parameters: OrderedDict) -> None:
         """Set the hidden parameters of the tile.
 
+        Caution:
+            Usually the hidden parameters are drawn according to the
+            parameter definitions (those given in the RPU config). If
+            the hidden parameters are arbitrary set by the user, then
+            this correspondence might be broken. This might cause problems
+            in the learning, in particular, the `weight granularity`
+            (usually ``dw_min``, depending on the device) is needed for
+            the dynamic adjustment of the bit length
+            (``update_bl_management``, see
+            :class:`~aihwkit.simulator.configs.utils.UpdateParameters`).
+
+            Currently, the new ``dw_min`` parameter is tried to be
+            estimated from the average of hidden parameters if the
+            discrepancy with the ``dw_min`` from the definition is too
+            large.
+
         Args:
             ordered_parameters: Ordered dictionary of hidden parameter tensors.
         """

--- a/src/aihwkit/utils/visualization.py
+++ b/src/aihwkit/utils/visualization.py
@@ -290,10 +290,10 @@ def estimate_n_steps(rpu_config: SingleRPUConfig) -> int:
     Returns:
         Guessed number of steps
     """
-    device_binding = rpu_config.device.as_bindings()
-    dw_min = device_binding.dw_min
-    w_min = device_binding.w_min
-    w_max = device_binding.w_max
+    device_bindings = rpu_config.device.as_bindings()
+    dw_min = device_bindings.calc_weight_granularity()
+    w_min = device_bindings.w_min
+    w_max = device_bindings.w_max
 
     n_steps = int(np.round((w_max - w_min) / dw_min))
     return n_steps

--- a/src/rpucuda/cuda/pulsed_weight_updater.cu
+++ b/src/rpucuda/cuda/pulsed_weight_updater.cu
@@ -95,7 +95,7 @@ void PulsedWeightUpdater<T>::executeUpdate(
     const bool d_trans_in) {
 
   blm_->makeCounts(
-      x_in, d_in, up, rpucuda_device->getDwMin(), lr, m_batch, x_trans_in, d_trans_in,
+      x_in, d_in, up, rpucuda_device->getWeightGranularity(), lr, m_batch, x_trans_in, d_trans_in,
       kpars->getOutTrans(), kpars->getUseBo64(), kpars->getImplicitPulses());
 
   CudaContext *c = context_;

--- a/src/rpucuda/cuda/rpucuda_powstep_device.cu
+++ b/src/rpucuda/cuda/rpucuda_powstep_device.cu
@@ -111,14 +111,6 @@ pwukpvec_t<T> PowStepRPUDeviceCuda<T>::getUpdateKernels(
 
 #undef ARGS
 
-template <typename T> T PowStepRPUDeviceCuda<T>::getDwMin() const {
-
-  // TODO: this should actually be just be a property from rpu_device. Need to do this in Base.
-  const auto &par = getPar();
-  // just approximately at zero (used for update management)
-  return par.dw_min * pow(0.5, par.ps_gamma);
-};
-
 template class PowStepRPUDeviceCuda<float>;
 #ifdef RPU_USE_DOUBLE
 template class PowStepRPUDeviceCuda<double>;

--- a/src/rpucuda/cuda/rpucuda_powstep_device.h
+++ b/src/rpucuda/cuda/rpucuda_powstep_device.h
@@ -74,8 +74,6 @@ public:
     return getPar().usesPersistentWeight() ? this->dev_persistent_weights_->getData() : nullptr;
   };
 
-  T getDwMin() const override;
-
 private:
   std::unique_ptr<CudaArray<float>> dev_gamma_ = nullptr;
   std::unique_ptr<CudaArray<T>> dev_write_noise_std_ = nullptr;

--- a/src/rpucuda/cuda/rpucuda_vector_device.cu
+++ b/src/rpucuda/cuda/rpucuda_vector_device.cu
@@ -75,7 +75,6 @@ VectorRPUDeviceCuda<T>::VectorRPUDeviceCuda(const VectorRPUDeviceCuda<T> &other)
     : PulsedRPUDeviceCudaBase<T>(other) {
   current_update_idx_ = other.current_update_idx_;
   current_device_idx_ = other.current_device_idx_;
-  dw_min_ = other.dw_min_;
   n_devices_ = other.n_devices_;
 
   allocateContainers();
@@ -110,7 +109,6 @@ VectorRPUDeviceCuda<T> &VectorRPUDeviceCuda<T>::operator=(VectorRPUDeviceCuda<T>
 
   PulsedRPUDeviceCudaBase<T>::operator=(std::move(other));
 
-  dw_min_ = other.dw_min_;
   n_devices_ = other.n_devices_;
   current_update_idx_ = other.current_update_idx_;
   current_device_idx_ = other.current_device_idx_;
@@ -143,8 +141,6 @@ void VectorRPUDeviceCuda<T>::populateFrom(const AbstractRPUDevice<T> &rpu_device
   current_update_idx_ = 0;
   current_device_idx_ = rpu_device.getCurrentDeviceIdx();
   n_devices_ = 0;
-
-  dw_min_ = rpu_device.getDwMin();
 
   const auto &rpu_device_vec = rpu_device.getRpuVec();
   T ***weights_vec = rpu_device.getWeightVec();

--- a/src/rpucuda/cuda/rpucuda_vector_device.h
+++ b/src/rpucuda/cuda/rpucuda_vector_device.h
@@ -35,7 +35,6 @@ public:
     swap(
         static_cast<PulsedRPUDeviceCudaBase<T> &>(a), static_cast<PulsedRPUDeviceCudaBase<T> &>(b));
     swap(a.n_devices_, b.n_devices_);
-    swap(a.dw_min_, b.dw_min_);
     swap(a.dev_weights_vec_, b.dev_weights_vec_);
     swap(a.rpucuda_device_vec_, b.rpucuda_device_vec_);
     swap(a.dev_weights_ptrs_, b.dev_weights_ptrs_);
@@ -62,7 +61,6 @@ public:
   };
 
   void populateFrom(const AbstractRPUDevice<T> &rpu_device) override;
-  T getDwMin() const override { return dw_min_; };
 
   VectorRPUDeviceMetaParameter<T> &getPar() const override {
     return static_cast<VectorRPUDeviceMetaParameter<T> &>(SimpleRPUDeviceCuda<T>::getPar());
@@ -91,7 +89,6 @@ public:
   std::vector<T> getReduceWeightening() const;
 
 protected:
-  T dw_min_ = 0;
   int n_devices_ = 0;
 
   virtual void reduceToWeights(CudaContext *c, T *dev_weights);

--- a/src/rpucuda/rpu_constantstep_device.h
+++ b/src/rpucuda/rpu_constantstep_device.h
@@ -28,6 +28,9 @@ BUILD_PULSED_DEVICE_META_PARAMETER(ConstantStep,
                                    /*print body*/
                                    ss << "\tNone additional.\n";
                                    ,
+                                   /* calc weight granularity body */
+                                   return this->dw_min;
+                                   ,
                                    /*add*/
 );
 

--- a/src/rpucuda/rpu_expstep_device.h
+++ b/src/rpucuda/rpu_expstep_device.h
@@ -40,6 +40,19 @@ BUILD_PULSED_DEVICE_META_PARAMETER(
     ss << "\t es_a:\t\t\t" << es_a << std::endl;
     ss << "\t es_b:\t\t\t" << es_b << std::endl;
     ,
+    /* calc weight granularity body */
+    T up_down = this->up_down;
+    T up_bias = up_down > 0 ? (T)0.0 : up_down;
+    T down_bias = up_down > 0 ? -up_down : (T)0.0;
+    T scale_up = (up_bias + 1.0) * this->dw_min;
+    T scale_down = (down_bias + 1.0) * this->dw_min;
+    T w = 0.0; // just take at zero
+    T z = (T)2.0 * w / (this->w_max - this->w_min) * es_a + es_b;
+    T dw_down = scale_down * MAX((T)1 - es_A_down * expf(es_gamma_down * (-z)), (T)0);
+    T dw_up = scale_up * MAX(1 - es_A_up * expf(es_gamma_up * z), (T)0);
+    T weight_granularity = MAX((dw_down + dw_down) / (T)2.0, (T)0);
+    return weight_granularity > (T)0 ? weight_granularity : this->dw_min;
+    ,
     /*add */
     bool implementsWriteNoise() const override { return true; };
 

--- a/src/rpucuda/rpu_linearstep_device.h
+++ b/src/rpucuda/rpu_linearstep_device.h
@@ -48,6 +48,9 @@ BUILD_PULSED_DEVICE_META_PARAMETER(
     ss << "\t ls_allow_increasing_slope:\t" << std::boolalpha << ls_allow_increasing_slope
        << std::endl;
     ,
+    /* calc weight granularity body */
+    return this->dw_min;
+    ,
     /*Add*/
     bool implementsWriteNoise() const override { return true; };);
 

--- a/src/rpucuda/rpu_mixedprec_device.cpp
+++ b/src/rpucuda/rpu_mixedprec_device.cpp
@@ -26,9 +26,9 @@ template <typename T>
 void MixedPrecRPUDeviceMetaParameter<T>::printToStream(std::stringstream &ss) const {
   ss << "Update using digital outer product + transfer to analog: " << std::endl;
 
-  ss << "\t n_x_bins: \t";
+  ss << "\t n_x_bins: \t\t";
   ss << n_x_bins << std::endl;
-  ss << "\t n_d_bins: \t";
+  ss << "\t n_d_bins: \t\t";
   ss << n_d_bins << std::endl;
 
   MixedPrecRPUDeviceBaseMetaParameter<T>::printToStream(ss);
@@ -159,6 +159,10 @@ void MixedPrecRPUDevice<T>::forwardUpdate(
     this->transfer_tmp_.resize(this->x_size_);
   }
 
+  if (this->granularity_ <= 0 )  {
+    RPU_FATAL("Granularity cannot be zero!");
+  }
+  
   // forward / update
   for (int j = 0; j < n_vec; j++) {
     T *chi_row = chi_[j_row_start + j];

--- a/src/rpucuda/rpu_mixedprec_device.cpp
+++ b/src/rpucuda/rpu_mixedprec_device.cpp
@@ -162,7 +162,7 @@ void MixedPrecRPUDevice<T>::forwardUpdate(
   if (this->granularity_ <= 0 )  {
     RPU_FATAL("Granularity cannot be zero!");
   }
-  
+
   // forward / update
   for (int j = 0; j < n_vec; j++) {
     T *chi_row = chi_[j_row_start + j];

--- a/src/rpucuda/rpu_mixedprec_device_base.cpp
+++ b/src/rpucuda/rpu_mixedprec_device_base.cpp
@@ -219,24 +219,27 @@ void MixedPrecRPUDeviceBase<T>::populate(
   avg_sparsity_ = 0;
   up_ptr_ = nullptr;
 
+  if (par.device_par == nullptr) {
+    RPU_FATAL("Expect device parameter in device_par!");
+  }
+
   rpu_device_ = par.device_par->createDeviceUnique(this->x_size_, this->d_size_, rng);
 
   auto shared_rng = std::make_shared<RNG<T>>(0); // we just take a new one here (seeds...)
   transfer_pwu_ =
       RPU::make_unique<PulsedRPUWeightUpdater<T>>(this->x_size_, this->d_size_, shared_rng);
 
-  T dw_min = 0.0;
+  granularity_ = 0.0;
   if (dynamic_cast<PulsedRPUDeviceBase<T> *>(&*rpu_device_) != nullptr) {
-    dw_min = dynamic_cast<PulsedRPUDeviceBase<T> *>(&*rpu_device_)->getDwMin();
+    granularity_ = dynamic_cast<PulsedRPUDeviceBase<T> *>(&*rpu_device_)->getWeightGranularity();
   }
-  if (getPar().granularity > 0) {
+  if (par.granularity > 0) {
     // overwrites
-    dw_min = getPar().granularity;
+    granularity_ = par.granularity;
   }
-  if (dw_min <= 0) {
-    RPU_FATAL("Cannot establish granularity from device. Need explicit settiing >=0.");
+  if (granularity_ <= 0) {
+    RPU_FATAL("Cannot establish granularity from device. Need explicit setting >=0.");
   }
-  granularity_ = dw_min;
 }
 
 /*********************************************************************************/

--- a/src/rpucuda/rpu_powstep_device.cpp
+++ b/src/rpucuda/rpu_powstep_device.cpp
@@ -126,12 +126,6 @@ inline void update_once(
 
 } // namespace
 
-template <typename T> T PowStepRPUDevice<T>::getDwMin() const {
-  const auto &par = getPar();
-  // just approximately at zero (used for update management)
-  return par.dw_min * pow(0.5, par.ps_gamma);
-};
-
 template <typename T>
 void PowStepRPUDevice<T>::doSparseUpdate(
     T **weights, int i, const int *x_signed_indices, int x_count, int d_sign, RNG<T> *rng) {

--- a/src/rpucuda/rpu_powstep_device.h
+++ b/src/rpucuda/rpu_powstep_device.h
@@ -35,6 +35,9 @@ BUILD_PULSED_DEVICE_META_PARAMETER(
     ss << "\t ps_gamma_up_down:\t" << ps_gamma_up_down << "\t(dtod=" << ps_gamma_up_down_dtod << ")"
        << std::endl;
     ,
+    /* calc weight granularity body */
+    return this->dw_min * pow(0.5, ps_gamma);
+    ,
     /*Add*/
     bool implementsWriteNoise() const override { return true; };);
 
@@ -110,8 +113,6 @@ template <typename T> class PowStepRPUDevice : public PulsedRPUDevice<T> {
   );
 
   void printDP(int x_count, int d_count) const override;
-
-  T getDwMin() const override;
 
   inline T **getGammaUp() const { return w_gamma_up_; };
   inline T **getGammaDown() const { return w_gamma_down_; };

--- a/src/rpucuda/rpu_pulsed_device.cpp
+++ b/src/rpucuda/rpu_pulsed_device.cpp
@@ -27,6 +27,7 @@ void PulsedRPUDeviceMetaParameter<T>::printToStream(std::stringstream &ss) const
     ss << "\n\t Device parameters set manually\n";
   } else {
     ss << "Pulsed device parameter:" << std::endl;
+    ss << "\t granularity (calc.):\t" << this->calcWeightGranularity() << std::endl;
     if (this->construction_seed != 0) {
       ss << "\t construction_seed:\t" << this->construction_seed << std::endl;
     }
@@ -341,9 +342,12 @@ void PulsedRPUDevice<T>::setDeviceParameter(const std::vector<T *> &data_ptrs) {
 
   dw_min /= this->size_;
   // need dw_min for update management
-  this->checkDwMin(dw_min);
-
-  getPar().dw_min = dw_min; //!! update par. Should be possible since unique
+  if (fabs(dw_min - getPar().dw_min) / getPar().dw_min > 2 * getPar().dw_min_dtod) {
+    RPU_WARNING("DW min seems to have changed during hidden parameter set. Will update parameter "
+                "with estimated value.");
+    getPar().dw_min = dw_min; //!! update par. Should be possible since unique
+    this->setWeightGranularity(getPar().calcWeightGranularity());
+  }
 };
 
 /********************************************************************************/

--- a/src/rpucuda/rpu_pulsed_meta_parameter.h
+++ b/src/rpucuda/rpu_pulsed_meta_parameter.h
@@ -184,7 +184,7 @@ template <typename T> struct PulsedUpdateMetaParameter {
   void initialize();
   virtual int getNK32Default() const { return desired_BL / 32 + 1; };
 
-  virtual void calculateBlAB(int &BL, T &A, T &B, T lr, T dw_min) const;
+  virtual void calculateBlAB(int &BL, T &A, T &B, T lr, T weight_granularity) const;
   virtual void performUpdateManagement(
       int &BL,
       T &A,
@@ -193,7 +193,7 @@ template <typename T> struct PulsedUpdateMetaParameter {
       const T x_abs_max,
       const T d_abs_max,
       const T lr,
-      const T dw_min) const;
+      const T weight_granularity) const;
   void print() const {
     std::stringstream ss;
     printToStream(ss);

--- a/src/rpucuda/rpu_transfer_device.cpp
+++ b/src/rpucuda/rpu_transfer_device.cpp
@@ -561,11 +561,7 @@ void TransferRPUDevice<T>::resetCols(
 
 template <typename T>
 void TransferRPUDevice<T>::setDeviceParameter(const std::vector<T *> &data_ptrs) {
-
   VectorRPUDevice<T>::setDeviceParameter(data_ptrs);
-
-  // take dwmin only from the first
-  this->dw_min_ = this->rpu_device_vec_[0]->getDwMin();
 }
 
 template class TransferRPUDevice<float>;

--- a/src/rpucuda/rpu_transfer_device.h
+++ b/src/rpucuda/rpu_transfer_device.h
@@ -106,6 +106,15 @@ template <typename T> struct TransferRPUDeviceMetaParameter : VectorRPUDeviceMet
   DeviceUpdateType implements() const override { return DeviceUpdateType::Transfer; };
   void printToStream(std::stringstream &ss) const override;
 
+  T calcWeightGranularity() const override {
+    T weight_granularity = 0.0;
+    if (this->vec_par.size() > 0) {
+      // only take that from first (fast) device
+      weight_granularity = this->vec_par[0]->calcWeightGranularity();
+    }
+    return weight_granularity;
+  }
+
   virtual T getTransferLR(int to_device_idx, int from_device_idx, T current_lr) const;
 };
 
@@ -171,7 +180,6 @@ public:
       const T reset_prob,
       const int i_col);
   virtual const T *getTransferVecs() const { return &transfer_vecs_[0]; };
-  T getDwMin() const override { return this->rpu_device_vec_[0]->getDwMin(); };
 
   void doSparseUpdate(
       T **weights, int i, const int *x_signed_indices, int x_count, int d_sign, RNG<T> *rng)

--- a/src/rpucuda/rpu_transfer_device_test.cpp
+++ b/src/rpucuda/rpu_transfer_device_test.cpp
@@ -155,7 +155,7 @@ TEST_P(RPUDeviceTestFixture, doSparseUpdate) {
   rpu_device->initUpdateCycle(this->weights, this->up, 1, 1);
 
   // last row update, net 1 (n_pos-n_neg)
-  float dx = rpu_device->getDwMin() * (n_pos - n_neg);
+  float dx = rpu_device->getWeightGranularity() * (n_pos - n_neg);
   int rowidx = this->d_size - 1;
   rpu_device->doSparseUpdate(
       this->weights, rowidx, this->x_indices, this->n_neg + this->n_pos, (num_t)-1.0, this->rng);
@@ -195,7 +195,7 @@ TEST_P(RPUDeviceTestFixture, doSparseUpdateWithTransfer) {
   rpu_device->initUpdateCycle(this->weights, this->up, 1, 1);
 
   // last row update, net 1 (n_pos-n_neg)
-  float dx = rpu_device->getDwMin() * (n_pos - n_neg);
+  float dx = rpu_device->getWeightGranularity() * (n_pos - n_neg);
   int rowidx = this->d_size - 1;
   rpu_device->doSparseUpdate(
       this->weights, rowidx, this->x_indices, this->n_neg + this->n_pos, (num_t)-1.0, this->rng);


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Update BL management needs an "approximate" device granularity, which was just set to dw_min, however, for some devices this is not quite correct, as it should be approximately the update step at the symmetry point.

## Details

Now the parameter object has a `calcWeightGranularity` function that can be overloaded by a device and the granularity is stored in the device for faster access by the `PulsedBase` classes.

Original contribution by Malte.