### PR TITLE
Added EcRamMOPreset configurations and test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 * `Security` in case of vulnerabilities.
 
 ## [UNRELEASED]
-* A number of new config presets added to the library, namely `EcRamMOPreset`, `EcRamMO2Preset`,
-  `EcRamMO4Preset`, `TikiTakaEcRamMOPreset`, `MixedPrecisionEcRamMOPreset`. These can be used for 
-  tile configuration (`rpu_config`). They specify a particular device and optimizer choice.
+
+### Added
+
+* A number of new config presets added to the library, namely `EcRamMOPreset`,
+  `EcRamMO2Preset`, `EcRamMO4Preset`, `TikiTakaEcRamMOPreset`,
+  `MixedPrecisionEcRamMOPreset`. These can be used for tile configuration
+  (`rpu_config`). They specify a particular device and optimizer choice. (\#207)
 
 ## [0.3.0] - 2021/04/14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 * `Security` in case of vulnerabilities.
 
 ## [UNRELEASED]
-
+* A number of new config presets added to the library, namely `EcRamMOPreset`, `EcRamMO2Preset`,
+  `EcRamMO4Preset`, `TikiTakaEcRamMOPreset`, `MixedPrecisionEcRamMOPreset`. These can be used for 
+  tile configuration (`rpu_config`). They specify a particular device and optimizer choice.
 
 ## [0.3.0] - 2021/04/14
 

--- a/src/aihwkit/simulator/presets/__init__.py
+++ b/src/aihwkit/simulator/presets/__init__.py
@@ -14,16 +14,19 @@
 
 from .configs import (
     # Single device configs.
-    ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, IdealizedPreset,
+    ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, EcRamMOPreset, IdealizedPreset,
     GokmenVlasovPreset,
     # 2-device configs.
-    ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, Idealized2Preset,
+    ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, EcRamMO2Preset,
+    Idealized2Preset,
     # 4-device configs.
-    ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset, Idealized4Preset,
+    ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset, EcRamMO4Preset,
+    Idealized4Preset,
     # Tiki-taka configs.
     TikiTakaReRamESPreset, TikiTakaReRamSBPreset, TikiTakaCapacitorPreset,
-    TikiTakaEcRamPreset, TikiTakaIdealizedPreset,
+    TikiTakaEcRamPreset, TikiTakaEcRamMOPreset, TikiTakaIdealizedPreset,
     # MixedPrecision configs.
     MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset, MixedPrecisionCapacitorPreset,
-    MixedPrecisionEcRamPreset, MixedPrecisionIdealizedPreset, MixedPrecisionGokmenVlasovPreset
+    MixedPrecisionEcRamPreset, MixedPrecisionEcRamMOPreset, MixedPrecisionIdealizedPreset,
+    MixedPrecisionGokmenVlasovPreset,
 )

--- a/src/aihwkit/simulator/presets/configs.py
+++ b/src/aihwkit/simulator/presets/configs.py
@@ -25,7 +25,7 @@ from aihwkit.simulator.configs.utils import (
     IOParameters, UpdateParameters, VectorUnitCellUpdatePolicy
 )
 from aihwkit.simulator.presets.devices import (
-    CapacitorPresetDevice, EcRamPresetDevice, IdealizedPresetDevice,
+    CapacitorPresetDevice, EcRamPresetDevice, EcRamMOPresetDevice, IdealizedPresetDevice,
     ReRamESPresetDevice, ReRamSBPresetDevice, GokmenVlasovPresetDevice
 )
 from aihwkit.simulator.presets.utils import (
@@ -101,7 +101,7 @@ class CapacitorPreset(SingleRPUConfig):
 
 @dataclass
 class EcRamPreset(SingleRPUConfig):
-    """Preset configuration using a single EcRAM device, see
+    """Preset configuration using a single Lithium-based EcRAM device, see
     :class:`~aihwkit.simulator.presets.devices.EcRamPresetDevice`.
 
     This preset uses standard SGD with fully parallel update on analog
@@ -115,6 +115,27 @@ class EcRamPreset(SingleRPUConfig):
     """
 
     device: PulsedDevice = field(default_factory=EcRamPresetDevice)
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class EcRamMOPreset(SingleRPUConfig):
+    """Preset configuration using a single metal-oxide EcRAM device, see
+    :class:`~aihwkit.simulator.presets.devices.EcRamMOPresetDevice`.
+
+    This preset uses standard SGD with fully parallel update on analog
+    with stochastic pulses.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: PulsedDevice = field(default_factory=EcRamMOPresetDevice)
     forward: IOParameters = field(default_factory=PresetIOParameters)
     backward: IOParameters = field(default_factory=PresetIOParameters)
     update: UpdateParameters = field(default_factory=PresetUpdateParameters)
@@ -242,8 +263,8 @@ class Capacitor2Preset(UnitCellRPUConfig):
 
 @dataclass
 class EcRam2Preset(UnitCellRPUConfig):
-    """Preset configuration using two Capacitor devices per cross-point
-    (:class:`~aihwkit.simulator.presets.devices.CapacitorPresetDevice`),
+    """Preset configuration using two Lithium-based EcRam devices per cross-point
+    (:class:`~aihwkit.simulator.presets.devices.EcRamPresetDevice`),
     where both are updated with random selection policy for update.
 
     See :class:`~aihwkit.simulator.configs.devices.VectorUnitCell` for
@@ -258,6 +279,31 @@ class EcRam2Preset(UnitCellRPUConfig):
 
     device: UnitCell = field(default_factory=lambda: VectorUnitCell(
         unit_cell_devices=[EcRamPresetDevice(), EcRamPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class EcRamMO2Preset(UnitCellRPUConfig):
+    """Preset configuration using two metal-oxide EcRam devices per cross-point
+    (:class:`~aihwkit.simulator.presets.devices.EcRamMOPresetDevice`),
+    where both are updated with random selection policy for update.
+
+    See :class:`~aihwkit.simulator.configs.devices.VectorUnitCell` for
+    more details on multiple devices per cross-points.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[EcRamMOPresetDevice(), EcRamMOPresetDevice()],
         update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
     ))
     forward: IOParameters = field(default_factory=PresetIOParameters)
@@ -372,8 +418,8 @@ class Capacitor4Preset(UnitCellRPUConfig):
 
 @dataclass
 class EcRam4Preset(UnitCellRPUConfig):
-    """Preset configuration using four Capacitor devices per cross-point
-    (:class:`~aihwkit.simulator.presets.devices.CapacitorPresetDevice`),
+    """Preset configuration using four Lithium-based EcRam devices per cross-point
+    (:class:`~aihwkit.simulator.presets.devices.EcRamPresetDevice`),
     where both are updated with random selection policy for update.
 
     See :class:`~aihwkit.simulator.configs.devices.VectorUnitCell` for
@@ -389,6 +435,32 @@ class EcRam4Preset(UnitCellRPUConfig):
     device: UnitCell = field(default_factory=lambda: VectorUnitCell(
         unit_cell_devices=[EcRamPresetDevice(), EcRamPresetDevice(),
                            EcRamPresetDevice(), EcRamPresetDevice()],
+        update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
+    ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class EcRamMO4Preset(UnitCellRPUConfig):
+    """Preset configuration using four metal-oxide EcRam devices per cross-point
+    (:class:`~aihwkit.simulator.presets.devices.EcRamMOPresetDevice`),
+    where both are updated with random selection policy for update.
+
+    See :class:`~aihwkit.simulator.configs.devices.VectorUnitCell` for
+    more details on multiple devices per cross-points.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: UnitCell = field(default_factory=lambda: VectorUnitCell(
+        unit_cell_devices=[EcRamMOPresetDevice(), EcRamMOPresetDevice(),
+                           EcRamMOPresetDevice(), EcRamMOPresetDevice()],
         update_policy=VectorUnitCellUpdatePolicy.SINGLE_RANDOM
     ))
     forward: IOParameters = field(default_factory=PresetIOParameters)
@@ -537,6 +609,34 @@ class TikiTakaEcRamPreset(UnitCellRPUConfig):
 
 
 @dataclass
+class TikiTakaEcRamMOPreset(UnitCellRPUConfig):
+    """Configuration using Tiki-taka with
+    :class:`~aihwkit.simulator.presets.devices.EcRamMOPresetDevice`.
+
+    See :class:`~aihwkit.simulator.configs.devices.TransferCompound`
+    for details on Tiki-taka-like optimizers.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: TransferCompound(
+            unit_cell_devices=[EcRamMOPresetDevice(), EcRamMOPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
 class TikiTakaIdealizedPreset(UnitCellRPUConfig):
     """Configuration using Tiki-taka with
     :class:`~aihwkit.simulator.presets.devices.IdealizedPresetDevice`.
@@ -657,6 +757,30 @@ class MixedPrecisionEcRamPreset(DigitalRankUpdateRPUConfig):
     device: DigitalRankUpdateCell = field(
         default_factory=lambda: MixedPrecisionCompound(
             device=EcRamPresetDevice(),
+        ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class MixedPrecisionEcRamMOPreset(DigitalRankUpdateRPUConfig):
+    """Configuration using Mixed-precision with
+    class:`~aihwkit.simulator.presets.devices.EcRamMOPresetDevice`.
+
+    See class:`~aihwkit.simulator.configs.devices.MixedPrecisionCompound`
+    for details on the mixed precision optimizer.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: DigitalRankUpdateCell = field(
+        default_factory=lambda: MixedPrecisionCompound(
+            device=EcRamMOPresetDevice(),
         ))
     forward: IOParameters = field(default_factory=PresetIOParameters)
     backward: IOParameters = field(default_factory=PresetIOParameters)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -16,12 +16,15 @@ from torch import Tensor
 
 from aihwkit.simulator.tiles.analog import AnalogTile
 from aihwkit.simulator.presets import (
-    ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, IdealizedPreset,
+    ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, EcRamMOPreset, IdealizedPreset,
     GokmenVlasovPreset,
-    ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, Idealized2Preset,
-    ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset, Idealized4Preset,
-    TikiTakaReRamESPreset, TikiTakaReRamSBPreset, TikiTakaCapacitorPreset,
-    TikiTakaEcRamPreset, TikiTakaIdealizedPreset
+    ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, EcRamMO2Preset,
+    Idealized2Preset, ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset,
+    EcRamMO4Preset, Idealized4Preset, TikiTakaReRamESPreset, TikiTakaReRamSBPreset,
+    TikiTakaCapacitorPreset, TikiTakaEcRamPreset, TikiTakaEcRamMOPreset, TikiTakaIdealizedPreset,
+    MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset, MixedPrecisionCapacitorPreset,
+    MixedPrecisionEcRamPreset, MixedPrecisionEcRamMOPreset, MixedPrecisionIdealizedPreset,
+    MixedPrecisionGokmenVlasovPreset,
 )
 from .helpers.decorators import parametrize_over_presets
 from .helpers.testcases import AihwkitTestCase
@@ -29,12 +32,16 @@ from .helpers.testcases import AihwkitTestCase
 
 @parametrize_over_presets(
     [
-        ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, IdealizedPreset,
+        ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, EcRamMOPreset, IdealizedPreset,
         GokmenVlasovPreset,
-        ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, Idealized2Preset,
-        ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset, Idealized4Preset,
-        TikiTakaReRamESPreset, TikiTakaReRamSBPreset, TikiTakaCapacitorPreset,
-        TikiTakaEcRamPreset, TikiTakaIdealizedPreset
+        ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, EcRamMO2Preset,
+        Idealized2Preset, ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset,
+        EcRamMO4Preset, Idealized4Preset, TikiTakaReRamESPreset, TikiTakaReRamSBPreset,
+        TikiTakaCapacitorPreset, TikiTakaEcRamPreset, TikiTakaEcRamMOPreset,
+        TikiTakaIdealizedPreset,
+        MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset, MixedPrecisionCapacitorPreset,
+        MixedPrecisionEcRamPreset, MixedPrecisionEcRamMOPreset, MixedPrecisionIdealizedPreset,
+        MixedPrecisionGokmenVlasovPreset,
     ]
 )
 class PresetTest(AihwkitTestCase):


### PR DESCRIPTION
## Description

Added EcRamMOPreset configurations and test

## Details

Added a number of new config presets added to the library, namely `EcRamMOPreset`, `EcRamMO2Preset`, `EcRamMO4Preset`, `TikiTakaEcRamMOPreset`, `MixedPrecisionEcRamMOPreset`. These can be used for tile configuration (`rpu_config`). They specify a particular device and optimizer choice.
