### PR TITLE
Fix bullet rendering in readthedocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 * Weight refresh mechanism for ``OneSidedUnitCell`` to counteract
   saturation, by differential read, reset, and re-write. (\#209)
-  
 * A number of new config presets added to the library, namely `EcRamMOPreset`,
   `EcRamMO2Preset`, `EcRamMO4Preset`, `TikiTakaEcRamMOPreset`,
   `MixedPrecisionEcRamMOPreset`. These can be used for tile configuration
   (`rpu_config`). They specify a particular device and optimizer choice. (\#207)
 
 ### Changed
+
 * Renamed the `DifferenceUnitCell` to `OneSidedUnitCell` which more
   properly reflects its function. (\#209)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx==3.1.2
-sphinx-rtd-theme==0.5.0
+sphinx-rtd-theme==0.5.2
 recommonmark==0.6.0
 torch>=1.7
 matplotlib

--- a/docs/source/using_simulator.rst
+++ b/docs/source/using_simulator.rst
@@ -120,7 +120,7 @@ Unit cell devices
 Resistive device class                                                Description
 ====================================================================  ========
 :class:`~aihwkit.simulator.configs.devices.VectorUnitCell`            abstract resistive device that combines multiple pulsed resistive devices in a single 'unit cell'.
-:class:`~aihwkit.simulator.configs.devices.DifferenceUnitCell`        abstract device model that takes an arbitrary device per crosspoint and implements an one-sided plus-minus device pair, where both devices only receive only positive updates and a refresh or reset needs to be added to avoid saturation.
+:class:`~aihwkit.simulator.configs.devices.OneSidedUnitCell`          abstract device model that takes an arbitrary device per crosspoint and implements an explicit plus-minus device pair with one sided update.
 :class:`~aihwkit.simulator.configs.devices.ReferenceUnitCell`         abstract device model takes two arbitrary device per cross-point and implements an device with reference pair.
 ====================================================================  ========
 


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

It seems that some recent changes in `docutils` resulted in the rendered documentation having some style issues, most notably the bullets in the lists. As suggested in https://github.com/readthedocs/sphinx_rtd_theme/issues/1115, this PR bumps the theme version to `0.5.2`, which pins the version of `docutils` used.

## Details

Additionally, added small tweaks in the changelog and the documentation to keep it up to date with the latest commits.
