### PR TITLE
Lighter import of Tile's default config

### DIFF
--- a/src/aihwkit/simulator/tiles/analog.py
+++ b/src/aihwkit/simulator/tiles/analog.py
@@ -191,7 +191,12 @@ class AnalogTile(BaseTile):
             in_trans: bool = False,
             out_trans: bool = False,
     ):
-        rpu_config = rpu_config or SingleRPUConfig(device=ConstantStepDevice())
+        if not rpu_config:
+            # Import `SingleRPUConfig` dynamically to avoid import cycles.
+            # pylint: disable=import-outside-toplevel
+            from aihwkit.simulator.configs import SingleRPUConfig
+            rpu_config = SingleRPUConfig(device=ConstantStepDevice())
+
         super().__init__(out_size, in_size, rpu_config, bias, in_trans, out_trans)
 
     def cpu(self) -> 'BaseTile':

--- a/src/aihwkit/simulator/tiles/analog.py
+++ b/src/aihwkit/simulator/tiles/analog.py
@@ -13,19 +13,21 @@
 """High level analog tiles (analog)."""
 
 from copy import deepcopy
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 
 from torch import device as torch_device
 from torch.cuda import current_device, current_stream
 from torch.cuda import device as cuda_device
 
 from aihwkit.exceptions import CudaError
-from aihwkit.simulator.configs import (
-    InferenceRPUConfig, SingleRPUConfig, UnitCellRPUConfig
-)
 from aihwkit.simulator.configs.devices import ConstantStepDevice
 from aihwkit.simulator.rpu_base import cuda, tiles
 from aihwkit.simulator.tiles.base import BaseTile
+
+if TYPE_CHECKING:
+    from aihwkit.simulator.configs import (
+        InferenceRPUConfig, SingleRPUConfig, UnitCellRPUConfig
+    )
 
 
 class AnalogTile(BaseTile):
@@ -185,8 +187,8 @@ class AnalogTile(BaseTile):
             self,
             out_size: int,
             in_size: int,
-            rpu_config: Optional[Union[SingleRPUConfig, UnitCellRPUConfig,
-                                       InferenceRPUConfig]] = None,
+            rpu_config: Optional[Union['SingleRPUConfig', 'UnitCellRPUConfig',
+                                       'InferenceRPUConfig']] = None,
             bias: bool = False,
             in_trans: bool = False,
             out_trans: bool = False,
@@ -230,7 +232,7 @@ class AnalogTile(BaseTile):
             self,
             x_size: int,
             d_size: int,
-            rpu_config: Union[SingleRPUConfig, UnitCellRPUConfig, InferenceRPUConfig]
+            rpu_config: Union['SingleRPUConfig', 'UnitCellRPUConfig', 'InferenceRPUConfig']
     ) -> tiles.AnalogTile:
         """Create a simulator tile.
 

--- a/src/aihwkit/simulator/tiles/floating_point.py
+++ b/src/aihwkit/simulator/tiles/floating_point.py
@@ -13,16 +13,18 @@
 """High level analog tiles (floating point)."""
 
 from copy import deepcopy
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 
 from torch import device as torch_device
 from torch.cuda import current_device, current_stream
 from torch.cuda import device as cuda_device
 
 from aihwkit.exceptions import CudaError
-from aihwkit.simulator.configs import FloatingPointRPUConfig
 from aihwkit.simulator.rpu_base import cuda, tiles
 from aihwkit.simulator.tiles.base import BaseTile
+
+if TYPE_CHECKING:
+    from aihwkit.simulator.configs import FloatingPointRPUConfig
 
 
 class FloatingPointTile(BaseTile):
@@ -104,7 +106,7 @@ class FloatingPointTile(BaseTile):
             self,
             out_size: int,
             in_size: int,
-            rpu_config: Optional[FloatingPointRPUConfig] = None,
+            rpu_config: Optional['FloatingPointRPUConfig'] = None,
             bias: bool = False,
             in_trans: bool = False,
             out_trans: bool = False,
@@ -147,7 +149,7 @@ class FloatingPointTile(BaseTile):
             self,
             x_size: int,
             d_size: int,
-            rpu_config: FloatingPointRPUConfig
+            rpu_config: 'FloatingPointRPUConfig'
     ) -> tiles.FloatingPointTile:
         """Create a simulator tile.
 

--- a/src/aihwkit/simulator/tiles/floating_point.py
+++ b/src/aihwkit/simulator/tiles/floating_point.py
@@ -109,7 +109,11 @@ class FloatingPointTile(BaseTile):
             in_trans: bool = False,
             out_trans: bool = False,
     ):
-        rpu_config = rpu_config or FloatingPointRPUConfig()
+        if not rpu_config:
+            # Import `FloatingPointRPUConfig` dynamically to avoid import cycles.
+            # pylint: disable=import-outside-toplevel
+            from aihwkit.simulator.configs import FloatingPointRPUConfig
+            rpu_config = FloatingPointRPUConfig()
         super().__init__(out_size, in_size, rpu_config, bias, in_trans, out_trans)
 
     def cpu(self) -> 'BaseTile':

--- a/src/aihwkit/simulator/tiles/inference.py
+++ b/src/aihwkit/simulator/tiles/inference.py
@@ -53,7 +53,11 @@ class InferenceTile(AnalogTile):
             in_trans: bool = False,
             out_trans: bool = False
     ):
-        rpu_config = rpu_config or InferenceRPUConfig()
+        if not rpu_config:
+            # Import `InferenceRPUConfig` dynamically to avoid import cycles.
+            # pylint: disable=import-outside-toplevel
+            from aihwkit.simulator.configs import InferenceRPUConfig
+            rpu_config = InferenceRPUConfig()
 
         # Noise model.
         self.noise_model = deepcopy(rpu_config.noise_model)

--- a/src/aihwkit/simulator/tiles/inference.py
+++ b/src/aihwkit/simulator/tiles/inference.py
@@ -13,7 +13,7 @@
 """High level analog tiles (inference)."""
 
 from copy import deepcopy
-from typing import List, Optional, Union
+from typing import List, Optional, Union, TYPE_CHECKING
 
 from torch import device as torch_device
 from torch import ones, Tensor
@@ -22,12 +22,14 @@ from torch.cuda import current_device, current_stream
 from torch.cuda import device as cuda_device
 
 from aihwkit.exceptions import CudaError
-from aihwkit.simulator.configs import InferenceRPUConfig
 from aihwkit.simulator.configs.helpers import parameters_to_bindings
 from aihwkit.simulator.configs.utils import WeightClipType, WeightModifierType
 from aihwkit.simulator.rpu_base import cuda, tiles
 from aihwkit.simulator.tiles.analog import AnalogTile
 from aihwkit.simulator.tiles.base import BaseTile
+
+if TYPE_CHECKING:
+    from aihwkit.simulator.configs import InferenceRPUConfig
 
 
 class InferenceTile(AnalogTile):
@@ -48,7 +50,7 @@ class InferenceTile(AnalogTile):
             self,
             out_size: int,
             in_size: int,
-            rpu_config: Optional[InferenceRPUConfig] = None,
+            rpu_config: Optional['InferenceRPUConfig'] = None,
             bias: bool = False,
             in_trans: bool = False,
             out_trans: bool = False


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Make the `import` of the RPU Configurations that are used by default in the `Tiles` (ie. if a `rpu_config` is not provided) at runtime, instead of a regular module import. The `Tile` and `RPUConfig` classes are naturally quite coupled, and while this change does not solve the coupling or potential import cycles fully, it should ease the introduction of upcoming changes (namely, being able to specify the tiles from the rpu configs directly).

## Details

<!-- A more elaborate description of the changes, if needed. -->
