### PR TITLE
Specify tile class in RPU Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 * Renamed the `DifferenceUnitCell` to `OneSidedUnitCell` which more
   properly reflects its function. (\#209)
+* The `BaseTile` subclass that is instantiated in the analog layers is now
+  retrieved from the new `RPUConfig.tile_class` attribute, facilitating the
+  use of custom tiles. (\#218)
 
 ## [0.3.0] - 2021/04/14
 

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -12,7 +12,7 @@
 
 """Base class for analog Modules."""
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 from torch import device as torch_device
 from torch import Tensor
@@ -23,9 +23,11 @@ from aihwkit.simulator.configs import (
     FloatingPointRPUConfig, InferenceRPUConfig, SingleRPUConfig,
     UnitCellRPUConfig
 )
-from aihwkit.simulator.tiles import (
-    AnalogTile, BaseTile, FloatingPointTile, InferenceTile
-)
+from aihwkit.simulator.tiles import InferenceTile
+
+if TYPE_CHECKING:
+    from aihwkit.simulator.tiles import BaseTile
+
 
 RPUConfigAlias = Union[FloatingPointRPUConfig, SingleRPUConfig,
                        UnitCellRPUConfig, InferenceRPUConfig]
@@ -49,10 +51,6 @@ class AnalogModuleBase(Module):
     """
     # pylint: disable=abstract-method
 
-    TILE_CLASS_FLOATING_POINT: Any = FloatingPointTile
-    TILE_CLASS_ANALOG: Any = AnalogTile
-    TILE_CLASS_INFERENCE: Any = InferenceTile
-
     def _setup_tile(
             self,
             in_features: int,
@@ -61,7 +59,7 @@ class AnalogModuleBase(Module):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0
-    ) -> BaseTile:
+    ) -> 'BaseTile':
         """Create an analog tile and setup this layer for using it.
 
         Create an analog tile to be used for the basis of this layer operations,
@@ -109,14 +107,7 @@ class AnalogModuleBase(Module):
         self.out_features = out_features
 
         # Create the tile.
-        if isinstance(rpu_config, FloatingPointRPUConfig):
-            tile_class = self.TILE_CLASS_FLOATING_POINT
-        elif isinstance(rpu_config, InferenceRPUConfig):
-            tile_class = self.TILE_CLASS_INFERENCE
-        else:
-            tile_class = self.TILE_CLASS_ANALOG
-
-        return tile_class(out_features, in_features, rpu_config, bias=bias)
+        return rpu_config.tile_class(out_features, in_features, rpu_config, bias=bias)
 
     def set_weights(
             self,

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -48,6 +48,8 @@ class AnalogModuleBase(Module):
       for performance reasons. The canonical way of reading and writing
       weights is via the ``set_weights()`` and ``get_weights()`` as opposed
       to using the attributes directly.
+    * the ``BaseTile`` subclass that is created is retrieved from the
+      ``rpu_config.tile_class`` attribute.
     """
     # pylint: disable=abstract-method
 

--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -40,6 +40,7 @@ class FloatingPointRPUConfig(_PrintableMixin):
     """Configuration for a floating point resistive processing unit."""
 
     tile_class: ClassVar[Type] = FloatingPointTile
+    """Tile class that correspond to this RPUConfig."""
 
     device: FloatingPointDevice = field(default_factory=FloatingPointDevice)
     """Parameters that modify the behavior of the pulsed device."""
@@ -50,6 +51,7 @@ class SingleRPUConfig(_PrintableMixin):
     """Configuration for an analog (pulsed device) resistive processing unit."""
 
     tile_class: ClassVar[Type] = AnalogTile
+    """Tile class that correspond to this RPUConfig."""
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 
@@ -75,6 +77,7 @@ class UnitCellRPUConfig(_PrintableMixin):
     """Configuration for an analog (unit cell) resistive processing unit."""
 
     tile_class: ClassVar[Type] = AnalogTile
+    """Tile class that correspond to this RPUConfig."""
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 
@@ -109,6 +112,7 @@ class InferenceRPUConfig(_PrintableMixin):
     # pylint: disable=too-many-instance-attributes
 
     tile_class: ClassVar[Type] = InferenceTile
+    """Tile class that correspond to this RPUConfig."""
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 
@@ -162,6 +166,7 @@ class DigitalRankUpdateRPUConfig(_PrintableMixin):
     """
 
     tile_class: ClassVar[Type] = AnalogTile
+    """Tile class that correspond to this RPUConfig."""
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 

--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -32,10 +32,14 @@ from aihwkit.simulator.noise_models import (
 )
 from aihwkit.simulator.rpu_base import devices
 
+from aihwkit.simulator.tiles import AnalogTile, FloatingPointTile, InferenceTile
+
 
 @dataclass
 class FloatingPointRPUConfig(_PrintableMixin):
     """Configuration for a floating point resistive processing unit."""
+
+    tile_class: ClassVar[Type] = FloatingPointTile
 
     device: FloatingPointDevice = field(default_factory=FloatingPointDevice)
     """Parameters that modify the behavior of the pulsed device."""
@@ -44,6 +48,8 @@ class FloatingPointRPUConfig(_PrintableMixin):
 @dataclass
 class SingleRPUConfig(_PrintableMixin):
     """Configuration for an analog (pulsed device) resistive processing unit."""
+
+    tile_class: ClassVar[Type] = AnalogTile
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 
@@ -67,6 +73,8 @@ class SingleRPUConfig(_PrintableMixin):
 @dataclass
 class UnitCellRPUConfig(_PrintableMixin):
     """Configuration for an analog (unit cell) resistive processing unit."""
+
+    tile_class: ClassVar[Type] = AnalogTile
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 
@@ -99,6 +107,8 @@ class InferenceRPUConfig(_PrintableMixin):
     and read noise can be used.
     """
     # pylint: disable=too-many-instance-attributes
+
+    tile_class: ClassVar[Type] = InferenceTile
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 
@@ -150,6 +160,8 @@ class DigitalRankUpdateRPUConfig(_PrintableMixin):
     used, and during update the digitally computed rank update is
     transferred to the analog crossbar using pulses.
     """
+
+    tile_class: ClassVar[Type] = AnalogTile
 
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Update the `BaseTile` in order to retrieve the tile class it needs to instantiate from the `RPUConfig` (via a new `tile_class` attribute defined on those), decoupling tiles from analog layers (albeit not fully). With this change (which needed https://github.com/IBM/aihwkit/pull/213), a user should have an easier way to use a custom tile via defining a `RPUConfig` that uses the tile - for example (from the test):

```python
class CustomAnalogTile(AnalogTile):
    """Helper tile for ``CustomTileTest``."""
    ...

class CustomRPUConfig(SingleRPUConfig):
    """Helper rpu config for ``CustomTileTest``."""
    tile_class = CustomAnalogTile
    ...

my_layer = AnalogLinear(..., rpu_config=CustomRPUConfig(...))
```

## Details

<!-- A more elaborate description of the changes, if needed. -->
