### PR TITLE
More flexible dataset options in BasicTraining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 * The `BaseTile` subclass that is instantiated in the analog layers is now
   retrieved from the new `RPUConfig.tile_class` attribute, facilitating the
   use of custom tiles. (\#218)
+* The default parameter for the `dataset` constructor used by `BasicTraining`
+  is now the `train=bool` argument. If using a dataset that requires other
+  arguments or transforms, they can now be specified via overriding
+  `get_dataset_arguments()` and `get_dataset_transform()`. (\#225)
 
 ## [0.3.0] - 2021/04/14
 


### PR DESCRIPTION
## Related issues

Closes #223 

## Description

Add two functions to `BasicTraining`:
* `get_dataset_transform()`
* `get_data_loaders()`

along with changing the default dataset constructor arguments to `train=False` and `train=True` (instead of the `split` string parameter), in order to allow for using different datasets more gracefully. 

## Details

This still does not solve the using of datasets directly fully, but hopefully allows for slightly more general defaults - and for the remaining cases, it should also help making the usage less verbose (via subclassing `BasicTraining` and just overriding the functions, in a similar way to example `14`).
