### PR TITLE
PCM presets with complex noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ The format is based on [Keep a Changelog], and this project adheres to
   (`rpu_config`). They specify a particular device and optimizer choice. (\#207)
 * Weight refresh mechanism for ``OneSidedUnitCell`` to counteract
   saturation, by differential read, reset, and re-write. (\#209)
-* Complex cycle-to-cycle noise for ``ExpStepDevice`` (\#???)
-* PCM Preset added (\#???)
+* Complex cycle-to-cycle noise for ``ExpStepDevice`` (\#226)
+* Added the following presets: ``PCMPresetDevice`` (uni-directional),
+  ``PCMPresetUnitCell`` (a pair of uni-directional devices with
+  periodical refresh) and a ``MixedPrecisionPCMPreset`` for using the
+  mixed precision optimizer with a PCM pair. (\#226)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-* Weight refresh mechanism for ``OneSidedUnitCell`` to counteract
-  saturation, by differential read, reset, and re-write. (\#209)
 * A number of new config presets added to the library, namely `EcRamMOPreset`,
   `EcRamMO2Preset`, `EcRamMO4Preset`, `TikiTakaEcRamMOPreset`,
   `MixedPrecisionEcRamMOPreset`. These can be used for tile configuration
   (`rpu_config`). They specify a particular device and optimizer choice. (\#207)
+* Weight refresh mechanism for ``OneSidedUnitCell`` to counteract
+  saturation, by differential read, reset, and re-write. (\#209)
+* Complex cycle-to-cycle noise for ``ExpStepDevice`` (\#???)
+* PCM Preset added (\#???)
 
 ### Changed
 

--- a/examples/10_plot_presets.py
+++ b/examples/10_plot_presets.py
@@ -21,30 +21,35 @@ from aihwkit.utils.visualization import plot_device, plot_device_compact
 
 from aihwkit.simulator.presets.devices import (
     ReRamSBPresetDevice, ReRamESPresetDevice, CapacitorPresetDevice,
-    EcRamPresetDevice, IdealizedPresetDevice
+    EcRamPresetDevice, IdealizedPresetDevice, EcRamMOPresetDevice,
+    PCMPresetUnitCell,
 )
 
 
 plt.ion()
 
-# ReRam based on ExpStep
-plot_device(ReRamESPresetDevice(), n_steps=1000)
-plot_device_compact(ReRamESPresetDevice(), n_steps=1000)
-
-# ReRam based on SoftBounds
-plot_device(ReRamSBPresetDevice(), n_steps=1000)
-plot_device_compact(ReRamSBPresetDevice(), n_steps=1000)
-
-# Capacitor
-plot_device(CapacitorPresetDevice(), n_steps=400)
-plot_device_compact(CapacitorPresetDevice(), n_steps=400)
-
-# ECRAM
-plot_device(EcRamPresetDevice(), n_steps=1000)
-plot_device_compact(EcRamPresetDevice(), n_steps=1000)
+# Note alternatively one can use plot_device_compact for a more compact
+# plot.
 
 # Idealized
 plot_device(IdealizedPresetDevice(), n_steps=10000)
-plot_device_compact(IdealizedPresetDevice(), n_steps=10000)
+
+# ReRam based on ExpStep
+plot_device(ReRamESPresetDevice(), n_steps=1000)
+
+# ReRam based on SoftBounds
+plot_device(ReRamSBPresetDevice(), n_steps=1000)
+
+# Capacitor
+plot_device(CapacitorPresetDevice(), n_steps=400)
+
+# ECRAM
+plot_device(EcRamPresetDevice(), n_steps=1000)
+
+# Mo-ECRAM
+plot_device(EcRamMOPresetDevice(), n_steps=8000)
+
+# PCM
+plot_device(PCMPresetUnitCell(), n_steps=80)
 
 plt.show()

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -198,7 +198,7 @@ class WeightModifierType(Enum):
     In detail, for the duration of a mini-batch, each weight will be
     added a Gaussian random number with the standard deviation of
     :math:`\sigma_\text{wnoise} (c_0 + c_1 w_{ij}/\omega + c_2
-    w_ij^2/\omega^2` where :math:`omega` is either the actual max
+    w_{ij}^2/\omega^2` where :math:`omega` is either the actual max
     weight (if ``rel_to_actual_wmax`` is set) or the value
     ``assumed_wmax``.
     """

--- a/src/aihwkit/simulator/presets/__init__.py
+++ b/src/aihwkit/simulator/presets/__init__.py
@@ -15,7 +15,7 @@
 from .configs import (
     # Single device configs.
     ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, EcRamMOPreset, IdealizedPreset,
-    GokmenVlasovPreset,
+    GokmenVlasovPreset, PCMPreset,
     # 2-device configs.
     ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, EcRamMO2Preset,
     Idealized2Preset,
@@ -28,5 +28,5 @@ from .configs import (
     # MixedPrecision configs.
     MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset, MixedPrecisionCapacitorPreset,
     MixedPrecisionEcRamPreset, MixedPrecisionEcRamMOPreset, MixedPrecisionIdealizedPreset,
-    MixedPrecisionGokmenVlasovPreset,
+    MixedPrecisionGokmenVlasovPreset, MixedPrecisionPCMPreset
 )

--- a/src/aihwkit/simulator/presets/configs.py
+++ b/src/aihwkit/simulator/presets/configs.py
@@ -26,7 +26,8 @@ from aihwkit.simulator.configs.utils import (
 )
 from aihwkit.simulator.presets.devices import (
     CapacitorPresetDevice, EcRamPresetDevice, EcRamMOPresetDevice, IdealizedPresetDevice,
-    ReRamESPresetDevice, ReRamSBPresetDevice, GokmenVlasovPresetDevice
+    ReRamESPresetDevice, ReRamSBPresetDevice, GokmenVlasovPresetDevice,
+    PCMPresetUnitCell
 )
 from aihwkit.simulator.presets.utils import (
     PresetIOParameters, PresetUpdateParameters
@@ -179,6 +180,27 @@ class GokmenVlasovPreset(SingleRPUConfig):
     """
 
     device: PulsedDevice = field(default_factory=GokmenVlasovPresetDevice)
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class PCMPreset(UnitCellRPUConfig):
+    """Preset configuration using a single pair of PCM devicec with refresh, see
+    :class:`~aihwkit.simulator.presets.devices.PCMPresetUnitCell`.
+
+    This preset uses standard SGD with fully parallel update on analog
+    with stochastic pulses.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: UnitCell = field(default_factory=PCMPresetUnitCell)
     forward: IOParameters = field(default_factory=PresetIOParameters)
     backward: IOParameters = field(default_factory=PresetIOParameters)
     update: UpdateParameters = field(default_factory=PresetUpdateParameters)
@@ -829,6 +851,30 @@ class MixedPrecisionGokmenVlasovPreset(DigitalRankUpdateRPUConfig):
     device: DigitalRankUpdateCell = field(
         default_factory=lambda: MixedPrecisionCompound(
             device=GokmenVlasovPresetDevice(),
+        ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class MixedPrecisionPCMPreset(DigitalRankUpdateRPUConfig):
+    """Configuration using Mixed-precision with
+    class:`~aihwkit.simulator.presets.devices.PCMPresetDevice`.
+
+    See class:`~aihwkit.simulator.configs.devices.MixedPrecisionCompound`
+    for details on the mixed precision optimizer.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: DigitalRankUpdateCell = field(
+        default_factory=lambda: MixedPrecisionCompound(
+            device=PCMPresetUnitCell(),
         ))
     forward: IOParameters = field(default_factory=PresetIOParameters)
     backward: IOParameters = field(default_factory=PresetIOParameters)

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -486,6 +486,8 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("a", &ExpStepParam::es_a)
       .def_readwrite("b", &ExpStepParam::es_b)
       .def_readwrite("write_noise_std", &ExpStepParam::write_noise_std)
+      .def_readwrite("dw_min_std_add", &ExpStepParam::dw_min_std_add)
+      .def_readwrite("dw_min_std_slope", &ExpStepParam::dw_min_std_slope)
       .def(
           "__str__",
           [](ExpStepParam &self) {
@@ -539,6 +541,7 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("refresh_update", &OneSidedParam::refresh_up)
       .def_readwrite("refresh_upper_thres", &OneSidedParam::refresh_upper_thres)
       .def_readwrite("refresh_lower_thres", &OneSidedParam::refresh_lower_thres)
+      .def_readwrite("copy_inverted", &OneSidedParam::copy_inverted)
       .def(
           "__str__",
           [](OneSidedParam &self) {

--- a/src/aihwkit/simulator/tiles/analog.py
+++ b/src/aihwkit/simulator/tiles/analog.py
@@ -147,7 +147,7 @@ class AnalogTile(BaseTile):
 
         for t in range(BL):
             if (pulse_train_x[t]==1) and (pulse_train_d[t]==1)
-                update_once(w_ij, direction = sign)
+                update_once(w_{ij}, direction = sign)
 
     The probabilities are generated using scaling factors ``A`` and ``B`` that
     are determined by the learning rate and pulse train length ``BL`` (see

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -246,8 +246,8 @@ class BaseTile(Generic[RPUConfigGeneric]):
         output of forward and backward pass, and the learning rate for this tile
         is adjusted accordingly.
 
-        The weights are scaled by :math:`\omega/\max_{ij} |w_ij|` and the global
-        digital factor :math:`alpha` is set to :math:`\max_{ij} |w_ij|/\omega`.
+        The weights are scaled by :math:`\omega/\max_{ij} |w_{ij}|` and the global
+        digital factor :math:`alpha` is set to :math:`\max_{ij} |w_{ij}|/\omega`.
 
         It can be shown that such a constant factor greatly improves the SNR and
         training accuracy as the full weight range of the analog devices are

--- a/src/rpucuda/cuda/rpucuda_expstep_device.cu
+++ b/src/rpucuda/cuda/rpucuda_expstep_device.cu
@@ -15,7 +15,7 @@
 #include "rpucuda_expstep_device.h"
 
 namespace RPU {
-
+namespace {
 #define UPDATE_ONCE                                                                                \
   {                                                                                                \
     T z = 2.0 * w / b_diff * a + b;                                                                \
@@ -54,9 +54,9 @@ template <typename T> struct UpdateFunctorExpStep {
     T wmin = par_4.x; //[0];
     T b_diff = (wmax - wmin);
 
-    T &w = uw_std > 0 ? persistent_weight : apparent_weight;
+    T &w = uw_std > 0.0f ? persistent_weight : apparent_weight;
 
-    if (b_diff > 0) { // only do something when bounds make sense
+    if (b_diff > 0.0f) { // only do something when bounds make sense
 
       T A = negative ? global_pars[1] : global_pars[0];        // 1: up, 0: down
       T gamma = negative ? global_pars[3] : (-global_pars[2]); // 3: up, 2 down
@@ -82,7 +82,112 @@ template <typename T> struct UpdateFunctorExpStep {
 };
 #undef UPDATE_ONCE
 
-RPUCUDA_DEVICE_ADD_FUNCTOR_UPDATE_KERNELS(ExpStep, UpdateFunctorExpStep<T>, 7);
+#define UPDATE_ONCE_COMPLEX_NOISE                                                                  \
+  {                                                                                                \
+    T z = 2.0 * w / b_diff * a + b;                                                                \
+    T y = 1.0 - A * __expf(gamma * z);                                                             \
+    if (y > 0.0f) {                                                                                \
+      T dw_act = y * dw;                                                                           \
+      T stoch_value = curand_normal(&local_state);                                                 \
+      stoch_value *= noise_std_dw * (fabs(dw_act) + dw_std_add + dw_std_slope * fabs(w));          \
+      w += dw_act + stoch_value;                                                                   \
+      w = (w > wmax) ? wmax : w;                                                                   \
+      w = (w < wmin) ? wmin : w;                                                                   \
+    }                                                                                              \
+  }
+
+template <typename T> struct UpdateFunctorExpStepComplexNoise {
+
+  __device__ __forceinline__ void operator()(
+      T &apparent_weight,
+      uint32_t n,
+      uint32_t negative,
+      const float4 par_4,
+      const float2 par_2,
+      T &persistent_weight,
+      const T *global_pars,
+      T noise_std_dw,
+      curandState &local_state)
+
+  {
+    // par_4 order (min_bound, scale_down, max_bound, scale_up )
+    // global_pars see below
+    T uw_std = global_pars[6];
+    T dw_std_add = global_pars[7];
+    T dw_std_slope = global_pars[8];
+    T wmax = par_4.z; //[2];
+    T wmin = par_4.x; //[0];
+    T b_diff = (wmax - wmin);
+
+    T &w = uw_std > 0.0f ? persistent_weight : apparent_weight;
+
+    if (b_diff > 0.0f) { // only do something when bounds make sense
+
+      T A = negative ? global_pars[1] : global_pars[0];        // 1: up, 0: down
+      T gamma = negative ? global_pars[3] : (-global_pars[2]); // 3: up, 2 down
+      T a = global_pars[4];
+      T b = global_pars[5];
+      T dw = (negative > 0) ? (par_4.w) : (-par_4.y); // [3], [1]
+
+      // n is larger 0 in any case
+      if (n == 1) {
+        UPDATE_ONCE_COMPLEX_NOISE;
+      } else {
+        for (int i_updates = 0; i_updates < n; i_updates++) {
+          UPDATE_ONCE_COMPLEX_NOISE;
+        }
+      }
+      // add update write noise onto apparent weight
+      if (uw_std > 0) {
+        T stoch_value = curand_normal(&local_state);
+        apparent_weight = persistent_weight + uw_std * stoch_value;
+      }
+    }
+  }
+};
+#undef UPDATE_ONCE_COMPLEX_NOISE
+
+} // namespace
+
+template <typename T>
+pwukpvec_t<T> ExpStepRPUDeviceCuda<T>::getUpdateKernels(
+    int m_batch, int nK32, int use_bo64, bool out_trans, const PulsedUpdateMetaParameter<T> &up) {
+
+  pwukpvec_t<T> v;
+  const auto &pars = getPar();
+
+  if (pars.hasComplexNoise()) {
+    v.push_back(RPU::make_unique<
+                PWUKernelParameterSingleFunctor<T, UpdateFunctorExpStepComplexNoise<T>, 9>>(
+        this->context_, this->x_size_, this->d_size_, m_batch, nK32, use_bo64, out_trans, up,
+        pars.getName()));
+
+    v.push_back(
+        RPU::make_unique<PWUKernelParameterBatchFunctor<T, UpdateFunctorExpStepComplexNoise<T>, 9>>(
+            this->context_, this->x_size_, this->d_size_, m_batch, nK32, use_bo64, out_trans, up,
+            pars.getName()));
+
+    v.push_back(RPU::make_unique<
+                PWUKernelParameterBatchSharedFunctor<T, UpdateFunctorExpStepComplexNoise<T>, 9>>(
+        this->context_, this->x_size_, this->d_size_, m_batch, nK32, use_bo64, out_trans, up,
+        pars.getName()));
+
+  } else {
+    v.push_back(RPU::make_unique<PWUKernelParameterSingleFunctor<T, UpdateFunctorExpStep<T>, 7>>(
+        this->context_, this->x_size_, this->d_size_, m_batch, nK32, use_bo64, out_trans, up,
+        pars.getName()));
+
+    v.push_back(RPU::make_unique<PWUKernelParameterBatchFunctor<T, UpdateFunctorExpStep<T>, 7>>(
+        this->context_, this->x_size_, this->d_size_, m_batch, nK32, use_bo64, out_trans, up,
+        pars.getName()));
+
+    v.push_back(
+        RPU::make_unique<PWUKernelParameterBatchSharedFunctor<T, UpdateFunctorExpStep<T>, 7>>(
+            this->context_, this->x_size_, this->d_size_, m_batch, nK32, use_bo64, out_trans, up,
+            pars.getName()));
+  }
+  return v;
+}
 
 template class ExpStepRPUDeviceCuda<float>;
 #ifdef RPU_USE_DOUBLE

--- a/src/rpucuda/cuda/rpucuda_expstep_device.h
+++ b/src/rpucuda/cuda/rpucuda_expstep_device.h
@@ -26,7 +26,7 @@ public:
       ExpStepRPUDeviceCuda,
       ExpStepRPUDevice,
       /*ctor body*/
-      dev_es_par_ = std::unique_ptr<CudaArray<T>>(new CudaArray<T>(this->context_, 7));
+      dev_es_par_ = std::unique_ptr<CudaArray<T>>(new CudaArray<T>(this->context_, 9));
       ,
       /*dtor body*/
       ,
@@ -40,7 +40,7 @@ public:
       swap(a.dev_es_par_, b.dev_es_par_);
       ,
       /*host copy from cpu (rpu_device). Parent device params are copyied automatically*/
-      T es_par_arr[7];
+      T es_par_arr[9];
       auto &par = getPar();
       es_par_arr[0] = par.es_A_down;
       es_par_arr[1] = par.es_A_up;
@@ -48,7 +48,9 @@ public:
       es_par_arr[3] = par.es_gamma_up;
       es_par_arr[4] = par.es_a;
       es_par_arr[5] = par.es_b;
-      es_par_arr[6] = getPar().getScaledWriteNoise();
+      es_par_arr[6] = par.getScaledWriteNoise();
+      es_par_arr[7] = par.dw_min_std_add;
+      es_par_arr[8] = par.dw_min_std_slope;
       dev_es_par_->assign(es_par_arr);
       this->context_->synchronize();)
 

--- a/src/rpucuda/rpu_expstep_device.cpp
+++ b/src/rpucuda/rpu_expstep_device.cpp
@@ -19,7 +19,6 @@ void ExpStepRPUDevice<T>::populate(
     const ExpStepRPUDeviceMetaParameter<T> &p, RealWorldRNG<T> *rng) {
   PulsedRPUDevice<T>::populate(p, rng);
 }
-
 template <typename T>
 inline void update_once(
     T &w,
@@ -62,6 +61,53 @@ inline void update_once(
 }
 
 template <typename T>
+inline void update_once_complex_noise(
+    T &w,
+    T &w_apparent,
+    int &sign,
+    T &min_bound,
+    T &max_bound,
+    T &scale_down,
+    T &scale_up,
+    const T &es_a,
+    const T &es_b,
+    const T &es_A_down,
+    const T &es_A_up,
+    const T &es_gamma_down,
+    const T &es_gamma_up,
+    const T &dw_min_std,
+    const T &dw_min_std_add,
+    const T &dw_min_std_slope,
+    const T &write_noise_std,
+    RNG<T> *rng) {
+  T b_diff = (max_bound - min_bound);
+  if (b_diff > 0.0) {
+    T z = (T)2.0 * w / b_diff * es_a + es_b;
+    T dw;
+
+    if (sign > 0) {
+      T y_down = MAX((T)1 - es_A_down * expf(es_gamma_down * (-z)), (T)0);
+      dw = -y_down * scale_down;
+
+    } else {
+      T y_up = MAX(1 - es_A_up * expf(es_gamma_up * z), (T)0);
+      dw = y_up * scale_up;
+    }
+
+    T dw_std = dw_min_std * (fabs(dw) + dw_min_std_add + dw_min_std_slope * fabs(w));
+    w += dw + dw_std * rng->sampleGauss();
+
+    // always check both bounds
+    w = MIN(w, max_bound);
+    w = MAX(w, min_bound);
+
+    if (write_noise_std > (T)0.0) {
+      w_apparent = w + write_noise_std * rng->sampleGauss();
+    }
+  }
+}
+
+template <typename T>
 void ExpStepRPUDevice<T>::doSparseUpdate(
     T **weights, int i, const int *x_signed_indices, int x_count, int d_sign, RNG<T> *rng) {
 
@@ -74,12 +120,20 @@ void ExpStepRPUDevice<T>::doSparseUpdate(
   T *max_bound = this->w_max_bound_[i];
 
   T write_noise_std = par.getScaledWriteNoise();
+  if (par.hasComplexNoise()) {
+    PULSED_UPDATE_W_LOOP(update_once_complex_noise(
+                             w[j], w_apparent[j], sign, min_bound[j], max_bound[j], scale_down[j],
+                             scale_up[j], par.es_a, par.es_b, par.es_A_down, par.es_A_up,
+                             par.es_gamma_down, par.es_gamma_up, par.dw_min_std, par.dw_min_std_add,
+                             par.dw_min_std_slope, write_noise_std, rng););
+  } else {
 
-  PULSED_UPDATE_W_LOOP(update_once(
-                           w[j], w_apparent[j], sign, min_bound[j], max_bound[j], scale_down[j],
-                           scale_up[j], par.es_a, par.es_b, par.es_A_down, par.es_A_up,
-                           par.es_gamma_down, par.es_gamma_up, par.dw_min_std, write_noise_std,
-                           rng););
+    PULSED_UPDATE_W_LOOP(update_once(
+                             w[j], w_apparent[j], sign, min_bound[j], max_bound[j], scale_down[j],
+                             scale_up[j], par.es_a, par.es_b, par.es_A_down, par.es_A_up,
+                             par.es_gamma_down, par.es_gamma_up, par.dw_min_std, write_noise_std,
+                             rng););
+  }
 };
 
 template <typename T>
@@ -94,12 +148,21 @@ void ExpStepRPUDevice<T>::doDenseUpdate(T **weights, int *coincidences, RNG<T> *
   T *max_bound = this->w_max_bound_[0];
 
   T write_noise_std = par.getScaledWriteNoise();
+  if (par.hasComplexNoise()) {
 
-  PULSED_UPDATE_W_LOOP_DENSE(update_once(
-                                 w[j], w_apparent[j], sign, min_bound[j], max_bound[j],
-                                 scale_down[j], scale_up[j], par.es_a, par.es_b, par.es_A_down,
-                                 par.es_A_up, par.es_gamma_down, par.es_gamma_up, par.dw_min_std,
-                                 write_noise_std, rng););
+    PULSED_UPDATE_W_LOOP_DENSE(
+        update_once_complex_noise(
+            w[j], w_apparent[j], sign, min_bound[j], max_bound[j], scale_down[j], scale_up[j],
+            par.es_a, par.es_b, par.es_A_down, par.es_A_up, par.es_gamma_down, par.es_gamma_up,
+            par.dw_min_std, par.dw_min_std_add, par.dw_min_std_slope, write_noise_std, rng););
+
+  } else {
+    PULSED_UPDATE_W_LOOP_DENSE(update_once(
+                                   w[j], w_apparent[j], sign, min_bound[j], max_bound[j],
+                                   scale_down[j], scale_up[j], par.es_a, par.es_b, par.es_A_down,
+                                   par.es_A_up, par.es_gamma_down, par.es_gamma_up, par.dw_min_std,
+                                   write_noise_std, rng););
+  }
 }
 
 template class ExpStepRPUDevice<float>;

--- a/src/rpucuda/rpu_expstep_device.h
+++ b/src/rpucuda/rpu_expstep_device.h
@@ -31,6 +31,8 @@ BUILD_PULSED_DEVICE_META_PARAMETER(
     T es_gamma_down = (T)12.78785; /* p_1278785 */
     T es_a = (T)0.244;             /* p_0244 */
     T es_b = (T)0.2425;            /*p_02425 */
+    T dw_min_std_add = (T)0.0;     // additive part of dw noise
+    T dw_min_std_slope = (T)0.0;   // multiplicative part of noise with abs(w)
     ,
     /*print body*/
     ss << "\t es_A_up:\t\t" << es_A_up << std::endl;
@@ -39,7 +41,11 @@ BUILD_PULSED_DEVICE_META_PARAMETER(
     ss << "\t es_gamma_down:\t\t" << es_gamma_down << std::endl;
     ss << "\t es_a:\t\t\t" << es_a << std::endl;
     ss << "\t es_b:\t\t\t" << es_b << std::endl;
-    ,
+    if (dw_min_std_add != 0.0) {
+      ss << "\t dw_min_std_add:\t " << dw_min_std_add << std::endl;
+    } if (dw_min_std_slope != 0.0) {
+      ss << "\t dw_min_std_slope:\t " << dw_min_std_slope << std::endl;
+    },
     /* calc weight granularity body */
     T up_down = this->up_down;
     T up_bias = up_down > 0 ? (T)0.0 : up_down;
@@ -55,8 +61,9 @@ BUILD_PULSED_DEVICE_META_PARAMETER(
     ,
     /*add */
     bool implementsWriteNoise() const override { return true; };
-
-);
+    inline bool hasComplexNoise() const {
+      return ((this->dw_min_std > 0) && (dw_min_std_slope != 0.0f || dw_min_std_add != 0.0f));
+    };);
 
 template <typename T> class ExpStepRPUDevice : public PulsedRPUDevice<T> {
 

--- a/src/rpucuda/rpu_mixedprec_device_base.cpp
+++ b/src/rpucuda/rpu_mixedprec_device_base.cpp
@@ -26,7 +26,7 @@ template <typename T>
 void MixedPrecRPUDeviceBaseMetaParameter<T>::printToStream(std::stringstream &ss) const {
 
   if (granularity > 0) {
-    ss << "\t granularity: \t";
+    ss << "\t granularity: \t\t";
     ss << granularity << std::endl;
   }
 

--- a/src/rpucuda/rpu_onesided_device.h
+++ b/src/rpucuda/rpu_onesided_device.h
@@ -30,6 +30,7 @@ template <typename T> struct OneSidedRPUDeviceMetaParameter : VectorRPUDeviceMet
   PulsedUpdateMetaParameter<T> refresh_up; // UP parameters for refresh
   T refresh_upper_thres = 0.75;
   T refresh_lower_thres = 0.25;
+  bool copy_inverted = false; // whether to use copy inverted for second device
 
   OneSidedRPUDeviceMetaParameter(){};
   OneSidedRPUDeviceMetaParameter(const PulsedRPUDeviceMetaParameterBase<T> &dp, int n_devices = 2)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -17,14 +17,14 @@ from torch import Tensor
 from aihwkit.simulator.tiles.analog import AnalogTile
 from aihwkit.simulator.presets import (
     ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, EcRamMOPreset, IdealizedPreset,
-    GokmenVlasovPreset,
+    GokmenVlasovPreset, PCMPreset,
     ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, EcRamMO2Preset,
     Idealized2Preset, ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset,
     EcRamMO4Preset, Idealized4Preset, TikiTakaReRamESPreset, TikiTakaReRamSBPreset,
     TikiTakaCapacitorPreset, TikiTakaEcRamPreset, TikiTakaEcRamMOPreset, TikiTakaIdealizedPreset,
     MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset, MixedPrecisionCapacitorPreset,
     MixedPrecisionEcRamPreset, MixedPrecisionEcRamMOPreset, MixedPrecisionIdealizedPreset,
-    MixedPrecisionGokmenVlasovPreset,
+    MixedPrecisionGokmenVlasovPreset, MixedPrecisionPCMPreset,
 )
 from .helpers.decorators import parametrize_over_presets
 from .helpers.testcases import AihwkitTestCase
@@ -33,7 +33,7 @@ from .helpers.testcases import AihwkitTestCase
 @parametrize_over_presets(
     [
         ReRamESPreset, ReRamSBPreset, CapacitorPreset, EcRamPreset, EcRamMOPreset, IdealizedPreset,
-        GokmenVlasovPreset,
+        GokmenVlasovPreset, PCMPreset,
         ReRamES2Preset, ReRamSB2Preset, Capacitor2Preset, EcRam2Preset, EcRamMO2Preset,
         Idealized2Preset, ReRamES4Preset, ReRamSB4Preset, Capacitor4Preset, EcRam4Preset,
         EcRamMO4Preset, Idealized4Preset, TikiTakaReRamESPreset, TikiTakaReRamSBPreset,
@@ -41,7 +41,7 @@ from .helpers.testcases import AihwkitTestCase
         TikiTakaIdealizedPreset,
         MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset, MixedPrecisionCapacitorPreset,
         MixedPrecisionEcRamPreset, MixedPrecisionEcRamMOPreset, MixedPrecisionIdealizedPreset,
-        MixedPrecisionGokmenVlasovPreset,
+        MixedPrecisionGokmenVlasovPreset, MixedPrecisionPCMPreset,
     ]
 )
 class PresetTest(AihwkitTestCase):


### PR DESCRIPTION
## Related issues

closes #220  

## Description
Adds the following presets: `PCMPresetDevice` (uni-directional), `PCMPresetUnitCell`  (a pair of uni-directional devices with periodical refresh) and a `MixedPrecisionPCMPreset` for using the mixed-precision optimizer with a PCM pair.    

## Details
* Based on OneSidedCell with refresh (open-loop).
* Fitted to PCM hardware measurement 
* Complex cycle-to-cycle noise needed to be added (for ExpStepDevice only)
* Updated plotting to work with UnitCells as well. 

## Example 
```python 
import matplotlib.pyplot as plt
from aihwkit.utils.visualization import plot_device_compact
from aihwkit.simulator.presets.devices import PCMPresetUnitCell

plot_device(PCMPresetUnitCell(), n_steps=80)
plt.show()

```
![image](https://user-images.githubusercontent.com/17587387/117327729-ebbc1f00-ae60-11eb-9ae9-a03e411fce23.png)
