### PR TITLE
N-D support for AnalogLinear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog], and this project adheres to
   ``PCMPresetUnitCell`` (a pair of uni-directional devices with
   periodical refresh) and a ``MixedPrecisionPCMPreset`` for using the
   mixed precision optimizer with a PCM pair. (\#226)
+* ``AnalogLinear`` layer now accpets multi-dimensional inputs in the same
+  way as PyTorch's ``Linear`` layer does. (\#227)
 
 ### Changed
 

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -82,7 +82,7 @@ void declare_rpu_devices(py::module &m) {
       PYBIND11_OVERLOAD_PURE(
           RPU::PulsedRPUDeviceBase<T> *, PulsedBaseParam, createDevice, x_size, d_size, rng);
     }
-    T calcWeightGranularity() const {
+    T calcWeightGranularity() const override {
       PYBIND11_OVERLOAD(T, PulsedBaseParam, calcWeightGranularity, );
     }
   };

--- a/src/rpucuda/rpu_mixedprec_device.h
+++ b/src/rpucuda/rpu_mixedprec_device.h
@@ -92,7 +92,7 @@ public:
 
   friend void swap(MixedPrecRPUDevice<T> &a, MixedPrecRPUDevice<T> &b) noexcept {
     using std::swap;
-    swap(static_cast<MixedPrecRPUDevice<T> &>(a), static_cast<MixedPrecRPUDevice<T> &>(b));
+    swap(static_cast<MixedPrecRPUDeviceBase<T> &>(a), static_cast<MixedPrecRPUDeviceBase<T> &>(b));
 
     swap(a.chi_, b.chi_);
     swap(a.qx_, b.qx_);

--- a/src/rpucuda/rpu_mixedprec_device_base.cpp
+++ b/src/rpucuda/rpu_mixedprec_device_base.cpp
@@ -137,9 +137,9 @@ bool MixedPrecRPUDeviceBaseMetaParameter<T>::setDevicePar(
   }
 }
 
-template class MixedPrecRPUDeviceBaseMetaParameter<float>;
+template struct MixedPrecRPUDeviceBaseMetaParameter<float>;
 #ifdef RPU_USE_DOUBLE
-template class MixedPrecRPUDeviceBaseMetaParameter<double>;
+template struct MixedPrecRPUDeviceBaseMetaParameter<double>;
 #endif
 
 /******************************************************************************************/


### PR DESCRIPTION
## Related issues

The tile multiply-and-add operation strictly required a 2D activation tensor. 

## Description
We now relax this requirement. In case of N-D activation tensor, the last dimension (or first when `trans` is specified) is taken as the matrix vector dimension, the others are automatically flattened in the same way as PyTroch's `Linear` layer.     

## Details
Just changed the dim check, as flattening was the default behavior internally already.  
