### PR TITLE
Fix examples, misc documentation tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog], and this project adheres to
   ``PCMPresetUnitCell`` (a pair of uni-directional devices with
   periodical refresh) and a ``MixedPrecisionPCMPreset`` for using the
   mixed precision optimizer with a PCM pair. (\#226)
-* ``AnalogLinear`` layer now accpets multi-dimensional inputs in the same
+* ``AnalogLinear`` layer now accepts multi-dimensional inputs in the same
   way as PyTorch's ``Linear`` layer does. (\#227)
 
 ### Changed

--- a/examples/04_lenet5_training.py
+++ b/examples/04_lenet5_training.py
@@ -77,7 +77,7 @@ def load_images():
 
 
 def create_analog_network():
-    """Returns a LeNet5 inspired analog model.""""
+    """Returns a LeNet5 inspired analog model."""
     channel = [16, 32, 512, 128]
     model = AnalogSequential(
         AnalogConv2d(in_channels=1, out_channels=channel[0], kernel_size=5, stride=1,

--- a/examples/11_vgg8_training.py
+++ b/examples/11_vgg8_training.py
@@ -79,7 +79,7 @@ def load_images():
 
 
 def create_analog_network():
-    """Returns a Vgg8 inspired analog model.""""
+    """Returns a Vgg8 inspired analog model."""
     channel_base = 48
     channel = [channel_base, 2 * channel_base, 3 * channel_base]
     fc_size = 8 * channel_base

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -432,7 +432,7 @@ class AnalogConv3d(_AnalogConvNd):
             fold_indices = pad(fold_indices, pad=[
                 self.padding[2], self.padding[2],
                 self.padding[1], self.padding[1],
-                self.padding[0], self.padding[0]], mode="constant", value=0)
+                self.padding[0], self.padding[0]], mode='constant', value=0)
         unfold = fold_indices.unfold(2, self.kernel_size[0], self.stride[0]). \
             unfold(3, self.kernel_size[1], self.stride[1]). \
             unfold(4, self.kernel_size[2], self.stride[2]).clone()

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -1026,8 +1026,8 @@ class OneSidedUnitCell(UnitCell):
             raise ConfigError('Could not add unit cell device parameter')
 
         if not onesided_parameters.append_parameter(device_parameter1):
-            raise ConfigError('Could not add unit cell device parameter' +
-                              "(both devices need to be of the same type)")
+            raise ConfigError('Could not add unit cell device parameter ' +
+                              '(both devices need to be of the same type)')
 
         return onesided_parameters
 

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -628,9 +628,7 @@ class ExpStepDevice(PulsedDevice):
     still defined with device-to-device variation and (additional)
     up-down bias (see :class:`~PulsedDevice`).
 
-
     Note:
-
         This device also features a more complex cycle-to-cycle noise
         model of the update step, when specifying ``dw_min_std_add``
         and ``dw_min_std_slope``. By default,    The Gaussian noise added to the
@@ -644,17 +642,16 @@ class ExpStepDevice(PulsedDevice):
         where the :math:`\sigma` is given by ``dw_min_std``,
         :math:`\sigma_\text{add}` is given by ``dw_min_std_add``, and
         :math:`\sigma_\text{slope}` is given by ``dw_min_std_slope``.
-
     """
     # pylint: disable=invalid-name
 
     bindings_class: ClassVar[Type] = devices.ExpStepResistiveDeviceParameter
 
     A_up: float = 0.00081
-    """Factor ``A`` for the up direction"""
+    """Factor ``A`` for the up direction."""
 
     A_down: float = 0.36833
-    """Factor ``A`` for the down direction"""
+    """Factor ``A`` for the down direction."""
 
     gamma_up: float = 12.44625
     """Exponent for the up direction."""
@@ -663,17 +660,17 @@ class ExpStepDevice(PulsedDevice):
     """Exponent for the down direction."""
 
     a: float = 0.244
-    """Global slope parameter"""
+    """Global slope parameter."""
 
     b: float = 0.2425
-    """Global offset parameter"""
+    """Global offset parameter."""
 
     dw_min_std_add: float = 0.0
     """additive cycle-to-cycle noise of the update size (in units of
-    ``dw_min_std``, see above)"""
+    ``dw_min_std``, see above)."""
 
     dw_min_std_slope: float = 0.0
-    """ cycle-to-cycle noise of the update size (in units of ``dw_min_std``, see above)"""
+    """ cycle-to-cycle noise of the update size (in units of ``dw_min_std``, see above)."""
 
     write_noise_std: float = 0.0
     r"""Whether to use update write noise.
@@ -846,12 +843,12 @@ class VectorUnitCell(UnitCell):
         vector_parameters = parameters_to_bindings(self)
 
         if not isinstance(self.unit_cell_devices, list):
-            raise ConfigError("unit_cell_devices should be a list of devices")
+            raise ConfigError('unit_cell_devices should be a list of devices')
 
         for param in self.unit_cell_devices:
             device_parameters = param.as_bindings()
             if not vector_parameters.append_parameter(device_parameters):
-                raise ConfigError("Could not add unit cell device parameter")
+                raise ConfigError('Could not add unit cell device parameter')
 
         return vector_parameters
 
@@ -906,7 +903,7 @@ class ReferenceUnitCell(UnitCell):
         vector_parameters = parameters_to_bindings(self)
 
         if not isinstance(self.unit_cell_devices, list):
-            raise ConfigError("unit_cell_devices should be a list of devices")
+            raise ConfigError('unit_cell_devices should be a list of devices')
 
         if len(self.unit_cell_devices) > 2:
             self.unit_cell_devices = self.unit_cell_devices[:2]
@@ -914,12 +911,12 @@ class ReferenceUnitCell(UnitCell):
             self.unit_cell_devices = [self.unit_cell_devices[0],
                                       deepcopy(self.unit_cell_devices[0])]
         elif len(self.unit_cell_devices) != 2:
-            raise ConfigError("ReferenceUnitCell expects two unit_cell_devices")
+            raise ConfigError('ReferenceUnitCell expects two unit_cell_devices')
 
         for param in self.unit_cell_devices:
             device_parameters = param.as_bindings()
             if not vector_parameters.append_parameter(device_parameters):
-                raise ConfigError("Could not add unit cell device parameter")
+                raise ConfigError('Could not add unit cell device parameter')
 
         return vector_parameters
 
@@ -1011,13 +1008,13 @@ class OneSidedUnitCell(UnitCell):
         """Return a representation of this instance as a simulator
         bindings object."""
         if not isinstance(self.unit_cell_devices, list):
-            raise ConfigError("unit_cell_devices should be a list of devices")
+            raise ConfigError('unit_cell_devices should be a list of devices')
 
         onesided_parameters = parameters_to_bindings(self)
         device_parameter0 = self.unit_cell_devices[0].as_bindings()
 
         if len(self.unit_cell_devices) == 0 or len(self.unit_cell_devices) > 2:
-            raise ConfigError("Need 1 or 2 unit_cell_devices")
+            raise ConfigError('Need 1 or 2 unit_cell_devices')
 
         if len(self.unit_cell_devices) == 1:
             device_parameter1 = device_parameter0
@@ -1026,10 +1023,10 @@ class OneSidedUnitCell(UnitCell):
 
         # need to be exactly 2 and same parameters
         if not onesided_parameters.append_parameter(device_parameter0):
-            raise ConfigError("Could not add unit cell device parameter")
+            raise ConfigError('Could not add unit cell device parameter')
 
         if not onesided_parameters.append_parameter(device_parameter1):
-            raise ConfigError("Could not add unit cell device parameter" +
+            raise ConfigError('Could not add unit cell device parameter' +
                               "(both devices need to be of the same type)")
 
         return onesided_parameters
@@ -1217,7 +1214,7 @@ class TransferCompound(UnitCell):
         """Return a representation of this instance as a simulator bindings object."""
 
         if not isinstance(self.unit_cell_devices, list):
-            raise ConfigError("unit_cell_devices should be a list of devices")
+            raise ConfigError('unit_cell_devices should be a list of devices')
 
         n_devices = len(self.unit_cell_devices)
 
@@ -1227,11 +1224,11 @@ class TransferCompound(UnitCell):
         param_slow = self.unit_cell_devices[1].as_bindings()
 
         if not transfer_parameters.append_parameter(param_fast):
-            raise ConfigError("Could not add unit cell device parameter")
+            raise ConfigError('Could not add unit cell device parameter')
 
         for _ in range(n_devices - 1):
             if not transfer_parameters.append_parameter(param_slow):
-                raise ConfigError("Could not add unit cell device parameter")
+                raise ConfigError('Could not add unit cell device parameter')
 
         return transfer_parameters
 
@@ -1356,6 +1353,6 @@ class MixedPrecisionCompound(DigitalRankUpdateCell):
         param_device = self.device.as_bindings()
 
         if not mixed_prec_parameter.set_device_parameter(param_device):
-            raise ConfigError("Could not add device parameter")
+            raise ConfigError('Could not add device parameter')
 
         return mixed_prec_parameter

--- a/src/aihwkit/simulator/presets/devices.py
+++ b/src/aihwkit/simulator/presets/devices.py
@@ -310,7 +310,6 @@ class PCMPresetDevice(ExpStepDevice):
     :class:`~aihwkit.simulator.configs.device.ExpStepDevice`)
 
     Note:
-
         This is an uni-directional device and thus can only be used as
         a plus-minus pair with refresh (see
         :class:`~PCMPresetUnitCell` which is using this device
@@ -365,7 +364,6 @@ class PCMPresetUnitCell(OneSidedUnitCell):
     Check for refresh is performed after each mini-batch update. See
     :class:`~aihwkit.simulator.configs.device.OneSidedUnitCell` for
     details on the refresh implementation.
-
     """
 
     unit_cell_devices: List = field(

--- a/src/aihwkit/simulator/tiles/analog.py
+++ b/src/aihwkit/simulator/tiles/analog.py
@@ -288,6 +288,6 @@ class CudaAnalogTile(AnalogTile):
             device: Optional[Union[torch_device, str, int]] = None
     ) -> 'CudaAnalogTile':
         if self.stream != current_stream(device):
-            raise CudaError("Cannot switch CUDA devices of existing Cuda tiles")
+            raise CudaError('Cannot switch CUDA devices of existing Cuda tiles')
 
         return self

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -177,7 +177,7 @@ class BaseTile(Generic[RPUConfigGeneric]):
         if self.bias:
             # Create a ``[out_size, in_size (+ 1)]`` matrix.
             if biases is None:
-                raise ValueError("Analog tile has a bias, but no bias given")
+                raise ValueError('Analog tile has a bias, but no bias given')
 
             biases_numpy = expand_dims(biases.clone().detach().cpu().numpy(), 1)
             combined_weights = concatenate([weights_numpy, biases_numpy], axis=1)
@@ -289,7 +289,7 @@ class BaseTile(Generic[RPUConfigGeneric]):
         if self.bias:
             # Create a ``[out_size, in_size (+ 1)]`` matrix.
             if biases is None:
-                raise ValueError("Analog tile has a bias, but no bias given")
+                raise ValueError('Analog tile has a bias, but no bias given')
 
             biases_numpy = expand_dims(biases.clone().detach().cpu().numpy(), 1)
             combined_weights = concatenate([weights_numpy, biases_numpy], axis=1)

--- a/src/aihwkit/simulator/tiles/floating_point.py
+++ b/src/aihwkit/simulator/tiles/floating_point.py
@@ -204,6 +204,6 @@ class CudaFloatingPointTile(FloatingPointTile):
             device: Optional[Union[torch_device, str, int]] = None
     ) -> 'CudaFloatingPointTile':
         if self.stream != current_stream(device):
-            raise CudaError("Cannot switch streams of existing Cuda tiles")
+            raise CudaError('Cannot switch streams of existing Cuda tiles')
 
         return self

--- a/src/aihwkit/simulator/tiles/inference.py
+++ b/src/aihwkit/simulator/tiles/inference.py
@@ -252,6 +252,6 @@ class CudaInferenceTile(InferenceTile):
             device: Optional[Union[torch_device, str, int]] = None
     ) -> 'CudaInferenceTile':
         if self.stream != current_stream(device):
-            raise CudaError("Cannot switch CUDA devices of existing Cuda tiles")
+            raise CudaError('Cannot switch CUDA devices of existing Cuda tiles')
 
         return self

--- a/src/aihwkit/utils/visualization.py
+++ b/src/aihwkit/utils/visualization.py
@@ -354,11 +354,9 @@ def plot_response_overview(
     Args:
         rpu_config: RPU Configuration to use for plotting
         n_loops: How many hyper-cycles (up/down pulse sequences) to plot
-
         n_steps: Number of up/down steps per cycle. If not given, will
             be tried to be estimated (only for ``PulsedDevice``
             possible otherwise defaults to 1000 if ``n_steps=None``).
-
         n_traces: Number of traces to plot
         use_cuda: Whether to use the CUDA implementation (if available)
         smoothness: value for smoothing the estimation of the

--- a/src/aihwkit/utils/visualization.py
+++ b/src/aihwkit/utils/visualization.py
@@ -330,8 +330,8 @@ def estimate_n_steps(rpu_config: Union[SingleRPUConfig, UnitCellRPUConfig]) -> i
     device_binding = rpu_config.device.as_bindings()
 
     if not hasattr(device_binding, 'w_min'):
-        raise ConfigError("n_step estimation only for PulsedDevice." +
-                          " Provide n_step explicitly.")
+        raise ConfigError('n_step estimation only for PulsedDevice. ' +
+                          'Provide n_step explicitly.')
 
     weight_granularity = device_binding.calc_weight_granularity()
     w_min = device_binding.w_min


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Fix examples `04` and `11`, as a typo was introduced inadvertently that prevent them from being executed directly, and revise docstrings and style overall after the recent PRs.

## Details

<!-- A more elaborate description of the changes, if needed. -->
