### PR TITLE
Update sphinx rtd dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,10 @@
 Sphinx==3.1.2
 sphinx-rtd-theme==0.5.2
 recommonmark==0.6.0
+# Runtime dependencies.
 torch>=1.7
-matplotlib
+torchvision
+requests>=2.25,<3
+numpy>=1.18
+dataclasses==0.7; python_version < '3.7'
+protobuf>=3.13.0,<4


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Update the sphinx dependencies used by readthedocs, in order to correctly display the modules that need them in the rendered documentation.

## Details

<!-- A more elaborate description of the changes, if needed. -->
