### PR TITLE
Fix missing matplotlib rtd dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ requests>=2.25,<3
 numpy>=1.18
 dataclasses==0.7; python_version < '3.7'
 protobuf>=3.13.0,<4
+matplotlib>=3.0


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Follow-up to #229 , reintroducing the `matplotlib` dependency that was incorrectly deleted that is needed for the rendering of the visualization package.

## Details

<!-- A more elaborate description of the changes, if needed. -->
