### PR TITLE
Enable new presets in mappings

### DIFF
--- a/src/aihwkit/cloud/converter/v1/mappings.py
+++ b/src/aihwkit/cloud/converter/v1/mappings.py
@@ -28,6 +28,10 @@ from aihwkit.nn import AnalogConv2d, AnalogLinear
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.presets import (
     CapacitorPreset, EcRamPreset, IdealizedPreset, ReRamESPreset, ReRamSBPreset,
+    PCMPreset,
+    MixedPrecisionCapacitorPreset, MixedPrecisionEcRamPreset,
+    MixedPrecisionIdealizedPreset, MixedPrecisionPCMPreset,
+    MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset,
     TikiTakaCapacitorPreset, TikiTakaEcRamPreset, TikiTakaIdealizedPreset,
     TikiTakaReRamESPreset, TikiTakaReRamSBPreset
 )
@@ -246,6 +250,13 @@ class Mappings:
         CapacitorPreset: 'CapacitorPreset',
         EcRamPreset: 'EcRamPreset',
         IdealizedPreset: 'IdealizedPreset',
+        PCMPreset: 'PCMPreset',
+        MixedPrecisionReRamESPreset: 'MixedPrecisionReRamESPreset',
+        MixedPrecisionReRamSBPreset: 'MixedPrecisionReRamSBPreset',
+        MixedPrecisionCapacitorPreset: 'MixedPrecisionCapacitorPreset',
+        MixedPrecisionEcRamPreset: 'MixedPrecisionEcRamPreset',
+        MixedPrecisionIdealizedPreset: 'MixedPrecisionIdealizedPreset',
+        MixedPrecisionPCMPreset: 'MixedPrecisionPCMPreset',
         TikiTakaReRamESPreset: 'TikiTakaReRamESPreset',
         TikiTakaReRamSBPreset: 'TikiTakaReRamSBPreset',
         TikiTakaCapacitorPreset: 'TikiTakaCapacitorPreset',


### PR DESCRIPTION
## Related issues

#184 

## Description

Enable the recently added presets (PCM, mixed precision) in the mappings for experiments, in preparation for enabling them in the cloud runner.

## Details

<!-- A more elaborate description of the changes, if needed. -->
