### PR TITLE
Update to epoch loss calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ The format is based on [Keep a Changelog], and this project adheres to
   is now the `train=bool` argument. If using a dataset that requires other
   arguments or transforms, they can now be specified via overriding
   `get_dataset_arguments()` and `get_dataset_transform()`. (\#225)
+  
+### Fixed
+* Fixed issue that was causing the epoch training loss per to be higher 
+  than the epoch validation loss.
 
 ## [0.3.0] - 2021/04/14
 

--- a/src/aihwkit/experiments/experiments/training.py
+++ b/src/aihwkit/experiments/experiments/training.py
@@ -181,6 +181,7 @@ class BasicTraining(Experiment):
             optimizer.zero_grad()
             output = model(images)
             loss = loss_function(output, labels)
+            batch_image_count = labels.size(0)
 
             # Run training (backward propagation).
             loss.backward()
@@ -188,7 +189,9 @@ class BasicTraining(Experiment):
             # Optimize weights.
             optimizer.step()
 
-            self._call_hook(Signals.TRAIN_EPOCH_BATCH_END, loss.item())
+            self._call_hook(Signals.TRAIN_EPOCH_BATCH_END,
+                            batch_image_count,
+                            loss.item()*batch_image_count)
 
     def validation_step(
             self,
@@ -224,7 +227,7 @@ class BasicTraining(Experiment):
             self._call_hook(Signals.VALIDATION_EPOCH_BATCH_END,
                             batch_image_count,
                             batch_correct_count,
-                            loss.item())
+                            loss.item()*batch_image_count)
 
     def train(
             self,

--- a/src/aihwkit/experiments/runners/metrics.py
+++ b/src/aihwkit/experiments/runners/metrics.py
@@ -34,16 +34,19 @@ class LocalMetric:
             'number': epoch,
             'start_time': datetime.utcnow(),
             'total_loss': 0,
-            'batches': 0,
-            'validation_batches': 0,
+            'training_images': 0,
             'validation_images': 0,
             'validation_correct': 0,
             'validation_loss': 0
         }
 
-    def receive_train_epoch_batch_end(self, train_loss: float) -> None:
+    def receive_train_epoch_batch_end(
+            self,
+            total: int,
+            train_loss: float
+    ) -> None:
         """Hook for `TRAIN_EPOCH_START`."""
-        self.current_epoch['batches'] += 1
+        self.current_epoch['training_images'] += total
         self.current_epoch['total_loss'] += train_loss
 
     def receive_validation_epoch_batch_end(
@@ -55,8 +58,6 @@ class LocalMetric:
         """Hook for `VALIDATION_EPOCH_BATCH_END`."""
         self.current_epoch['validation_images'] += total
         self.current_epoch['validation_correct'] += int(correct)
-
-        self.current_epoch['validation_batches'] += 1
         self.current_epoch['validation_loss'] += validation_loss
 
     def receive_train_epoch_end(self) -> None:
@@ -66,7 +67,7 @@ class LocalMetric:
 
         print('Epoch: {}, loss: {:.8f}'.format(
                 self.current_epoch['number'],
-                self.current_epoch['total_loss'] / self.current_epoch['batches'],
+                self.current_epoch['total_loss'] / self.current_epoch['training_images'],
               ))
 
     def receive_validation_epoch_end(self) -> None:
@@ -77,7 +78,7 @@ class LocalMetric:
         print('Number of images: {}, accuracy: {:.6%}, validation loss: {:.8f}'.format(
             self.current_epoch['validation_images'],
             self.current_epoch['validation_correct'] / self.current_epoch['validation_images'],
-            self.current_epoch['validation_loss'] / self.current_epoch['batches'],
+            self.current_epoch['validation_loss'] / self.current_epoch['validation_images'],
         ))
 
     def receive_epoch_end(self) -> Dict:
@@ -95,7 +96,7 @@ class LocalMetric:
             'accuracy': (self.current_epoch['validation_correct'] /
                          self.current_epoch['validation_images']),
             'train_loss': (self.current_epoch['total_loss'] /
-                           self.current_epoch['batches']),
+                           self.current_epoch['training_images']),
             'valid_loss': (self.current_epoch['validation_loss'] /
-                           self.current_epoch['batches'])
+                           self.current_epoch['validation_images'])
         }


### PR DESCRIPTION
## Related issues

Loss calculation in some of the examples was higher for the validation set than the training set

## Description

fix in the validation loss calculation and update to the hook call for the training and validation runner metrics
