### PR TITLE
Hardware-ware training with weight gradients, AnalogContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-* A new `AnalogLSTM` module: a recurrent neural network that uses
-  AnalogLinear. (\#240)
 * A number of new config presets added to the library, namely `EcRamMOPreset`,
   `EcRamMO2Preset`, `EcRamMO4Preset`, `TikiTakaEcRamMOPreset`,
   `MixedPrecisionEcRamMOPreset`. These can be used for tile configuration
@@ -31,6 +29,13 @@ The format is based on [Keep a Changelog], and this project adheres to
   mixed precision optimizer with a PCM pair. (\#226)
 * ``AnalogLinear`` layer now accepts multi-dimensional inputs in the same
   way as PyTorch's ``Linear`` layer does. (\#227)
+* A new `AnalogLSTM` module: a recurrent neural network that uses
+  AnalogLinear. (\#240)
+
+    A new AnalogContext is introduced which inherits from Parameter. This is the only proxy needed for the AnalogSGD.
+    In case of "shared_weights" (for inference only) weights are set to the torch memory and handled as a normal Parameter. Thus all SGD should work for inference tiles (including distributed training in principle).
+    Regrouping is not necessary any more, because only an AnalogContext is inserted as parameter, and not the weights/bias of AnalogLinear etc. layers.
+    weight / bias field is still used for syncing as before, but state_dict will not save these values, since they are not Parameters anymore. The weight is handled by the tile instead.
 
 ### Changed
 
@@ -43,7 +48,10 @@ The format is based on [Keep a Changelog], and this project adheres to
   is now the `train=bool` argument. If using a dataset that requires other
   arguments or transforms, they can now be specified via overriding
   `get_dataset_arguments()` and `get_dataset_transform()`. (\#225)
-
+* ``AnalogContext`` is introduced, along with tile registeration
+  function to handle arbitrary optimizers, so that re-grouping param
+  groups becomes unecessary. (\#???)
+*  (\#???)
 ### Fixed
 
 * Fixed autograd functionality for recurrent neural networks. (\#240)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,8 @@ The format is based on [Keep a Changelog], and this project adheres to
   way as PyTorch's ``Linear`` layer does. (\#227)
 * A new `AnalogLSTM` module: a recurrent neural network that uses
   AnalogLinear. (\#240)
-
-    A new AnalogContext is introduced which inherits from Parameter. This is the only proxy needed for the AnalogSGD.
-    In case of "shared_weights" (for inference only) weights are set to the torch memory and handled as a normal Parameter. Thus all SGD should work for inference tiles (including distributed training in principle).
-    Regrouping is not necessary any more, because only an AnalogContext is inserted as parameter, and not the weights/bias of AnalogLinear etc. layers.
-    weight / bias field is still used for syncing as before, but state_dict will not save these values, since they are not Parameters anymore. The weight is handled by the tile instead.
+* Return of weight gradients for ``InferenceTile`` (only),
+  so that the gradient can be handled with any pytorch optimizer (\#241)
 
 ### Changed
 
@@ -50,8 +47,11 @@ The format is based on [Keep a Changelog], and this project adheres to
   `get_dataset_arguments()` and `get_dataset_transform()`. (\#225)
 * ``AnalogContext`` is introduced, along with tile registeration
   function to handle arbitrary optimizers, so that re-grouping param
-  groups becomes unecessary. (\#???)
-*  (\#???)
+  groups becomes unecessary. (\#241)
+* Removed `weight` and `bias` of analog layers from the module
+  parameters as these parameters are handled internally for analog
+  tiles (\#241).
+
 ### Fixed
 
 * Fixed autograd functionality for recurrent neural networks. (\#240)

--- a/src/aihwkit/nn/functions.py
+++ b/src/aihwkit/nn/functions.py
@@ -14,101 +14,115 @@
 
 from typing import Any, Optional, Tuple
 
-from torch import Tensor
+from torch import Tensor, empty_like
 from torch.autograd import Function
+from aihwkit.simulator.tiles.base import AnalogContext
 
-from aihwkit.simulator.tiles import FloatingPointTile
+
+class AnalogFunctionBase(Function):
+    """ Base function for analog functions """
+    # pylint: disable=arguments-differ, protected-access
+
+    @staticmethod
+    def forward(
+            ctx: Any,
+            analog_ctx: AnalogContext,
+            input_: Tensor,
+            shared_weights: Optional[Tensor] = None,
+            is_test: bool = False) -> Tensor:
+        """Execute the forward pass in the analog tile.
+
+        Note: Indexed versions can used when analog_ctx.use_indexed is
+        set to True.
+        """
+
+        # Store in context for using during `backward()`.
+        analog_tile = analog_ctx.analog_tile
+        ctx.analog_ctx = analog_ctx
+        ctx.shared_weights = None
+        ctx.save_for_backward(input_)
+
+        use_indexed = analog_ctx.use_indexed
+        if shared_weights is not None:
+            ctx.shared_weights = shared_weights
+            analog_tile.ensure_shared_weights(shared_weights)
+            analog_ctx.use_torch_update = True
+        else:
+            analog_ctx.use_torch_update = False
+
+        # Invoke the forward pass in the tile instance.
+        if use_indexed:
+            return analog_tile.forward_indexed(input_, is_test)
+        return analog_tile.forward(input_, is_test)
+
+    @staticmethod
+    def backward(
+            ctx: Any,
+            grad_output: Tensor,
+    ) -> Tuple[Optional[Tensor], Optional[Tensor], Optional[Tensor], Optional[Tensor]]:
+        """Execute the backward pass in the analog tile."""
+
+        analog_ctx = ctx.analog_ctx
+        analog_tile = analog_ctx.analog_tile
+        input_, = ctx.saved_tensors
+        shared_weights_grad = None
+        use_indexed = analog_ctx.use_indexed
+
+        if analog_ctx.shared_weights is not None:
+            analog_tile.ensure_shared_weights(analog_ctx.shared_weights)
+
+        # Call the backward function in the tile instance.
+        if use_indexed:
+            grad_input = analog_tile.backward_indexed(grad_output)
+        else:
+            grad_input = analog_tile.backward(grad_output)
+
+        if analog_ctx.use_torch_update:
+            # Grad computed directly (for inference training)
+            shared_weights_grad = empty_like(ctx.shared_weights)
+            analog_tile.set_delta_weights(shared_weights_grad)
+            if use_indexed:
+                analog_tile.update_indexed(input_, grad_output)
+            else:
+                analog_tile.update(input_, grad_output)
+            analog_tile.reset_delta_weights()
+        else:
+            # Store activation and errors for optimizer (for analog training)
+            analog_ctx.analog_input.append(input_)
+            analog_ctx.analog_grad_output.append(grad_output)
+
+        return None, grad_input, shared_weights_grad, None
 
 
-class AnalogFunction(Function):
+class AnalogFunction(AnalogFunctionBase):
     """Function that delegates into a `RPU` unit."""
     # pylint: disable=arguments-differ
 
     @staticmethod
     def forward(
             ctx: Any,
-            analog_tile: FloatingPointTile,
+            analog_ctx: AnalogContext,
             input_: Tensor,
-            weights: Tensor,
-            _: Optional[Tensor] = None,
+            shared_weights: Optional[Tensor] = None,
             is_test: bool = False) -> Tensor:
         """Execute the forward pass in the analog tile."""
-
-        # Store in context for using during `backward()`.
-        ctx.analog_tile = analog_tile
-        ctx.weights = weights
-        ctx.save_for_backward(input_)
-
-        # Invoke the forward pass in the tile instance.
-        return analog_tile.forward(input_, is_test)
-
-    @staticmethod
-    def backward(
-            ctx: Any,
-            grad_output: Tensor
-    ) -> Tuple[Optional[Tensor], Optional[Tensor], Optional[Tensor],
-               Optional[Tensor], Optional[Tensor]]:
-        """Execute the backward pass in the analog tile."""
-
-        # Call the backward function in the tile instance.
-        grad_input = ctx.analog_tile.backward(grad_output)
-
-        # Store the parameters needed by the optimizer for `rpu.update()`.
-        input_, = ctx.saved_tensors
-        if not hasattr(ctx.weights, 'analog_input'):
-            ctx.weights.analog_input = [input_]
-            ctx.weights.analog_grad_output = [grad_output]
-        else:
-            ctx.weights.analog_input.append(input_)
-            ctx.weights.analog_grad_output.append(grad_output)
-
-        ctx.weights.analog_use_indexed = False
-
-        return None, grad_input, None, None, None
+        analog_ctx.use_indexed = False
+        return AnalogFunctionBase.forward(
+            ctx, analog_ctx, input_, shared_weights, is_test)
 
 
-class AnalogIndexedFunction(Function):
+class AnalogIndexedFunction(AnalogFunctionBase):
     """Function that delegates into a `RPU` unit to use the indexed forward/backward/update."""
     # pylint: disable=arguments-differ
 
     @staticmethod
     def forward(
             ctx: Any,
-            analog_tile: FloatingPointTile,
+            analog_ctx: AnalogContext,
             input_: Tensor,
-            weights: Tensor,
-            _: Optional[Tensor] = None,
+            shared_weights: Optional[Tensor] = None,
             is_test: bool = False) -> Tensor:
         """Execute the forward pass in the analog tile."""
-
-        # Store in context for using during `backward()`.
-        ctx.analog_tile = analog_tile
-        ctx.weights = weights
-        ctx.save_for_backward(input_)
-
-        # Invoke the forward pass in the tile instance.
-        return analog_tile.forward_indexed(input_, is_test)
-
-    @staticmethod
-    def backward(
-            ctx: Any,
-            grad_output: Tensor
-    ) -> Tuple[Optional[Tensor], Optional[Tensor], Optional[Tensor],
-               Optional[Tensor], Optional[Tensor]]:
-        """Execute the backward pass in the analog tile."""
-
-        # Call the backward function in the tile instance.
-        grad_input = ctx.analog_tile.backward_indexed(grad_output)
-
-        # Store the parameters needed by the optimizer for `rpu.update_indexed()`.
-        input_, = ctx.saved_tensors
-        if not hasattr(ctx.weights, 'analog_input'):
-            ctx.weights.analog_input = [input_]
-            ctx.weights.analog_grad_output = [grad_output]
-        else:
-            ctx.weights.analog_input.append(input_)
-            ctx.weights.analog_grad_output.append(grad_output)
-
-        ctx.weights.analog_use_indexed = True
-
-        return None, grad_input, None, None, None
+        analog_ctx.use_indexed = True
+        return AnalogFunctionBase.forward(
+            ctx, analog_ctx, input_, shared_weights, is_test)

--- a/src/aihwkit/simulator/tiles/analog.py
+++ b/src/aihwkit/simulator/tiles/analog.py
@@ -279,6 +279,9 @@ class CudaAnalogTile(AnalogTile):
         self.stream = current_stream()
         self.device = torch_device(current_device())
 
+        self.analog_ctx.data = source_tile.analog_ctx.data.cuda(self.device)
+        self.analog_ctx.reset(self)
+
     def cpu(self) -> 'BaseTile':
         """Return a copy of this tile in CPU memory."""
         raise CudaError('CUDA tiles cannot be moved to CPU')

--- a/src/aihwkit/simulator/tiles/floating_point.py
+++ b/src/aihwkit/simulator/tiles/floating_point.py
@@ -195,6 +195,10 @@ class CudaFloatingPointTile(FloatingPointTile):
         self.stream = current_stream()
         self.device = torch_device(current_device())
 
+        # ctx
+        self.analog_ctx.data = source_tile.analog_ctx.data.cuda(self.device)
+        self.analog_ctx.reset(self)
+
     def cpu(self) -> 'BaseTile':
         """Return a copy of this tile in CPU memory."""
         raise CudaError('CUDA tiles cannot be moved to CPU')

--- a/src/rpucuda/cuda/rpucuda.h
+++ b/src/rpucuda/cuda/rpucuda.h
@@ -71,6 +71,7 @@ public:
     swap(a.wdrifter_cuda_, b.wdrifter_cuda_);
     swap(a.wclipper_cuda_, b.wclipper_cuda_);
     swap(a.fb_wmodifier_cuda_, b.fb_wmodifier_cuda_);
+    swap(a.shared_weights_if_, b.shared_weights_if_);
   }
 
   void printToStream(std::stringstream &ss) const override;
@@ -196,6 +197,8 @@ public:
   void applyWeightUpdate(T *dw_and_current_weights_out) override;
 
   void setStream(cudaStream_t s) { context_->setStream(s); };
+  cudaStream_t getStream() { return context_->getStream(); };
+  int getGPUId() { return context_->getGPUId(); };
 
   void modifyFBWeights(const WeightModifierParameter &wmpar) override;
 
@@ -220,6 +223,7 @@ protected:
   std::unique_ptr<WeightClipperCuda<T>> wclipper_cuda_ = nullptr;
 
 private:
+  bool shared_weights_if_ = false;
   void
   initFrom(const RPUSimple<T> &rpu_in); // to populate from CPU->CUDA, will be called by constructor
   void initialize(CudaContext *c);

--- a/src/rpucuda/cuda/weight_modifier_cuda.cu
+++ b/src/rpucuda/cuda/weight_modifier_cuda.cu
@@ -30,9 +30,7 @@ namespace RPU {
   for (int i_stride = 0; i_stride < size; i_stride += total_threads) {                             \
     int i = i_stride + tid;                                                                        \
     if (i < size_without_bias) {                                                                   \
-      {                                                                                            \
-        BODY;                                                                                      \
-      }                                                                                            \
+      { BODY; }                                                                                    \
     } else if ((i < size) && (new_weights != weights)) {                                           \
       new_weights[i] = weights[i];                                                                 \
     }                                                                                              \

--- a/src/rpucuda/rpu.h
+++ b/src/rpucuda/rpu.h
@@ -625,7 +625,6 @@ protected:
   T **weights_buffer_ = nullptr;
   T **fb_weights_ = nullptr;
 
-  bool shared_weights_if_ = false;
   int last_update_m_batch_ = 1;
   bool use_delayed_update_ = false;
 
@@ -637,7 +636,6 @@ private:
   SimpleMetaParameter<T> par_;
 
   T *temp_x_vector_bias_ = nullptr;
-
   T *temp_x_matrix_bias_ = nullptr;
   int temp_x_matrix_bias_size_ = 0;
   T *temp_tensor_ = nullptr;
@@ -652,6 +650,8 @@ private:
 
   T fwd_alpha_ = 1.0;
   T bwd_alpha_ = 1.0;
+
+  bool shared_weights_if_ = false;
 };
 
 }; // namespace RPU

--- a/src/rpucuda/utility_functions.h
+++ b/src/rpucuda/utility_functions.h
@@ -83,7 +83,7 @@
 
 namespace RPU {
 
-template <typename T, typename... Args> std::unique_ptr<T> make_unique(Args &&... args) {
+template <typename T, typename... Args> std::unique_ptr<T> make_unique(Args &&...args) {
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 

--- a/tests/helpers/tiles.py
+++ b/tests/helpers/tiles.py
@@ -79,7 +79,8 @@ class ConstantStep:
     use_cuda = False
 
     def get_rpu_config(self):
-        return SingleRPUConfig(device=ConstantStepDevice(w_max_dtod=0, w_min_dtod=0))
+        return SingleRPUConfig(device=ConstantStepDevice(w_max_dtod=0, w_min_dtod=0,
+                                                         up_down_dtod=0.0))
 
     def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
         rpu_config = rpu_config or self.get_rpu_config()
@@ -261,14 +262,16 @@ class MixedPrecision:
 
 
 class Inference:
-    """Inference tile."""
+    """Inference tile (perfect forward)."""
 
     simulator_tile_class = tiles.AnalogTile
     first_hidden_field = None
     use_cuda = False
 
     def get_rpu_config(self):
-        return InferenceRPUConfig()
+        rpu_config = InferenceRPUConfig()
+        rpu_config.forward.is_perfect = True
+        return rpu_config
 
     def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
         rpu_config = rpu_config or self.get_rpu_config()

--- a/tests/test_bindings_tiles.py
+++ b/tests/test_bindings_tiles.py
@@ -336,7 +336,7 @@ class FloatingPointTileTest(ParametrizedTestCase):
         add_shape = [4, 2]
 
         python_tile = self.get_tile(out_size, in_size)
-        init_weights = python_tile.get_weights()[0]
+        init_weights = python_tile.get_weights()[0].cpu().numpy()
         d_t = from_numpy(uniform(-0.1, 0.1, size=add_shape + [out_size]).astype('float32'))
 
         if python_tile.is_cuda:
@@ -359,7 +359,7 @@ class FloatingPointTileTest(ParametrizedTestCase):
         add_shape = []
 
         python_tile = self.get_tile(out_size, in_size)
-        init_weights = python_tile.get_weights()[0]
+        init_weights = python_tile.get_weights()[0].numpy()
         python_tile.set_learning_rate(lr)
 
         x_t = from_numpy(uniform(-0.1, 0.1, size=add_shape + [in_size]).astype('float32'))


### PR DESCRIPTION
## Related issues

makes foundation of #48 
closes #94  (any torch weight decay can now be used for inference tiles for hardware aware training)
closes #211 

The use of `weight` and `bias` as the proxy for the analog updater was awkward, since these were added as parameters and then removed again in `AnalogSgd`.  Especially for inference one might want to use the standard torch optimizers.  

## Description
Now inference tiles uses shared weights, which means that all standard torch optimizers can be used in this case in principle. This is because, the inference tiles now return the weight gradient in the backward pass. For analog training, the weight gradient is still directly applied in-memory as before.    

## Details

* A new `AnalogContext` is introduced which inherits from `Parameter`. This is the only proxy needed for the `AnalogSGD`. 
* In case of "shared_weights" (for inference only) weights are set to the torch memory and handled as a normal Parameter. Thus all SGD should work for inference tiles (including distributed training in principle).
* Regrouping is not necessary any more, because only an `AnalogContext` is inserted as parameter, and not the weights/bias of AnalogLinear etc. layers.
* weight / bias field is still used for syncing as before, but `state_dict` will not save these values, since they are not `Parameters` anymore. The weight is handled by the tile instead.   
* Also fixes a segfault in case of shared weights usage 