### PR TITLE
PCM Preset refresh once per mbatch (OneSidedUnitCell)  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 * N-D support for `AnalogLinear`. (\#227)
 * Fixed an issue in the Experiments that was causing the epoch training loss
   to be higher than the epoch validation loss. (\#238)
+* The default refresh rate is changed to once per mini-batch for
+  `PCMPreset` (as opposed to once per mat-vec). (\#???)
 
 ## [0.3.0] - 2021/04/14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Fixed an issue in the Experiments that was causing the epoch training loss
   to be higher than the epoch validation loss. (\#238)
 * The default refresh rate is changed to once per mini-batch for
-  `PCMPreset` (as opposed to once per mat-vec). (\#???)
+  `PCMPreset` (as opposed to once per mat-vec). (\#243)
 
 ## [0.3.0] - 2021/04/14
 

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -973,6 +973,16 @@ class OneSidedUnitCell(UnitCell):
         impacts.
     """
 
+    units_in_mbatch: bool = True
+    """If set, the ``refresh_every`` counter is given in ``m_batch``
+    which is the re-use factor. Smaller numbers are not possible.
+
+    Caution:
+        For CUDA devices, refresh is always done in  ``m_batch`` (ie
+        the number of re-use per layer for a mini-batch). Smaller
+        numbers will have no effect.
+    """
+
     refresh_upper_thres: float = 0.75
     """Upper threshold for determining the refresh, see above."""
 

--- a/src/aihwkit/simulator/presets/devices.py
+++ b/src/aihwkit/simulator/presets/devices.py
@@ -370,6 +370,7 @@ class PCMPresetUnitCell(OneSidedUnitCell):
         default_factory=lambda: [PCMPresetDevice(), PCMPresetDevice()])
 
     refresh_every: int = 1
+    units_in_mbatch: bool = True
     refresh_forward: IOParameters = field(default_factory=PresetIOParameters)
     refresh_update: UpdateParameters = field(
         default_factory=lambda: PresetUpdateParameters(desired_bl=31))

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -541,6 +541,7 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("refresh_update", &OneSidedParam::refresh_up)
       .def_readwrite("refresh_upper_thres", &OneSidedParam::refresh_upper_thres)
       .def_readwrite("refresh_lower_thres", &OneSidedParam::refresh_lower_thres)
+      .def_readwrite("units_in_mbatch", &OneSidedParam::units_in_mbatch)
       .def_readwrite("copy_inverted", &OneSidedParam::copy_inverted)
       .def(
           "__str__",

--- a/src/rpucuda/rpu_onesided_device.cpp
+++ b/src/rpucuda/rpu_onesided_device.cpp
@@ -224,8 +224,12 @@ void OneSidedRPUDevice<T>::finishUpdateCycle(
 
   const auto &par = getPar();
   if (par.refresh_every > 0) {
+    int refresh_every = par.refresh_every;
+    if (par.units_in_mbatch) {
+      refresh_every *= m_batch_info;
+    }
     int refresh_count = 0;
-    if (this->current_update_idx_ % par.refresh_every == 0) {
+    if (this->current_update_idx_ % refresh_every == 0) {
       refresh_count += refreshWeights();
     }
     if (refresh_count > 0) {

--- a/src/rpucuda/rpu_onesided_device.h
+++ b/src/rpucuda/rpu_onesided_device.h
@@ -25,8 +25,9 @@ template <typename T> class OneSidedRPUDevice;
 
 template <typename T> struct OneSidedRPUDeviceMetaParameter : VectorRPUDeviceMetaParameter<T> {
 
-  int refresh_every = 0;         // refresh every x updates (ie counting single vector updates)
-  IOMetaParameter<T> refresh_io; // the IO for reading out during refresh
+  int refresh_every = 0; // refresh every x updates (ie counting single vector updates)
+  bool units_in_mbatch = true;
+  IOMetaParameter<T> refresh_io;           // the IO for reading out during refresh
   PulsedUpdateMetaParameter<T> refresh_up; // UP parameters for refresh
   T refresh_upper_thres = 0.75;
   T refresh_lower_thres = 0.25;


### PR DESCRIPTION
## Related issues

CPU and GPU did different refresh cycles by default for `OneSidedUnitCell` ( on which `PCMPreset` is based on).  

## Description

* This adds a `units_in_mbatch` switch to the refresh for `OneSidedUnitCell` and sets it by default on once per `mbatch` (ie the array reuse factor for one mini-batch). 
* Note that for the GPU version, refresh can only be done once per `mbatch`, for CPU can do also once per mat-vec. 
