### PR TITLE
Refresh apidoc stubs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,4 +20,6 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 apidoc:
-	sphinx-apidoc --separate --module-first --output-dir source/api ../src/aihwkit
+	sphinx-apidoc --separate --module-first --output-dir source/api ../src/aihwkit \
+	../src/aihwkit/cloud/converter/definitions/*_pb2.py ../src/aihwkit/cloud/converter/v1/mappings.py \
+	../src/aihwkit/cloud/converter/v1/training.py

--- a/docs/source/api/aihwkit.cloud.converter.definitions.rst
+++ b/docs/source/api/aihwkit.cloud.converter.definitions.rst
@@ -5,9 +5,3 @@ aihwkit.cloud.converter.definitions package
    :members:
    :undoc-members:
    :show-inheritance:
-
-Submodules
-----------
-
-.. toctree::
-   :maxdepth: 4

--- a/docs/source/api/aihwkit.cloud.converter.v1.rst
+++ b/docs/source/api/aihwkit.cloud.converter.v1.rst
@@ -5,9 +5,3 @@ aihwkit.cloud.converter.v1 package
    :members:
    :undoc-members:
    :show-inheritance:
-
-Submodules
-----------
-
-.. toctree::
-   :maxdepth: 4

--- a/docs/source/api/aihwkit.optim.context.rst
+++ b/docs/source/api/aihwkit.optim.context.rst
@@ -1,0 +1,7 @@
+aihwkit.optim.context module
+============================
+
+.. automodule:: aihwkit.optim.context
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/aihwkit.optim.context.rst
+++ b/docs/source/api/aihwkit.optim.context.rst
@@ -5,3 +5,4 @@ aihwkit.optim.context module
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: clone

--- a/docs/source/api/aihwkit.optim.rst
+++ b/docs/source/api/aihwkit.optim.rst
@@ -13,3 +13,4 @@ Submodules
    :maxdepth: 4
 
    aihwkit.optim.analog_optimizer
+   aihwkit.optim.context

--- a/docs/source/api/aihwkit.rst
+++ b/docs/source/api/aihwkit.rst
@@ -26,3 +26,4 @@ Submodules
    :maxdepth: 4
 
    aihwkit.exceptions
+   aihwkit.version

--- a/docs/source/api/aihwkit.version.rst
+++ b/docs/source/api/aihwkit.version.rst
@@ -1,0 +1,7 @@
+aihwkit.version module
+======================
+
+.. automodule:: aihwkit.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -27,8 +27,10 @@ API Reference
    aihwkit.nn.modules.lstm
    aihwkit.optim
    aihwkit.optim.analog_optimizer
+   aihwkit.optim.context
    aihwkit.utils
    aihwkit.utils.visualization
+   aihwkit.version
 
 
 .. only:: env_local


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Refresh the apidoc stubs:
* updating the `make apidoc` target (in `docs/`) for easier generation
* adding `aiwhkit.optim.context` as the main change

## Details

<!-- A more elaborate description of the changes, if needed. -->
