### PR TITLE
CUB namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ The format is based on [Keep a Changelog], and this project adheres to
   to be higher than the epoch validation loss. (\#238)
 * The default refresh rate is changed to once per mini-batch for
   `PCMPreset` (as opposed to once per mat-vec). (\#243)
+* Fixed "Wrong device ordinal" errors for CUDA which resulted from a known
+  issue of using CUB together with pytorch. (#\250)
 
 ## [0.3.0] - 2021/04/14
 

--- a/src/rpucuda/cuda/cuda_util.h
+++ b/src/rpucuda/cuda/cuda_util.h
@@ -34,6 +34,11 @@
 #define BLUE_ON "\033[0;34m"
 #define COLOR_OFF "\033[0m"
 
+#undef CUB_NS_PREFIX
+#undef CUB_NS_POSTFIX
+#define CUB_NS_PREFIX namespace RPU {
+#define CUB_NS_POSTFIX }
+
 #define CUBLAS_CALL(x)                                                                             \
   if ((x) != CUBLAS_STATUS_SUCCESS) {                                                              \
     std::ostringstream ss;                                                                         \

--- a/src/rpucuda/cuda/io_manager.cu
+++ b/src/rpucuda/cuda/io_manager.cu
@@ -946,8 +946,8 @@ template <typename T> void InputOutputManager<T>::initializeBatchBuffer(int m_ba
         MIN(nblocks_batch_max_, this->context_->getNBlocks(in_size_ * m_batch, nthreads_));
 
     size_t byte_size = 0;
-    cub::CountingInputIterator<int> itr(0);
-    cub::DeviceSelect::Flagged(
+    RPU::cub::CountingInputIterator<int> itr(0);
+    RPU::cub::DeviceSelect::Flagged(
         (void *)nullptr, byte_size, itr, dev_bound_exceeded_->getData(),
         dev_selected_bidx_->getData(), dev_selected_m_batch_->getData(), m_batch,
         context_->getStream());
@@ -1116,9 +1116,9 @@ int InputOutputManager<T>::applyToInputWithBoundManagement(InputIteratorT dev_in
     // dev_bound_exceeded_->printValues();
 
     // it is bound_management_round_>1 here
-    cub::CountingInputIterator<int> itr(0);
+    RPU::cub::CountingInputIterator<int> itr(0);
     size_t byte_size = dev_flagged_temp_storage_->getSize();
-    cub::DeviceSelect::Flagged(
+    RPU::cub::DeviceSelect::Flagged(
         (void *)dev_flagged_temp_storage_->getData(), byte_size, itr,
         dev_bound_exceeded_->getData(), dev_selected_bidx_->getData(),
         dev_selected_m_batch_->getData(), m_batch, s);

--- a/src/rpucuda/cuda/rpucuda_mixedprec_device_base.cu
+++ b/src/rpucuda/cuda/rpucuda_mixedprec_device_base.cu
@@ -167,14 +167,14 @@ void MixedPrecRPUDeviceBaseCuda<T>::computeSparsityPartly(
     // init
     current_zero_size_ = size;
     size_t temp_storage_bytes = 0;
-    cub::DeviceReduce::Sum(
+    RPU::cub::DeviceReduce::Sum(
         nullptr, temp_storage_bytes, input_values, sparsity, size, this->context_->getStream());
     dev_zc_temp_storage_ = RPU::make_unique<CudaArray<char>>(this->context_, temp_storage_bytes);
   }
 
   // Run sum-reduction (use T as output)
   size_t temp_storage_bytes = dev_zc_temp_storage_->getSize();
-  cub::DeviceReduce::Sum(
+  RPU::cub::DeviceReduce::Sum(
       dev_zc_temp_storage_->getData(), temp_storage_bytes, input_values, sparsity, size,
       this->context_->getStream());
 }

--- a/src/rpucuda/cuda/weight_clipper_cuda.cu
+++ b/src/rpucuda/cuda/weight_clipper_cuda.cu
@@ -51,9 +51,9 @@ WeightClipperCuda<T>::WeightClipperCuda(CudaContext *context, int x_size, int d_
 
   T *tmp = nullptr;
   StdFunctor<T> std_functor((T)x_size_, tmp);
-  cub::TransformInputIterator<T, StdFunctor<T>, T *> std_input(tmp, std_functor);
+  RPU::cub::TransformInputIterator<T, StdFunctor<T>, T *> std_input(tmp, std_functor);
 
-  cub::DeviceReduce::Sum(
+  RPU::cub::DeviceReduce::Sum(
       nullptr, temp_storage_bytes_, std_input, tmp, size_, context_->getStream());
   dev_temp_storage_ = RPU::make_unique<CudaArray<char>>(context, temp_storage_bytes_);
 }
@@ -79,7 +79,7 @@ void WeightClipperCuda<T>::apply(T *weights, const WeightClipParameter &wclpar) 
     }
     row_amaximizer_->compute(weights, d_size_, true);
 
-    cub::DeviceReduce::Sum(
+    RPU::cub::DeviceReduce::Sum(
         dev_temp_storage_->getData(), temp_storage_bytes_, row_amaximizer_->getMaxValues(),
         dev_sum_value_->getData(), d_size_, s);
 
@@ -98,15 +98,15 @@ void WeightClipperCuda<T>::apply(T *weights, const WeightClipParameter &wclpar) 
     }
 
     StdFunctor<T> std_functor((T)size_, dev_sum_value_->getData());
-    cub::TransformInputIterator<T, StdFunctor<T>, T *> std_input(weights, std_functor);
+    RPU::cub::TransformInputIterator<T, StdFunctor<T>, T *> std_input(weights, std_functor);
 
     // mean (sum)
-    cub::DeviceReduce::Sum(
+    RPU::cub::DeviceReduce::Sum(
         dev_temp_storage_->getData(), temp_storage_bytes_, weights, dev_sum_value_->getData(),
         size_, s);
 
     // std
-    cub::DeviceReduce::Sum(
+    RPU::cub::DeviceReduce::Sum(
         dev_temp_storage_->getData(), temp_storage_bytes_, std_input, dev_std_value_->getData(),
         size_, s);
 


### PR DESCRIPTION
## Related issues

CUB headers use static variables which results in CUDA errors for some configurations when using it together with pytorch's CUB and Thrust headers (known issue in pytorch).   

## Description

Use a private namespace for all CUB calls in RPUCUDA. 
