### PR TITLE
Hidden parameter field fix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 * The default refresh rate is changed to once per mini-batch for
   `PCMPreset` (as opposed to once per mat-vec). (\#243)
 * Fixed "Wrong device ordinal" errors for CUDA which resulted from a known
-  issue of using CUB together with pytorch. (#\250)
+  issue of using CUB together with pytorch. (\#250)
+* Renamed persistent weight hidden parameter field to
+  `persistent_weights`. (\#251)
 
 ## [0.3.0] - 2021/04/14
 

--- a/src/aihwkit/utils/visualization.py
+++ b/src/aihwkit/utils/visualization.py
@@ -25,7 +25,7 @@ from copy import deepcopy
 from matplotlib.figure import Figure
 from numpy import ndarray
 
-from torch import ones, eye, from_numpy, zeros
+from torch import ones, eye, from_numpy
 from torch import device as torch_device
 
 import numpy as np
@@ -547,7 +547,8 @@ def plot_device_symmetry(
         w_noise: float = 0.0,
         n_pulses: int = 10000,
         n_traces: int = 3,
-        use_cuda: bool = False
+        use_cuda: bool = False,
+        w_init: float = 1.0,
 ) -> None:
     """Plot the response figure for a given device (preset).
 
@@ -562,7 +563,8 @@ def plot_device_symmetry(
         n_pulses: total number of pulses
         w_noise: Weight noise standard deviation during read
         n_traces: Number of device traces
-        use_cuda: Whether to use CUDA
+        use_cuda: Whether to use CUDA,
+        w_init: Initial value of the weights
     """
     plt.figure(figsize=[10, 5])
 
@@ -581,7 +583,7 @@ def plot_device_symmetry(
     plt.clf()
 
     analog_tile = get_tile_for_plotting(rpu_config, n_traces, use_cuda, noise_free=False)
-    weights = zeros((n_traces, 1))
+    weights = w_init*ones((n_traces, 1))
     analog_tile.set_weights(weights)
 
     plot_pulse_response(analog_tile, direction, use_forward=False)

--- a/src/rpucuda/rpu_pulsed_device.cpp
+++ b/src/rpucuda/rpu_pulsed_device.cpp
@@ -256,7 +256,7 @@ template <typename T> void PulsedRPUDevice<T>::getDPNames(std::vector<std::strin
         "drift_nu")); // we only save the nu, not the t/w0 etc. drift will thus reset at zero
   }
   if (getPar().usesPersistentWeight()) {
-    names.push_back(std::string("hidden_weigths"));
+    names.push_back(std::string("persistent_weights"));
   }
 }
 


### PR DESCRIPTION
## Related issues

For persistent weight, the hidden state weight field was named also `hidden_weigths` (with typo)  confusing with other fields
## Description

* Now renamed to `persistent_weights`.
* also added `w_init` as argument for `plot_symmetry` 

## Details

<!-- A more elaborate description of the changes, if needed. -->
