### PR TITLE
Move to cuda using analog context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ The format is based on [Keep a Changelog], and this project adheres to
   issue of using CUB together with pytorch. (\#250)
 * Renamed persistent weight hidden parameter field to
   `persistent_weights`. (\#251)
+* Analog tiles now always move correctly to CUDA when `model.cuda()`
+  or `model.to(device)` is used. (\#252)
 
 ## [0.3.0] - 2021/04/14
 

--- a/src/aihwkit/optim/analog_optimizer.py
+++ b/src/aihwkit/optim/analog_optimizer.py
@@ -14,10 +14,8 @@
 
 from types import new_class
 from typing import Any, Callable, Dict, Optional, Type
-from warnings import warn
 
 from torch.optim import Optimizer, SGD
-from torch.nn import Module
 
 from aihwkit.optim.context import AnalogContext
 
@@ -30,45 +28,12 @@ class AnalogOptimizerMixin:
     ``AnalogOptimizer`` or torch ``Optimizer``.
     """
 
-    def check_analog_module_devices(self, model: Module) -> None:
-        """Check and move analog modules to the correct cuda device."""
-        # TODO: remove this check and add a .to / .cuda to the AnalogContext
-
-        # Import dynamically, in order to avoid circular imports.
-        # pylint: disable=import-outside-toplevel
-        from aihwkit.nn.modules.base import AnalogModuleBase
-
-        manual_cuda_move = False  # For showing only one warning.
-        for (_, module) in model.named_modules():
-            if isinstance(module, AnalogModuleBase):
-                analog_tile = module.analog_tile
-                analog_ctx = analog_tile.get_analog_ctx()
-
-                # Pytorch module applies everything only to the parameters
-                # and buffers, including the device, so we might need to change
-                # the device of the module to put the analog layer on the
-                # correct device.
-                if analog_ctx.device != analog_tile.device:
-                    module.cuda(analog_ctx.device)
-                    manual_cuda_move = True
-
-        if manual_cuda_move:
-            warn('The tiles of the analog layers have been moved to cuda '
-                 'manually. Please use `.cuda()` directly on the analog layers '
-                 'or `AnalogSequential.cuda()` for automatic handling.')
-
-    def regroup_param_groups(self, model: Module) -> None:
+    def regroup_param_groups(self, *_: Any) -> None:
         """Reorganize the parameter groups, isolating analog layers.
 
         Update the `param_groups` of the optimizer, moving the parameters for
         each analog layer to a new single group.
-
-        Also checks analog modules for the correct CUDA device.
-
-        Args:
-            model: model for the optimizer.
         """
-        self.check_analog_module_devices(model)
 
         # Create the new param groups.
         analog_param_groups = []
@@ -148,7 +113,6 @@ class AnalogOptimizerMixin:
                             analog_tile.update(x_input, d_input)
 
                     analog_ctx.reset()
-
         # Apply post-update step operations (diffuse, decay, etc).
         # (only here because of unknown params order and shared weights)
         for group in self.param_groups:

--- a/src/aihwkit/optim/context.py
+++ b/src/aihwkit/optim/context.py
@@ -12,9 +12,11 @@
 
 """Parameter context for analog tiles."""
 
-from typing import Optional, Type, TYPE_CHECKING
-from torch import ones
+from typing import Optional, Type, Union, Any, TYPE_CHECKING
+
+from torch import ones, dtype, Tensor
 from torch.nn import Parameter
+from torch import device as torch_device
 
 if TYPE_CHECKING:
     from aihwkit.simulator.tiles.base import BaseTile
@@ -23,8 +25,8 @@ if TYPE_CHECKING:
 class AnalogContext(Parameter):
     """Context for analog optimizer."""
 
-    # pylint: disable=signature-differs
     def __new__(cls: Type['AnalogContext'], analog_tile: 'BaseTile') -> 'AnalogContext':
+        # pylint: disable=signature-differs
         return Parameter.__new__(cls, data=ones((), device=analog_tile.device),
                                  requires_grad=True)
 
@@ -47,6 +49,57 @@ class AnalogContext(Parameter):
     def has_gradient(self) -> bool:
         """Return whether a gradient trace was stored."""
         return len(self.analog_input) > 0
+
+    def cuda(
+            self,
+            device: Optional[Union[torch_device, str, int]] = None
+    ) -> 'AnalogContext':
+        """Move the context to a cuda device.
+
+        Args:
+             device: the desired device of the tile.
+
+        Returns:
+            This context in the specified device.
+        """
+        super().cuda(device)
+
+        self.analog_tile = self.analog_tile.cuda(device)
+        self.reset()
+
+        return self
+
+    def to(self, *args: Any, **kwargs: Any) -> 'AnalogContext':
+        """Move analog tiles of the current context to a device.
+
+        Note:
+            Please be aware that moving analog tiles from GPU to CPU is
+            currently not supported.
+
+        Caution:
+            Other tensor conversions than moving the device to CUDA,
+            such as changing the data type are not supported for analog
+            tiles and will be simply ignored.
+
+        Returns:
+            This module in the specified device.
+        """
+        # pylint: disable=invalid-name
+        super().to(*args, **kwargs)
+
+        device = None
+        if 'device' in kwargs:
+            device = kwargs['device']
+        elif len(args) > 0 and not isinstance(args[0], (Tensor, dtype)):
+            device = torch_device(args[0])
+
+        if device is not None:
+            device = torch_device(device)
+            if device.type == 'cuda':
+                self.analog_tile = self.analog_tile.cuda(device)
+                self.reset()
+
+        return self
 
     def __repr__(self) -> str:
         return 'AnalogContext of ' + self.analog_tile.get_brief_info()


### PR DESCRIPTION
## Related issues

`model.cuda()` would not move tiles to CUDA if analog tiles reside inside a module that is derived from `nn.Module`.    

## Description

Now the tile cuda move is handled in the `AnalogContext`
