### PR TITLE
Update test_utils context-related tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,22 +14,21 @@
 
 from tempfile import TemporaryFile
 
-from numpy.random import rand
 from numpy import array
+from numpy.random import rand
 from numpy.testing import assert_array_almost_equal, assert_raises
-from torch import Tensor, save, load
-from torch.nn import Sequential, Module
+from torch import Tensor, load, save
+from torch.nn import Module, Sequential
 from torch.nn.functional import mse_loss
 
-from aihwkit.nn import AnalogConv2d, AnalogLinear
+from aihwkit.nn import AnalogConv2d
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
 from aihwkit.simulator.configs.utils import IOParameters, UpdateParameters
-from aihwkit.simulator.presets.configs import ReRamESPreset
 
 from .helpers.decorators import parametrize_over_layers
-from .helpers.layers import Linear, Conv2d, LinearCuda, Conv2dCuda
+from .helpers.layers import Conv2d, Conv2dCuda, Linear, LinearCuda
 from .helpers.testcases import ParametrizedTestCase
 from .helpers.tiles import FloatingPoint
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -149,6 +149,11 @@ class SerializationTest(ParametrizedTestCase):
             assert_array_almost_equal(model_biases, new_model_biases)
             assert_array_almost_equal(tile_biases, new_tile_biases)
 
+        # Asserts over the AnalogContext of the new model.
+        self.assertTrue(hasattr(new_model.analog_tile.analog_ctx, 'analog_tile'))
+        self.assertIsInstance(new_model.analog_tile.analog_ctx.analog_tile,
+                              model.analog_tile.__class__)
+
     def test_save_load_meta_parameter(self):
         """Test saving and loading a device with custom parameters."""
         # Create the device and the array.
@@ -321,31 +326,15 @@ class SerializationTest(ParametrizedTestCase):
         # Check that it passes when not using `strict`.
         model.load_state_dict(state_dict, strict=False)
 
-    def test_using_state_dict_directly(self):
-        """Test saving and loading using a state dict after training."""
-        model = AnalogLinear(2, 4, rpu_config=ReRamESPreset())
-        loss_func = mse_loss
-        input_x = Tensor(rand(2, model.in_features))*0.2
-        input_y = Tensor(rand(2, model.out_features))*0.2
-
+    def test_state_dict(self):
+        """Test creating a new model using a state dict, without saving to disk."""
+        model = self.get_layer()
         state_dict = model.state_dict()
-        new_model = AnalogLinear(2, 4, rpu_config=ReRamESPreset())
+
+        new_model = self.get_layer()
         new_model.load_state_dict(state_dict)
 
-        self.train_model(new_model, loss_func, input_x, input_y)
-
-    def test_using_file(self):
-        """Test saving and loading using a state dict after training."""
-        model = AnalogLinear(2, 4, rpu_config=ReRamESPreset())
-        loss_func = mse_loss
-        input_x = Tensor(rand(2, model.in_features))*0.2
-        input_y = Tensor(rand(2, model.out_features))*0.2
-
-        with TemporaryFile() as file:
-            save(model.state_dict(), file)
-            # Create a new model and load its state dict.
-            file.seek(0)
-            new_model = AnalogLinear(2, 4, rpu_config=ReRamESPreset())
-            new_model.load_state_dict(load(file))
-
-        self.train_model(new_model, loss_func, input_x, input_y)
+        # Asserts over the AnalogContext of the new model.
+        self.assertTrue(hasattr(new_model.analog_tile.analog_ctx, 'analog_tile'))
+        self.assertIsInstance(new_model.analog_tile.analog_ctx.analog_tile,
+                              model.analog_tile.__class__)


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Small follow-up to #257 revising the tests that were aimed at ensuring that the `AnalogContext` of a deserialized tile, making them assert over the context directly and reorganizing.

## Details

<!-- A more elaborate description of the changes, if needed. -->
