### PR TITLE
Start new unreleased section in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 * Load model state dict into a new model with modified `RPUConfig`. (\#276)
-* Visualization for noise models for analog inference hardware simulation. (#278)
+* Visualization for noise models for analog inference hardware simulation. (\#278)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ The format is based on [Keep a Changelog], and this project adheres to
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
+## [UNRELEASED]
+
+### Added
+
+* Load model state dict into a new model with modified `RPUConfig`. (\#276)
+* Visualization for noise models for analog inference hardware simulation. (#278)
+
+### Fixed
+
+* Removed GPU warning during destruction when using multiple GPUs. (\#277)
+
 ## [0.4.0] - 2021/06/25
 
 ### Added
@@ -37,8 +48,6 @@ The format is based on [Keep a Changelog], and this project adheres to
   any existing optimizer with analog-specific features. (\#242)
 * Conversion tools for converting torch models into a model having analog
   layers. (\#265)
-* Load model state dict into a new model with modified `RPUConfig`. (\#276)
-* Visualization for noise models for analog inference hardware simulation. (#278)
 
 ### Changed
 
@@ -89,7 +98,6 @@ The format is based on [Keep a Changelog], and this project adheres to
   state dict. (\#262)
 * Fixed `MixedPrecisionCompound` being bypassed with floating point compute.
   (\#263)
-* Removed GPU warning during destruction when using multiple GPUs. (\#277)
 
 ## [0.3.0] - 2021/04/14
 


### PR DESCRIPTION
## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Description

Small post-release tweak in order to start a new section in the changelog after the 0.4.0 release, moving the entries since then to this new section.

## Details

<!-- A more elaborate description of the changes, if needed. -->
