### PR TITLE
Digital bias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * State indipendent inference noise model. (\# 284)
 * Transfer LR parameter for ``MixedPrecisionCompound``. (\#283)
 * The bias term can now be handled either by the analog or digital domain by controlling
-  the `digital_bias` layer parameter. (\#190 to be updated)
+  the `digital_bias` layer parameter. (\#306 to be updated)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Visualization for noise models for analog inference hardware simulation. (\#278)
 * State indipendent inference noise model. (\# 284)
 * Transfer LR parameter for ``MixedPrecisionCompound``. (\#283)
+* The bias term can now be handled either by the analog or digital domain by controlling
+  the `digital_bias` layer parameter. (\#190 to be updated)
 
 ### Fixed
 

--- a/examples/17_resnet34_imagenet_conversion_to_analog.py
+++ b/examples/17_resnet34_imagenet_conversion_to_analog.py
@@ -35,7 +35,7 @@ def main():
     print(model)
 
     # Convert the model to its analog version.
-    model = convert_to_analog(model, RPU_CONFIG, weight_scaling_omega=0.6)
+    model = convert_to_analog(model, RPU_CONFIG, weight_scaling_omega=0.6, digital_bias=True)
 
     print(model)
 

--- a/src/aihwkit/inference/noise/custom.py
+++ b/src/aihwkit/inference/noise/custom.py
@@ -39,8 +39,8 @@ class StateIndependentNoiseModel(BaseNoiseModel):  # pylint: disable=too-many-in
 
     .. math::
 
-         \sigma_text{programming noise}=\gamma\,\left(c_0 + c_1 \frac{g_T}{g_\text{max}}
-         + c_2 \frac{g_T^2}{g_\text{max}^2}\right)
++         \sigma_text{programming noise}=\gamma\,\left(c_0 + c_1 \frac{g_T}{g_\text{max}} +
++              +c_2 \frac{g_T^2}{g_\text{max}^2}\right)
 
     where :math:`\gamma` is a additional convenience scale and :math:`g_T`
     is the target conductance established from the given

--- a/src/aihwkit/nn/conversion.py
+++ b/src/aihwkit/nn/conversion.py
@@ -39,6 +39,7 @@ def convert_to_analog(
         rpu_config: RPUConfigGeneric,
         realistic_read_write: bool = False,
         weight_scaling_omega: float = 0.0,
+        digital_bias: bool = False,
         conversion_map: Optional[Dict] = None
 ) -> Module:
     """Convert a given digital model to analog counter parts.
@@ -59,6 +60,8 @@ def convert_to_analog(
         weight_scaling_omega: If non-zero, applied weights of analog
             layers will be scaled by ``weight_scaling_omega`` divided by
             the absolute maximum value of the original weight matrix.
+        digital_bias: decide whether the bias term is handled by the analog tile
+                or kept in digital.
 
             Note:
                 Make sure that the weight max and min setting of the
@@ -83,7 +86,7 @@ def convert_to_analog(
     # Convert parent.
     if module.__class__ in conversion_map:
         module = conversion_map[module.__class__].from_digital(  # type: ignore
-            module, rpu_config, realistic_read_write, weight_scaling_omega)
+            module, rpu_config, realistic_read_write, weight_scaling_omega, digital_bias)
 
     # Convert children.
     convert_dic = {}
@@ -92,11 +95,11 @@ def convert_to_analog(
         n_grand_children = len(list(mod.named_children()))
         if n_grand_children > 0:
             new_mod = convert_to_analog(mod, rpu_config, realistic_read_write,
-                                        weight_scaling_omega, conversion_map)
+                                        weight_scaling_omega, digital_bias, conversion_map)
 
         elif mod.__class__ in conversion_map:
             new_mod = conversion_map[mod.__class__].from_digital(   # type: ignore
-                mod, rpu_config, realistic_read_write, weight_scaling_omega)
+                mod, rpu_config, realistic_read_write, weight_scaling_omega, digital_bias)
         else:
             continue
 

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -49,7 +49,7 @@ class AnalogModuleBase(Module):
     * the ``BaseTile`` subclass that is created is retrieved from the
       ``rpu_config.tile_class`` attribute.
     """
-    # pylint: disable=abstract-method
+    # pylint: disable=abstract-method, too-many-instance-attributes
     ANALOG_CTX_PREFIX: str = 'analog_ctx_'
     ANALOG_SHARED_WEIGHT_PREFIX: str = 'analog_shared_weights_'
 
@@ -105,7 +105,8 @@ class AnalogModuleBase(Module):
             bias: bool,
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
-            weight_scaling_omega: float = 0.0
+            weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False
     ) -> 'BaseTile':
         """Create an analog tile and setup this layer for using it.
 
@@ -137,6 +138,7 @@ class AnalogModuleBase(Module):
             weight_scaling_omega: the weight value where the max
                 weight will be scaled to. If zero, no weight scaling will
                 be performed
+            digital
 
         Returns:
             An analog tile with the requested parameters.
@@ -148,13 +150,17 @@ class AnalogModuleBase(Module):
 
         # Setup the analog-related attributes of this instance.
         self.use_bias = bias
+        self.digital_bias = bias and digital_bias
+        self.analog_bias = bias and not digital_bias
+
         self.realistic_read_write = realistic_read_write
         self.weight_scaling_omega = weight_scaling_omega
         self.in_features = in_features
         self.out_features = out_features
 
         # Create the tile.
-        return rpu_config.tile_class(out_features, in_features, rpu_config, bias=bias)
+        return rpu_config.tile_class(out_features, in_features, rpu_config,
+                                     bias=self.analog_bias)
 
     def set_weights(
             self,
@@ -187,10 +193,15 @@ class AnalogModuleBase(Module):
         realistic = self.realistic_read_write and not force_exact
 
         if self.weight_scaling_omega > 0.0:
-            self.analog_tile.set_weights_scaled(weight, bias, realistic=realistic,
+            self.analog_tile.set_weights_scaled(weight, bias if self.analog_bias else None,
+                                                realistic=realistic,
                                                 omega=self.weight_scaling_omega)
         else:
-            self.analog_tile.set_weights(weight, bias, realistic=realistic)
+            self.analog_tile.set_weights(weight, bias if self.analog_bias else None,
+                                         realistic=realistic)
+
+        if bias is not None and self.digital_bias:
+            self.bias.data = bias
 
         self._sync_weights_from_tile()
 
@@ -222,9 +233,13 @@ class AnalogModuleBase(Module):
         realistic = self.realistic_read_write and not force_exact
 
         if self.weight_scaling_omega > 0.0:
-            return self.analog_tile.get_weights_scaled(realistic=realistic)
+            weight, bias = self.analog_tile.get_weights_scaled(realistic=realistic)
+        else:
+            weight, bias = self.analog_tile.get_weights(realistic=realistic)
 
-        return self.analog_tile.get_weights(realistic=realistic)
+        if self.digital_bias:
+            bias = self.bias.data.detach().cpu()
+        return weight, bias
 
     def _sync_weights_from_tile(self) -> None:
         """Update the layer weight and bias from the values on the analog tile.
@@ -233,8 +248,9 @@ class AnalogModuleBase(Module):
         exact copy of the internal analog tile weights.
         """
         tile_weight, tile_bias = self.get_weights(force_exact=True)  # type: Tuple[Tensor, Tensor]
+
         self.weight.data[:] = tile_weight.reshape(self.weight.shape)
-        if self.use_bias:
+        if self.analog_bias:
             self.bias.data[:] = tile_bias.reshape(self.bias.shape)
 
     def _sync_weights_to_tile(self) -> None:
@@ -243,7 +259,8 @@ class AnalogModuleBase(Module):
         Update the internal tile weights with an exact copy of the values of
         the ``self.weight`` and ``self.bias`` Parameters.
         """
-        self.set_weights(self.weight, self.bias, force_exact=True)
+        self.set_weights(self.weight, self.bias if self.analog_bias else None,
+                         force_exact=True)
 
     def _set_load_rpu_config_state(self, load_rpu_config: bool = True) -> None:
         self._load_rpu_config = load_rpu_config
@@ -313,7 +330,7 @@ class AnalogModuleBase(Module):
         elif strict:
             missing_keys.append(key)
 
-        # update the weight / bias (not saved explicitly)
+        # update the weight / analog bias (not saved explicitly)
         self._sync_weights_from_tile()
 
         # remove helper parameters. We never load context or shared
@@ -390,5 +407,9 @@ class AnalogModuleBase(Module):
             output += ', realistic_read_write={}'.format(self.realistic_read_write)
         if self.weight_scaling_omega > 0:
             output += ', weight_scaling_omega={:.3f}'.format(self.weight_scaling_omega)
+        if self.analog_bias:
+            output += ', analog bias)'
+        if self.digital_bias:
+            output += ', digital bias)'
 
         return output

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -12,15 +12,17 @@
 
 """Analog Modules that contain children Modules."""
 
-from typing import Callable, Optional, Union, Any, NamedTuple
+from typing import Callable, Optional, Union, Any, NamedTuple, TYPE_CHECKING
 from collections import OrderedDict
 
-from torch import Tensor
 from torch import device as torch_device
 from torch.nn import Sequential
 
 from aihwkit.exceptions import ModuleError
 from aihwkit.nn.modules.base import AnalogModuleBase
+
+if TYPE_CHECKING:
+    from torch import Tensor  # pylint: disable=ungrouped-imports
 
 
 class AnalogSequential(Sequential):

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -62,7 +62,8 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
             padding_mode: str,
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
-            weight_scaling_omega: float = 0.0
+            weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False,
     ):
         # pylint: disable=too-many-arguments, too-many-locals
         if groups != 1:
@@ -78,7 +79,8 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
                                             bias,
                                             rpu_config,
                                             realistic_read_write,
-                                            weight_scaling_omega)
+                                            weight_scaling_omega,
+                                            digital_bias)
 
         # Call super() after tile creation, including ``reset_parameters``.
         AnalogModuleBase.__init__(self)
@@ -94,7 +96,7 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
         # Unregister weight/bias as a parameter but keep it as a
         # field (needed for syncing still)
         self.unregister_parameter('weight')
-        if bias:
+        if self.analog_bias:
             self.unregister_parameter('bias')
 
         self.register_analog_tile(self.analog_tile)
@@ -132,9 +134,13 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
         if not self.fold_indices.numel() or self.input_size != input_size:
             self.recalculate_indexes(x_input)
 
-        return AnalogIndexedFunction.apply(
+        out = AnalogIndexedFunction.apply(
             self.analog_tile.get_analog_ctx(), x_input,
             self.analog_tile.shared_weights, not self.training)
+
+        if self.digital_bias:
+            return out + self.bias.view(self.out_channels, 1, 1)
+        return out
 
 
 class AnalogConv1d(_AnalogConvNd):
@@ -167,6 +173,8 @@ class AnalogConv1d(_AnalogConvNd):
             setting initial weights and read out of weights.
         weight_scaling_omega: the weight value where the max weight will be
             scaled to. If zero, no weight scaling will be performed.
+        digital_bias: decide whether the bias term is handled by the analog tile
+            or kept in digital.
     """
     # pylint: disable=abstract-method
 
@@ -183,7 +191,8 @@ class AnalogConv1d(_AnalogConvNd):
             padding_mode: str = 'zeros',
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
-            weight_scaling_omega: float = 0.0
+            weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False,
     ):
         # pylint: disable=too-many-arguments
         kernel_size = _single(kernel_size)
@@ -197,7 +206,7 @@ class AnalogConv1d(_AnalogConvNd):
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,  # type: ignore
             False, _single(0), groups, bias, padding_mode,
-            rpu_config, realistic_read_write, weight_scaling_omega
+            rpu_config, realistic_read_write, weight_scaling_omega, digital_bias
         )
 
     @classmethod
@@ -207,6 +216,7 @@ class AnalogConv1d(_AnalogConvNd):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False,
     ) -> 'AnalogConv1d':
         """Return an AnalogConv1d layer from a torch Conv1d layer.
 
@@ -220,6 +230,8 @@ class AnalogConv1d(_AnalogConvNd):
             weight_scaling_omega: If non-zero, applied weights of analog
                 layers will be scaled by ``weight_scaling_omega`` divided by
                 the absolute maximum value of the original weight matrix.
+            digital_bias: decide whether the bias term is handled by the analog tile
+                or kept in digital.
 
                 Note:
                     Make sure that the weight max and min setting of the
@@ -239,7 +251,8 @@ class AnalogConv1d(_AnalogConvNd):
                             module.padding_mode,
                             rpu_config,
                             realistic_read_write,
-                            weight_scaling_omega)
+                            weight_scaling_omega,
+                            digital_bias)
 
         analog_module.set_weights(module.weight, module.bias)
         return analog_module
@@ -324,6 +337,8 @@ class AnalogConv2d(_AnalogConvNd):
             for setting initial weights and read out of weights.
         weight_scaling_omega: the weight value where the max weight will be
             scaled to. If zero, no weight scaling will be performed.
+        digital_bias: decide whether the bias term is handled by the analog tile
+            or kept in digital.
     """
     # pylint: disable=abstract-method
 
@@ -341,6 +356,7 @@ class AnalogConv2d(_AnalogConvNd):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False,
     ):
         # pylint: disable=too-many-arguments
         kernel_size = _pair(kernel_size)
@@ -351,7 +367,7 @@ class AnalogConv2d(_AnalogConvNd):
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,  # type: ignore
             False, _pair(0), groups, bias, padding_mode,
-            rpu_config, realistic_read_write, weight_scaling_omega
+            rpu_config, realistic_read_write, weight_scaling_omega, digital_bias
         )
 
     @classmethod
@@ -361,6 +377,7 @@ class AnalogConv2d(_AnalogConvNd):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False,
     ) -> 'AnalogConv2d':
         """Return an AnalogConv2d layer from a torch Conv2d layer.
 
@@ -374,6 +391,8 @@ class AnalogConv2d(_AnalogConvNd):
             weight_scaling_omega: If non-zero, applied weights of analog
                 layers will be scaled by ``weight_scaling_omega`` divided by
                 the absolute maximum value of the original weight matrix.
+            digital_bias: decide whether the bias term is handled by the analog tile
+                or kept in digital.
 
                 Note:
                     Make sure that the weight max and min setting of the
@@ -393,7 +412,8 @@ class AnalogConv2d(_AnalogConvNd):
                             module.padding_mode,
                             rpu_config,
                             realistic_read_write,
-                            weight_scaling_omega)
+                            weight_scaling_omega,
+                            digital_bias,)
 
         analog_module.set_weights(module.weight, module.bias)
         return analog_module
@@ -468,6 +488,8 @@ class AnalogConv3d(_AnalogConvNd):
             for setting initial weights and read out of weights.
         weight_scaling_omega: the weight value where the max weight will be
             scaled to. If zero, no weight scaling will be performed.
+        digital_bias: decide whether the bias term is handled by the analog tile
+            or kept in digital.
     """
     # pylint: disable=abstract-method
 
@@ -485,6 +507,7 @@ class AnalogConv3d(_AnalogConvNd):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False,
     ):
         # pylint: disable=too-many-arguments
         kernel_size = _triple(kernel_size)
@@ -498,7 +521,7 @@ class AnalogConv3d(_AnalogConvNd):
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,  # type: ignore
             False, _triple(0), groups, bias, padding_mode,
-            rpu_config, realistic_read_write, weight_scaling_omega
+            rpu_config, realistic_read_write, weight_scaling_omega, digital_bias
         )
 
     @classmethod
@@ -508,6 +531,7 @@ class AnalogConv3d(_AnalogConvNd):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False,
     ) -> 'AnalogConv3d':
         """Return an AnalogConv3d layer from a torch Conv3d layer.
 
@@ -521,6 +545,8 @@ class AnalogConv3d(_AnalogConvNd):
             weight_scaling_omega: If non-zero, applied weights of analog
                 layers will be scaled by ``weight_scaling_omega`` divided by
                 the absolute maximum value of the original weight matrix.
+            digital_bias: decide whether the bias term is handled by the analog tile
+                or kept in digital.
 
                 Note:
                     Make sure that the weight max and min setting of the
@@ -540,7 +566,8 @@ class AnalogConv3d(_AnalogConvNd):
                             module.padding_mode,
                             rpu_config,
                             realistic_read_write,
-                            weight_scaling_omega)
+                            weight_scaling_omega,
+                            digital_bias)
 
         analog_module.set_weights(module.weight, module.bias)
         return analog_module

--- a/src/aihwkit/nn/modules/linear.py
+++ b/src/aihwkit/nn/modules/linear.py
@@ -39,12 +39,14 @@ class AnalogLinear(AnalogModuleBase, Linear):
         in_features: input vector size (number of columns).
         out_features: output vector size (number of rows).
         rpu_config: resistive processing unit configuration.
-        bias: whether to use a bias row on the analog tile or not
+        bias: whether to use a bias row on the analog tile or not.
         realistic_read_write: whether to enable realistic read/write
-            for setting initial weights and read out of weights
+            for setting initial weights and read out of weights.
         weight_scaling_omega: the weight value where the max
             weight will be scaled to. If zero, no weight scaling will
-            be performed
+            be performed.
+        digital_bias: decide whether the bias term is handled by the analog tile
+            or kept in digital.
     """
     # pylint: disable=abstract-method
 
@@ -62,6 +64,7 @@ class AnalogLinear(AnalogModuleBase, Linear):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False
     ):
         # Create the tile.
         self.analog_tile = self._setup_tile(in_features,
@@ -69,7 +72,8 @@ class AnalogLinear(AnalogModuleBase, Linear):
                                             bias,
                                             rpu_config,
                                             realistic_read_write,
-                                            weight_scaling_omega)
+                                            weight_scaling_omega,
+                                            digital_bias)
         # Call super() after tile creation, including ``reset_parameters``.
         AnalogModuleBase.__init__(self)
         Linear.__init__(self, in_features, out_features, bias=bias)
@@ -77,7 +81,7 @@ class AnalogLinear(AnalogModuleBase, Linear):
         # Unregister weight/bias as a parameter but keep it as a
         # field (needed for syncing still)
         self.unregister_parameter('weight')
-        if bias:
+        if self.analog_bias:
             self.unregister_parameter('bias')
 
         # Register tile instead
@@ -90,6 +94,7 @@ class AnalogLinear(AnalogModuleBase, Linear):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False,
     ) -> 'AnalogLinear':
         """Return an AnalogLinear layer from a torch Linear layer.
 
@@ -103,6 +108,8 @@ class AnalogLinear(AnalogModuleBase, Linear):
             weight_scaling_omega: If non-zero, applied weights of analog
                 layers will be scaled by ``weight_scaling_omega`` divided by
                 the absolute maximum value of the original weight matrix.
+            digital_bias: decide whether the bias term is handled by the analog tile
+                or kept in digital.
 
                 Note:
                     Make sure that the weight max and min setting of the
@@ -116,7 +123,8 @@ class AnalogLinear(AnalogModuleBase, Linear):
                             module.bias is not None,
                             rpu_config,
                             realistic_read_write,
-                            weight_scaling_omega)
+                            weight_scaling_omega,
+                            digital_bias)
 
         analog_module.set_weights(module.weight, module.bias)
         return analog_module
@@ -129,6 +137,11 @@ class AnalogLinear(AnalogModuleBase, Linear):
     def forward(self, x_input: Tensor) -> Tensor:
         """Compute the forward pass."""
         # pylint: disable=arguments-differ, arguments-renamed
-        return AnalogFunction.apply(
-            self.analog_tile.get_analog_ctx(), x_input,
-            self.analog_tile.shared_weights, not self.training)
+
+        out = AnalogFunction.apply(
+                self.analog_tile.get_analog_ctx(), x_input,
+                self.analog_tile.shared_weights, not self.training)
+
+        if self.digital_bias:
+            return out + self.bias
+        return out

--- a/src/aihwkit/simulator/configs/helpers.py
+++ b/src/aihwkit/simulator/configs/helpers.py
@@ -49,7 +49,7 @@ def tile_parameters_to_bindings(params: Any) -> Any:
     field_map = {'forward': 'forward_io',
                  'backward': 'backward_io'}
     excluded_fields = ('device', 'noise_model', 'drift_compensation',
-                       'clip', 'modifier')
+                       'clip', 'modifier', 'mapping')
 
     result = params.bindings_class()
     for field, value in params.__dict__.items():

--- a/tests/helpers/decorators.py
+++ b/tests/helpers/decorators.py
@@ -45,7 +45,8 @@ def parametrize_over_tiles(tiles: List) -> Callable:
                                class_name_func=class_name)
 
 
-def parametrize_over_layers(layers: List, tiles: List, biases: List) -> Callable:
+def parametrize_over_layers(layers: List, tiles: List, biases: List, digital_biases: List) \
+        -> Callable:
     """Parametrize a TestCase over different kind of layers.
 
     The ``TestCase`` will be repeated for each combination of `layer`, `tile`
@@ -55,12 +56,13 @@ def parametrize_over_layers(layers: List, tiles: List, biases: List) -> Callable
         layers: list of layer descriptions.
         tiles: list of tile descriptions.
         biases: list of bias values.
+        digital_biases: list of digital_biases values.
 
     Returns:
         The decorated TestCase.
     """
 
-    def object_to_dict(layer, tile, bias):
+    def object_to_dict(layer, tile, bias, digital_bias):
         """Convert the public members of an object to a dictionary."""
         ret = {key: value for key, value in vars(layer).items()
                if not key.startswith('_')}
@@ -69,6 +71,7 @@ def parametrize_over_layers(layers: List, tiles: List, biases: List) -> Callable
                                              'Bias' if bias else 'NoBias')
         ret['get_rpu_config'] = tile.get_rpu_config
         ret['bias'] = bias
+        ret['digital_bias'] = digital_bias
 
         return ret
 
@@ -77,8 +80,8 @@ def parametrize_over_layers(layers: List, tiles: List, biases: List) -> Callable
         return '{}_{}'.format(cls.__name__, params_dict['parameter'])
 
     return parameterized_class(
-        [object_to_dict(layer, tile, bias) for
-         layer, tile, bias in product(layers, tiles, biases)],
+        [object_to_dict(layer, tile, bias, digital_bias) for
+         layer, tile, bias, digital_bias in product(layers, tiles, biases, digital_biases)],
         class_name_func=class_name)
 
 

--- a/tests/helpers/testcases.py
+++ b/tests/helpers/testcases.py
@@ -59,6 +59,9 @@ class ParametrizedTestCase(AihwkitTestCase):
     bias: bool = False
     """If True, the tiles and layer in this test will use bias."""
 
+    digital_bias: bool = False
+    """If True, the tiles and layer in this test will use bias."""
+
     parameter: str = ''
     """Friendly name of the parameters used in this test."""
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -37,7 +37,8 @@ from .helpers.tiles import ConstantStep, Inference
     layers=[Linear, Conv1d, Conv2d, Conv3d,
             LinearCuda, Conv1dCuda, Conv2dCuda, Conv3dCuda],
     tiles=[ConstantStep],
-    biases=[True, False]
+    biases=[True, False],
+    digital_biases=[True, False]
 )
 class AnalogLayerTest(ParametrizedTestCase):
     """Analog layers abstraction tests."""
@@ -125,7 +126,8 @@ class AnalogLayerTest(ParametrizedTestCase):
     layers=[Linear, Conv1d, Conv2d, Conv3d,
             LinearCuda, Conv1dCuda, Conv2dCuda, Conv3dCuda],
     tiles=[ConstantStep, Inference],
-    biases=[True, False]
+    biases=[True, False],
+    digital_biases=[True, False]
 )
 class AnalogLayerMoveTest(ParametrizedTestCase):
     """Analog layers abstraction tests."""
@@ -317,7 +319,8 @@ class AnalogLayerMoveTest(ParametrizedTestCase):
 @parametrize_over_layers(
     layers=[Linear, Conv1d, Conv2d, Conv3d],
     tiles=[ConstantStep, Inference],
-    biases=[True, False]
+    biases=[True, False],
+    digital_biases=[True, False]
 )
 class CpuAnalogLayerTest(ParametrizedTestCase):
     """Analog layers tests using CPU tiles as the source."""
@@ -388,7 +391,8 @@ class CustomTileTestHelper:
 @parametrize_over_layers(
     layers=[Linear, Conv1d, Conv2d, Conv3d],
     tiles=[CustomTileTestHelper],
-    biases=[True, False]
+    biases=[True, False],
+    digital_biases=[True, False]
 )
 class CustomTileTest(ParametrizedTestCase):
     """Test for analog layers using custom tiles."""

--- a/tests/test_layers_convolution.py
+++ b/tests/test_layers_convolution.py
@@ -76,7 +76,8 @@ class ConvolutionLayerTest(ParametrizedTestCase):
 @parametrize_over_layers(
     layers=[Conv1d, Conv1dCuda],
     tiles=[FloatingPoint, Inference],
-    biases=[True, False]
+    biases=[True, False],
+    digital_biases=[True, False]
 )
 class Convolution1dLayerTest(ConvolutionLayerTest):
     """Tests for AnalogConv1d layer."""
@@ -175,7 +176,8 @@ class Convolution1dLayerTest(ConvolutionLayerTest):
 @parametrize_over_layers(
     layers=[Conv2d, Conv2dCuda],
     tiles=[FloatingPoint, Inference],
-    biases=[True, False]
+    biases=[True, False],
+    digital_biases=[True, False]
 )
 class Convolution2dLayerTest(ConvolutionLayerTest):
     """Tests for AnalogConv2d layer."""
@@ -274,7 +276,8 @@ class Convolution2dLayerTest(ConvolutionLayerTest):
 @parametrize_over_layers(
     layers=[Conv3d, Conv3dCuda],
     tiles=[FloatingPoint, Inference],
-    biases=[True, False]
+    biases=[True, False],
+    digital_biases=[True, False]
 )
 class Convolution3dLayerTest(ConvolutionLayerTest):
     """Tests for AnalogConv3d layer."""

--- a/tests/test_layers_linear.py
+++ b/tests/test_layers_linear.py
@@ -32,7 +32,8 @@ from .helpers.tiles import FloatingPoint, IdealizedConstantStep, Inference
 @parametrize_over_layers(
     layers=[Linear, LinearCuda],
     tiles=[FloatingPoint, IdealizedConstantStep, Inference],
-    biases=[True, False]
+    biases=[True, False],
+    digital_biases=[True, False]
 )
 class LinearLayerTest(ParametrizedTestCase):
     """Linear layer abstractions tests."""
@@ -177,8 +178,10 @@ class LinearLayerTest(ParametrizedTestCase):
 
         manual_seed(4321)
         model2 = AnalogSequential(
-            AnalogLinear(4, 3, rpu_config=FloatingPointRPUConfig(), bias=self.bias),
-            AnalogLinear(3, 1, rpu_config=FloatingPointRPUConfig(), bias=self.bias)
+            AnalogLinear(4, 3, rpu_config=FloatingPointRPUConfig(), bias=self.bias,
+                         digital_bias=self.digital_bias),
+            AnalogLinear(3, 1, rpu_config=FloatingPointRPUConfig(), bias=self.bias,
+                         digital_bias=self.digital_bias)
         )
 
         if self.use_cuda:

--- a/tests/test_layers_lstm.py
+++ b/tests/test_layers_lstm.py
@@ -31,7 +31,8 @@ from .helpers.tiles import FloatingPoint, Inference
 @parametrize_over_layers(
     layers=[LSTM, LSTMCuda],
     tiles=[FloatingPoint, Inference],
-    biases=[False, True]
+    biases=[False, True],
+    digital_biases=[False]
 )
 class LSTMLayerTest(ParametrizedTestCase):
     """Tests for AnalogLSTM layer."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,7 +43,8 @@ from .helpers.tiles import FloatingPoint, ConstantStep, Inference
 @parametrize_over_layers(
     layers=[Linear, Conv2d, LinearCuda, Conv2dCuda],
     tiles=[FloatingPoint, ConstantStep, Inference],
-    biases=[True, False]
+    biases=[True, False],
+    digital_biases=[True, False]
 )
 class SerializationTest(ParametrizedTestCase):
     """Tests for serialization."""
@@ -523,7 +524,8 @@ class SerializationTest(ParametrizedTestCase):
 @parametrize_over_layers(
     layers=[Linear, LinearCuda],
     tiles=[FloatingPoint],
-    biases=[False]
+    biases=[False],
+    digital_biases=[False]
 )
 class SerializationTestExtended(ParametrizedTestCase):
     """Tests for serialization."""


### PR DESCRIPTION
## Related issues

#306 

## Description

Until now, when the bias term is requested from the layers, an additional column in the rpu_tile is created and the biases are updated during the analog backward pass, which add noise and non-idealities typical of the analog devices. In some hardware design it may be desirable to compute the bias in digital, as it would improve the overall network accuracy.

## Details

Now the bias can be either compute in the analog rpu_tile or left as pytorch nn.Parameter. This behavior can be controlled by setting the digital_bias parameter of the layers to True.
