### PR TITLE
Compilation fixes and short-cuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,25 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-.PHONY: build_inplace clean clean-doc clang-format mypy pycodestyle pylint pytest
+.PHONY: build_inplace clean clean-doc clang-format mypy pycodestyle pylint pytest build_inplace_mkl build_inplace_cuda build_cuda
 
 build_inplace:
-	python setup.py build_ext -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE --inplace
+	python setup.py build_ext -j8 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE --inplace ${flags}
+
+build_inplace_mkl:
+	make build_inplace flags="-DRPU_BLAS=MKL -DINTEL_MKL_DIR=${MKLROOT} ${flags}"
+
+build:
+	python setup.py install --user -j8 -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE  ${flags}
+
+build_mkl:
+	make build flags="-DRPU_BLAS=MKL -DINTEL_MKL_DIR=${MKLROOT}  ${flags}"
+
+build_cuda:
+	make build_mkl flags="-DUSE_CUDA=ON ${flags}"
+
+build_inplace_cuda:
+	make build_inplace_mkl flags="-DUSE_CUDA=ON ${flags}"
 
 clean:
 	python setup.py clean

--- a/src/aihwkit/inference/noise/custom.py
+++ b/src/aihwkit/inference/noise/custom.py
@@ -39,8 +39,8 @@ class StateIndependentNoiseModel(BaseNoiseModel):  # pylint: disable=too-many-in
 
     .. math::
 
-+         \sigma_text{programming noise}=\gamma\,\left(c_0 + c_1 \frac{g_T}{g_\text{max}} +
-+              +c_2 \frac{g_T^2}{g_\text{max}^2}\right)
+         \sigma_text{programming noise}=\gamma\,\left(c_0 + c_1 \frac{g_T}{g_\text{max}} +
+              + c_2 \frac{g_T^2}{g_\text{max}^2}\right)
 
     where :math:`\gamma` is a additional convenience scale and :math:`g_T`
     is the target conductance established from the given

--- a/src/rpucuda/cuda/cuda_util.h
+++ b/src/rpucuda/cuda/cuda_util.h
@@ -40,12 +40,40 @@
 #define CUB_NS_PREFIX namespace RPU {
 #define CUB_NS_POSTFIX }
 
-#define CUBLAS_CALL(x)                                                                             \
-  if ((x) != CUBLAS_STATUS_SUCCESS) {                                                              \
+#define CUBLAS_CALL(X)                                                                             \
+  if (X != CUBLAS_STATUS_SUCCESS) {                                                                \
     std::ostringstream ss;                                                                         \
-    ss << "CUBLAS_CALL Error at " << __FILENAME__ << " : " << __LINE__ << "\n";                    \
+    ss << "CUBLAS_CALL Error ";                                                                    \
+    switch (X) {                                                                                   \
+    case CUBLAS_STATUS_NOT_INITIALIZED:                                                            \
+      ss << "CUBLAS_STATUS_NOT_INITIALIZED";                                                       \
+      break;                                                                                       \
+    case CUBLAS_STATUS_INVALID_VALUE:                                                              \
+      ss << "CUBLAS_STATUS_INVALID_VALUE";                                                         \
+      break;                                                                                       \
+    case CUBLAS_STATUS_ARCH_MISMATCH:                                                              \
+      ss << "CUBLAS_STATUS_ARCH_MISMATCH";                                                         \
+      break;                                                                                       \
+    case CUBLAS_STATUS_MAPPING_ERROR:                                                              \
+      ss << "CUBLAS_STATUS_MAPPING_ERROR";                                                         \
+      break;                                                                                       \
+    case CUBLAS_STATUS_EXECUTION_FAILED:                                                           \
+      ss << "CUBLAS_STATUS_EXECUTION_FAILED";                                                      \
+      break;                                                                                       \
+    case CUBLAS_STATUS_INTERNAL_ERROR:                                                             \
+      ss << "CUBLAS_STATUS_INTERNAL_ERROR";                                                        \
+      break;                                                                                       \
+    case CUBLAS_STATUS_NOT_SUPPORTED:                                                              \
+      ss << "CUBLAS_STATUS_NOT_SUPPORTED";                                                         \
+      break;                                                                                       \
+    case CUBLAS_STATUS_LICENSE_ERROR:                                                              \
+      ss << "CUBLAS_STATUS_LICENSE_ERROR";                                                         \
+      break;                                                                                       \
+    }                                                                                              \
+    ss << " at " << __FILENAME__ << ":" << __LINE__ << std::endl;                                  \
     throw std::runtime_error(ss.str());                                                            \
   }
+
 #define CUDA_CALL(x)                                                                               \
   {                                                                                                \
     cudaError_t tmpe = x;                                                                          \
@@ -63,30 +91,42 @@
     if ((x) != CURAND_STATUS_SUCCESS) {                                                            \
       std::ostringstream ss;                                                                       \
       ss << "CURAND_CALL Error ";                                                                  \
-      if (x == CURAND_STATUS_VERSION_MISMATCH)                                                     \
+      switch (x) {                                                                                 \
+      case CURAND_STATUS_VERSION_MISMATCH:                                                         \
         ss << "CURAND_STATUS_VERSION_MISMATCH";                                                    \
-      else if (x == CURAND_STATUS_NOT_INITIALIZED)                                                 \
-        ss << "CURAND_STATUS_NOT_INITIALIZED";                                                     \
-      else if (x == CURAND_STATUS_ALLOCATION_FAILED)                                               \
+        break case CURAND_STATUS_NOT_INITIALIZED : ss << "CURAND_STATUS_NOT_INITIALIZED";          \
+        break;                                                                                     \
+      case CURAND_STATUS_ALLOCATION_FAILED:                                                        \
         ss << "CURAND_STATUS_ALLOCATION_FAILED";                                                   \
-      else if (x == CURAND_STATUS_TYPE_ERROR)                                                      \
+        break;                                                                                     \
+      case CURAND_STATUS_TYPE_ERROR:                                                               \
         ss << "CURAND_STATUS_TYPE_ERROR";                                                          \
-      else if (x == CURAND_STATUS_OUT_OF_RANGE)                                                    \
+        break;                                                                                     \
+      case CURAND_STATUS_OUT_OF_RANGE:                                                             \
         ss << "CURAND_STATUS_OUT_OF_RANGE";                                                        \
-      else if (x == CURAND_STATUS_LENGTH_NOT_MULTIPLE)                                             \
+        break;                                                                                     \
+      case CURAND_STATUS_LENGTH_NOT_MULTIPLE:                                                      \
         ss << "CURAND_STATUS_LENGTH_NOT_MULTIPLE";                                                 \
-      else if (x == CURAND_STATUS_DOUBLE_PRECISION_REQUIRED)                                       \
+        break;                                                                                     \
+      case CURAND_STATUS_DOUBLE_PRECISION_REQUIRED:                                                \
         ss << "CURAND_STATUS_DOUBLE_PRECISION_REQUIRED";                                           \
-      else if (x == CURAND_STATUS_LAUNCH_FAILURE)                                                  \
+        break;                                                                                     \
+      case CURAND_STATUS_LAUNCH_FAILURE:                                                           \
         ss << "CURAND_STATUS_LAUNCH_FAILURE";                                                      \
-      else if (x == CURAND_STATUS_PREEXISTING_FAILURE)                                             \
+        break;                                                                                     \
+      case CURAND_STATUS_PREEXISTING_FAILURE:                                                      \
         ss << "CURAND_STATUS_PREEXISTING_FAILURE";                                                 \
-      else if (x == CURAND_STATUS_INITIALIZATION_FAILED)                                           \
+        break;                                                                                     \
+      case CURAND_STATUS_INITIALIZATION_FAILED:                                                    \
         ss << "CURAND_STATUS_INITIALIZATION_FAILED";                                               \
-      else if (x == CURAND_STATUS_ARCH_MISMATCH)                                                   \
+        break;                                                                                     \
+      case CURAND_STATUS_ARCH_MISMATCH:                                                            \
         ss << "CURAND_STATUS_ARCH_MISMATCH";                                                       \
-      else if (x == CURAND_STATUS_INTERNAL_ERROR)                                                  \
+        break;                                                                                     \
+      case CURAND_STATUS_INTERNAL_ERROR:                                                           \
         ss << "CURAND_STATUS_INTERNAL_ERROR";                                                      \
+        break;                                                                                     \
+      }                                                                                            \
       ss << " at " << __FILENAME__ << ":" << __LINE__ << "\n";                                     \
       throw std::runtime_error(ss.str());                                                          \
     }                                                                                              \

--- a/src/rpucuda/cuda/rpucuda_expstep_device.cu
+++ b/src/rpucuda/cuda/rpucuda_expstep_device.cu
@@ -47,6 +47,8 @@ template <typename T> struct UpdateFunctorExpStep {
       curandState &local_state)
 
   {
+    (void)par_2; // no used here
+
     // par_4 order (min_bound, scale_down, max_bound, scale_up )
     // global_pars see below
     T uw_std = global_pars[6];
@@ -110,6 +112,8 @@ template <typename T> struct UpdateFunctorExpStepComplexNoise {
       curandState &local_state)
 
   {
+    (void)par_2; // no used here
+
     // par_4 order (min_bound, scale_down, max_bound, scale_up )
     // global_pars see below
     T uw_std = global_pars[6];


### PR DESCRIPTION
## Related issues

#289

## Description

Missing convenience  short-cut for compilation on CUDA. 

## Details

* Fix some compilation issues.
* Add compilation short-cuts:  `make build_cuda`, `make build_mkl`, `make build_inplace_cuda` etc.   
* Improved CUBLAS error message
* Removed compilation warning with newer GCC

<!-- A more elaborate description of the changes, if needed. -->
