### PR TITLE
More non-idealities of analog mat-vec & transfer compound enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 * State indipendent inference noise model. (\# 284)
 * Transfer LR parameter for ``MixedPrecisionCompound``. (\#283)
 * The bias term can now be handled either by the analog or digital domain by controlling
-  the `digital_bias` layer parameter. (\#306 to be updated)
+  the `digital_bias` layer parameter. (\#307)
+* PCM short-term weight noise. (#???)
+* IR-drop simulation across columns during analog mat-vec. (\#???)
+* Transposed-read for ``TransferCompound``. (\???)
 
 ### Fixed
 
@@ -35,6 +38,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 * The inference noise models are now located in `aihwkit.inference`. (\#281)
 * Analog state dict structure `has changed (shared weight are not saved). (\#293)
+* Some of the parameter names of the``TransferCompound`` have
+  changed. (\#???)
+* New fast learning rate parameter for TransferCompound, SGD learning
+  rate then is applied on the slow matrix (\#???). 
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,16 +22,16 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Transfer LR parameter for ``MixedPrecisionCompound``. (\#283)
 * The bias term can now be handled either by the analog or digital domain by controlling
   the `digital_bias` layer parameter. (\#307)
-* PCM short-term weight noise. (#???)
-* IR-drop simulation across columns during analog mat-vec. (\#???)
-* Transposed-read for ``TransferCompound``. (\???)
+* PCM short-term weight noise. (\#312)
+* IR-drop simulation across columns during analog mat-vec. (\#312)
+* Transposed-read for ``TransferCompound``. (\#312)
 
 ### Fixed
 
 * Removed GPU warning during destruction when using multiple GPUs. (\#277)
 * Fixed issue in transfer counter for mixed precision in case of GPU. (\#283)
 * Map location keyword for load / save observed. (\#293)
-* Fixed issue with CUDA buffer allocation when batch size changed. (\294)
+* Fixed issue with CUDA buffer allocation when batch size changed. (\#294)
 * Fixed missing load statedict for AnalogSequential. (\#295) 
 
 ### Changed
@@ -39,9 +39,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 * The inference noise models are now located in `aihwkit.inference`. (\#281)
 * Analog state dict structure `has changed (shared weight are not saved). (\#293)
 * Some of the parameter names of the``TransferCompound`` have
-  changed. (\#???)
+  changed. (\#312)
 * New fast learning rate parameter for TransferCompound, SGD learning
-  rate then is applied on the slow matrix (\#???). 
+  rate then is applied on the slow matrix (\#312). 
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ A series of primitives and features that allow using the toolkit within
 * Analog inference using torch inference workflow:
   * State-of-the-art statistical model of a phase-change memory (PCM) array
     calibrated on hardware measurements from a 1 million PCM devices chip.
-  * Hardware-aware training with hardware non-idealities and noise included
-    in the forward pass to make the trained models more robust during inference on Analog hardware.
+  * Hardware-aware training with hardware non-idealities and noise
+    included in the forward pass to make the trained models more
+    robust during inference on Analog hardware.
 
 ### Analog devices simulator
 
@@ -55,7 +56,8 @@ adjustable parameters. Features include:
 
 ### Other features
 
-Along with the two main components, the toolkit includes other functionalities such as:
+Along with the two main components, the toolkit includes other
+functionalities such as:
 
 * A library of device presets that are calibrated to real hardware data and
   based on models in the literature, along with configuration that specifies a particular device and optimizer choice.

--- a/cmake/dependencies_test.cmake
+++ b/cmake/dependencies_test.cmake
@@ -13,8 +13,8 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 if(BUILD_TEST)
   include(ExternalProject)
   ExternalProject_Add(GTest
-    URL               https://github.com/google/googletest/archive/release-1.10.0.zip
-    URL_HASH          MD5=82358affdd7ab94854c8ee73a180fc53
+    URL               https://github.com/google/googletest/archive/release-1.11.0.zip
+    URL_HASH          MD5=52943a59cefce0ae0491d4d2412c120b
     CMAKE_ARGS        "-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI\=0"
     INSTALL_COMMAND   ""
   )

--- a/examples/08_simple_layer_with_tiki_taka.py
+++ b/examples/08_simple_layer_with_tiki_taka.py
@@ -47,10 +47,12 @@ rpu_config = UnitCellRPUConfig(
         # Make some adjustments of the way Tiki-Taka is performed.
         units_in_mbatch=True,    # batch_size=1 anyway
         transfer_every=2,        # every 2 batches do a transfer-read
-        n_cols_per_transfer=1,   # one forward read for each transfer
+        n_reads_per_transfer=1,  # one forward read for each transfer
         gamma=0.0,               # all SGD weight in second device
         scale_transfer_lr=True,  # in relative terms to SGD LR
         transfer_lr=1.0,         # same transfer LR as for SGD
+        fast_lr=0.1,             # SGD update onto first matrix constant
+        transfer_columns=True    # transfer use columns (not rows)
     )
 )
 

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -138,7 +138,7 @@ class AnalogModuleBase(Module):
             weight_scaling_omega: the weight value where the max
                 weight will be scaled to. If zero, no weight scaling will
                 be performed
-            digital
+            digital_bias: whether to use bias in digital
 
         Returns:
             An analog tile with the requested parameters.

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -1076,17 +1076,17 @@ class TransferCompound(UnitCell):
     in the list of ``unit_cell_devices``) need to be of the same spec.
 
     The rate of transfer (e.g. learning rate and how often and how
-    many columns per transfer) and the type (ie. with ADC or without,
+    many columns/rows per transfer) and the type (ie. with ADC or without,
     with noise etc.) can be adjusted.
 
     Each transfer event that is triggered by counting the update
     cycles (in units of either mini-batch or single mat-vecs),
-    ``n_cols_per_transfer`` columns are read from the left device
+    ``n_reads_per_transfer`` columns/rows are read from the left device
     using the forward pass with transfer vectors as input and
     transferred to the right (taking the order of the
     ``unit_cell_devices`` list) using the outer-product update with
     the read-out vectors and the transfer vectors. Currently, transfer
-    vectors are fixed to be one-hot vectors. The columns to take are
+    vectors are fixed to be one-hot vectors. The columns/rows to take are
     in sequential order and warped around at the edge of the
     crossbar. The learning rate and forward and update specs of the
     transfer can be user-defined.
@@ -1136,7 +1136,7 @@ class TransferCompound(UnitCell):
     If not given explicitely with ``transfer_every_vec``, then the higher
     transfer cycles are geometrically scaled, the first is set to
     transfer_every. Each next transfer cycle is multiplied by ``x_size
-    / n_cols_per_transfer``.
+    / n_reads_per_transfer``.
     """
 
     no_self_transfer: bool = True
@@ -1159,24 +1159,50 @@ class TransferCompound(UnitCell):
     weight re-use during a while mini-batch.
     """
 
-    n_cols_per_transfer: int = 1
-    """Number of consecutive columns to use during transfer events.
+    n_reads_per_transfer: int = 1
+    """Number of consecutive reads to use during transfer events.
 
-    How many consecutive columns to read (from one tile) and write (to the next
+    How many consecutive columns or rows to read (from one tile) and write (to the next
     tile) every transfer event. For read, the input is a 1-hot vector. Once the
-    final column is reached, reading starts again from the first.
+    final columns or row is reached, reading starts again from the first.
+    """
+
+    transfer_columns: bool = True
+    """Whether to read and transfer columns or rows.
+
+    If set, read is done with an additional forward pass
+    determined by the ``transfer_forward`` settings. If not set, rows
+    are transferred instead, that is, the read is done internally
+    with a backward pass instead. However, the parameters defining the
+    backward are still given by setting the ``transfer_forward`` field for
+    convenience.
     """
 
     with_reset_prob: float = 0.0
     """Whether to apply reset of the columns that were transferred with a given
-    probability."""
+    probability.
 
-    random_column: bool = False
-    """Whether to select a random starting column.
+    Note:
+        Reset is only available in case of column reads
+        (``transfer_columns==True``).
+    """
 
-    Whether to select a random starting column for each transfer event and not
-    take the next column that was previously not transferred as a starting
-    column (the default).
+    random_selection: bool = False
+    """Whether to select a random starting column or row.
+
+    Whether to select a random starting column or row for each
+    transfer event and not take the next column or row that was
+    previously not transferred as a starting column or row (the
+    default).
+    """
+
+    fast_lr: float = 0.0
+    """Whether to set the `fast` tile's learning rate.
+
+    If set, then the SGD gradient update onto the first (fast) tile is
+    set to this learning rate and is kept constant even when the SGD
+    learning rate is scheduled. The SGD learning rate is then only
+    used to scale the transfer LR (see ``scale_transfer_lr``).
     """
 
     transfer_lr: float = 1.0
@@ -1206,7 +1232,7 @@ class TransferCompound(UnitCell):
     """Input-output parameters that define the read of a transfer event.
 
     :class:`~aihwkit.simulator.config.utils.AnalogTileInputOutputParameters` that define the read
-    (forward) of an transfer event. For instance the amount of noise
+    (forward or backward) of an transfer event. For instance the amount of noise
     or whether transfer is done using a ADC/DAC etc.
     """
 

--- a/src/aihwkit/simulator/configs/helpers.py
+++ b/src/aihwkit/simulator/configs/helpers.py
@@ -49,7 +49,7 @@ def tile_parameters_to_bindings(params: Any) -> Any:
     field_map = {'forward': 'forward_io',
                  'backward': 'backward_io'}
     excluded_fields = ('device', 'noise_model', 'drift_compensation',
-                       'clip', 'modifier', 'mapping')
+                       'clip', 'modifier')
 
     result = params.bindings_class()
     for field, value in params.__dict__.items():

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -353,9 +353,27 @@ class IOParameters(_PrintableMixin):
         :meth:`diffuse_weights`.
     """
 
+    ir_drop: float = 0.0
+    """Scale of IR drop along the inputs (rows of the weight matrix).
+
+    The IR-drop is calculated assuming that the first input is
+    farthest away from the output channel. The expected drop is
+    approximating the steady-state voltage distributions and depends
+    on the input current.
+    """
+
+    ir_drop_g_ratio: float = 1/(0.35*5e-6)
+    """Physical ratio of wire conductance from one cell to the next to
+    physical max conductance of a device.
+
+    Default is compute with 5mS maximal conductance set state and 0.35
+    Ohm wire resistance.
+    """
+
 
 @dataclass
 class UpdateParameters(_PrintableMixin):
+
     """Parameter that modify the update behaviour of a pulsed device."""
 
     bindings_class: ClassVar[Type] = devices.AnalogTileUpdateParameter

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -349,7 +349,9 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("out_scale", &RPU::IOMetaParameter<T>::out_scale)
       .def_readwrite("out_sto_round", &RPU::IOMetaParameter<T>::out_sto_round)
       .def_readwrite("w_noise", &RPU::IOMetaParameter<T>::w_noise)
-      .def_readwrite("w_noise_type", &RPU::IOMetaParameter<T>::w_noise_type);
+      .def_readwrite("w_noise_type", &RPU::IOMetaParameter<T>::w_noise_type)
+      .def_readwrite("ir_drop", &RPU::IOMetaParameter<T>::ir_drop)
+      .def_readwrite("ir_drop_g_ratio", &RPU::IOMetaParameter<T>::ir_drop_Gw_div_gmax);
 
   py::class_<RPU::DriftParameter<T>>(m, "DriftParameter")
       .def(py::init<>())
@@ -567,10 +569,12 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite(
           "transfer_every_vec", &TransferParam::transfer_every_vec) // can this be filled?
       .def_readwrite("units_in_mbatch", &TransferParam::units_in_mbatch)
-      .def_readwrite("n_cols_per_transfer", &TransferParam::n_cols_per_transfer)
+      .def_readwrite("n_reads_per_transfer", &TransferParam::n_reads_per_transfer)
       .def_readwrite("with_reset_prob", &TransferParam::with_reset_prob)
-      .def_readwrite("random_column", &TransferParam::random_column)
+      .def_readwrite("random_selection", &TransferParam::random_selection)
+      .def_readwrite("transfer_columns", &TransferParam::transfer_columns)
       .def_readwrite("transfer_lr", &TransferParam::transfer_lr)
+      .def_readwrite("fast_lr", &TransferParam::fast_lr)
       .def_readwrite("transfer_lr_vec", &TransferParam::transfer_lr_vec)
       .def_readwrite("scale_transfer_lr", &TransferParam::scale_transfer_lr)
       .def_readwrite("transfer_forward", &TransferParam::transfer_io)

--- a/src/rpucuda/cuda/bit_line_maker_test.cpp
+++ b/src/rpucuda/cuda/bit_line_maker_test.cpp
@@ -308,8 +308,7 @@ public:
     up.res = resolution;
     up.sto_round = false;
 
-    context_container = RPU::make_unique<CudaContext>(-1, false); // blocking for timings
-    context = &*context_container;
+    context = &context_container;
 
     blm = RPU::make_unique<BitLineMaker<num_t>>(context, x_size, d_size);
 
@@ -352,7 +351,7 @@ public:
     delete[] d_counts;
   }
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
   int nK32;
   int x_size;

--- a/src/rpucuda/cuda/cuda_util.cu
+++ b/src/rpucuda/cuda/cuda_util.cu
@@ -644,8 +644,6 @@ void CudaContext::subtractMemCounter(int64_t n_bytes) {
   global_mem_counter -= n_bytes;
 }
 
-int64_t CudaContext::getTotalMem() { return global_mem_counter; }
-
 //**********************************************************************//
 
 template <typename T>

--- a/src/rpucuda/cuda/cuda_util.h
+++ b/src/rpucuda/cuda/cuda_util.h
@@ -94,7 +94,9 @@
       switch (x) {                                                                                 \
       case CURAND_STATUS_VERSION_MISMATCH:                                                         \
         ss << "CURAND_STATUS_VERSION_MISMATCH";                                                    \
-        break case CURAND_STATUS_NOT_INITIALIZED : ss << "CURAND_STATUS_NOT_INITIALIZED";          \
+        break;                                                                                     \
+      case CURAND_STATUS_NOT_INITIALIZED:                                                          \
+        ss << "CURAND_STATUS_NOT_INITIALIZED";                                                     \
         break;                                                                                     \
       case CURAND_STATUS_ALLOCATION_FAILED:                                                        \
         ss << "CURAND_STATUS_ALLOCATION_FAILED";                                                   \
@@ -159,9 +161,6 @@
 #ifndef MAX
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #endif
-
-#define RPU_CUDA_1D_KERNEL_LOOP(i, n)                                                              \
-  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < (n); i += blockDim.x * gridDim.x)
 
 #define RPU_GET_CUDA_BUFFER(CONTEXT, TYPE, BUFFER, SIZE)                                           \
   if (!BUFFER || BUFFER->getSize() < (SIZE)) {                                                     \
@@ -329,7 +328,7 @@ public:
 
   inline int64_t getAllocatedMem() { return allocated_mem_; }
 
-  int64_t getTotalMem();
+  int64_t getTotalMem() { return global_mem_counter; }
 
 private:
   int gpu_id_ = 0;

--- a/src/rpucuda/cuda/io_iterator_test.cpp
+++ b/src/rpucuda/cuda/io_iterator_test.cpp
@@ -64,8 +64,7 @@ public:
       unfolded_vector2[i] = unfolded_vector[i];
     }
 
-    context_container = RPU::make_unique<CudaContext>(-1, false);
-    context = &*context_container;
+    context = &context_container;
     dev_orig_vector = RPU::make_unique<CudaArray<T>>(context, orig_matrix_size * N, orig_vector);
     dev_orig_vector2 = RPU::make_unique<CudaArray<T>>(context, orig_matrix_size * N, orig_vector2);
     dev_unfolded_vector =
@@ -100,7 +99,7 @@ public:
     delete[] batch_indices;
   };
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
   std::unique_ptr<CudaArray<T>> dev_orig_vector;
   std::unique_ptr<CudaArray<T>> dev_orig_vector2;

--- a/src/rpucuda/cuda/io_manager.h
+++ b/src/rpucuda/cuda/io_manager.h
@@ -63,6 +63,7 @@ private:
   void applyOutputWeightNoise(const bool out_trans);
   void applyOutputNonIdealities(const T *dev_weights, const bool out_trans);
   void applyOutputPCMReadNoise(const T *dev_weights, const bool out_trans);
+  void applyIrDrop(const T *dev_weights, const bool out_trans);
 
   void initializeBatchBuffer(int m_batch);
 
@@ -106,7 +107,6 @@ private:
   std::unique_ptr<CudaArray<float>> dev_scale_values_ = nullptr;
   std::unique_ptr<CudaArray<int>> dev_bound_exceeded_ = nullptr;
   std::unique_ptr<CudaArray<int>> dev_any_exceeded_ = nullptr;
-  std::unique_ptr<CudaArray<int>> dev_channel_exceeded_ = nullptr;
   std::unique_ptr<CudaArray<char>> dev_flagged_temp_storage_ = nullptr;
   std::unique_ptr<CudaArray<int>> dev_selected_bidx_ = nullptr;
   std::unique_ptr<CudaArray<int>> dev_selected_m_batch_ = nullptr;

--- a/src/rpucuda/cuda/io_manager_test.cpp
+++ b/src/rpucuda/cuda/io_manager_test.cpp
@@ -93,8 +93,7 @@ public:
     d_size = 490;
     m_batch = 100;
 
-    context_container = RPU::make_unique<CudaContext>(-1, false); // blocking for timings
-    context = &*context_container;
+    context = &context_container;
     iom = RPU::make_unique<InputOutputManager<num_t>>(context, x_size, d_size);
 
     num_t bound = 0.8;
@@ -170,7 +169,7 @@ public:
     delete[] W;
   }
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
 
   int x_size;

--- a/src/rpucuda/cuda/rpucuda_expstep_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_expstep_test.cpp
@@ -38,8 +38,7 @@ template <typename Tio> class RPUCudaExpstepStateTestFixture : public ::testing:
 public:
   void SetUp() {
 
-    context_container = RPU::make_unique<CudaContext>(-1, false);
-    context = &*context_container;
+    context = &context_container;
 
     x_size = 100;
     d_size = 110;
@@ -140,7 +139,7 @@ public:
     d_vec2_batch.resize(m_batch * d_size);
   }
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
 
   std::unique_ptr<RPUPulsed<num_t>> layer_pulsed;

--- a/src/rpucuda/cuda/rpucuda_linearstep_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_linearstep_test.cpp
@@ -38,8 +38,7 @@ class RPUCudaLinearStepTestFixture : public ::testing::TestWithParam<bool> {
 public:
   void SetUp() {
 
-    context_container = RPU::make_unique<CudaContext>(-1, false);
-    context = &*context_container;
+    context = &context_container;
 
     x_size = 100;
     d_size = 110;
@@ -139,7 +138,7 @@ public:
     d_vec_batch.resize(m_batch * d_size);
   }
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
 
   std::unique_ptr<RPUPulsed<num_t>> layer_pulsed;

--- a/src/rpucuda/cuda/rpucuda_onesided_device.cu
+++ b/src/rpucuda/cuda/rpucuda_onesided_device.cu
@@ -302,6 +302,7 @@ void OneSidedRPUDeviceCuda<T>::runUpdateKernel(
     int m_batch,
     const BitLineMaker<T> *blm,
     const PulsedUpdateMetaParameter<T> &up,
+    const T lr,
     curandState_t *dev_states,
     int one_sided,
     uint32_t *x_counts_chunk,

--- a/src/rpucuda/cuda/rpucuda_onesided_device.h
+++ b/src/rpucuda/cuda/rpucuda_onesided_device.h
@@ -60,6 +60,7 @@ public:
       int m_batch,
       const BitLineMaker<T> *blm,
       const PulsedUpdateMetaParameter<T> &up,
+      const T lr,
       curandState_t *dev_states,
       int one_sided = 0,
       uint32_t *x_counts_chunk = nullptr,

--- a/src/rpucuda/cuda/rpucuda_onesided_device_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_onesided_device_test.cpp
@@ -36,8 +36,7 @@ class RPUDeviceCudaTestFixture : public ::testing::TestWithParam<int> {
 public:
   void SetUp() {
 
-    context_container = RPU::make_unique<CudaContext>(-1, false);
-    context = &*context_container;
+    context = &context_container;
 
     x_size = 5;
     d_size = 8;
@@ -119,7 +118,7 @@ public:
   std::unique_ptr<AbstractRPUDevice<num_t>> rpu_device;
   std::unique_ptr<AbstractRPUDeviceCuda<num_t>> rpucuda_device;
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
 };
 

--- a/src/rpucuda/cuda/rpucuda_powstep_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_powstep_test.cpp
@@ -38,8 +38,7 @@ class RPUCudaPowStepTestFixture : public ::testing::TestWithParam<num_t> {
 public:
   void SetUp() {
 
-    context_container = RPU::make_unique<CudaContext>(-1, false);
-    context = &*context_container;
+    context = &context_container;
 
     x_size = 100;
     d_size = 110;
@@ -140,7 +139,7 @@ public:
     d_vec_batch.resize(m_batch * d_size);
   }
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
 
   std::unique_ptr<RPUPulsed<num_t>> layer_pulsed;

--- a/src/rpucuda/cuda/rpucuda_pulsed_device.cu
+++ b/src/rpucuda/cuda/rpucuda_pulsed_device.cu
@@ -366,6 +366,7 @@ void PulsedRPUDeviceCuda<T>::runUpdateKernel(
     int m_batch,
     const BitLineMaker<T> *blm,
     const PulsedUpdateMetaParameter<T> &up,
+    const T lr,
     curandState_t *dev_states,
     int one_sided,
     uint32_t *x_counts_chunk,

--- a/src/rpucuda/cuda/rpucuda_pulsed_device.h
+++ b/src/rpucuda/cuda/rpucuda_pulsed_device.h
@@ -80,6 +80,7 @@ public:
       int m_batch,
       const BitLineMaker<T> *blm,
       const PulsedUpdateMetaParameter<T> &up,
+      const T lr,
       curandState_t *dev_states,
       int one_sided = 0,
       uint32_t *x_counts_chunk = nullptr,
@@ -94,6 +95,7 @@ public:
   PulsedRPUDeviceCudaBase<T> *clone() const override { RPU_FATAL("Needs implementation"); };
 
   inline T getWeightGranularity() const { return weight_granularity_; };
+  virtual T getPulseCountLearningRate(T learning_rate) { return learning_rate; };
 
 protected:
   inline void setWeightGranularity(T weight_granularity) {
@@ -155,6 +157,7 @@ public:
       int m_batch,
       const BitLineMaker<T> *blm,
       const PulsedUpdateMetaParameter<T> &up,
+      const T lr,
       curandState_t *dev_states,
       int one_sided = 0,
       uint32_t *x_counts_chunk = nullptr,

--- a/src/rpucuda/cuda/rpucuda_pulsed_device_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_pulsed_device_test.cpp
@@ -43,8 +43,7 @@ template <typename DeviceParT> class RPUDeviceTestFixture : public ::testing::Te
 public:
   void SetUp() {
 
-    context_container = RPU::make_unique<CudaContext>(-1, false);
-    context = &*context_container;
+    context = &context_container;
 
     this->x_size = 53;
     this->d_size = 43;
@@ -226,7 +225,7 @@ public:
 
   void TearDown() { Array_2D_Free(refweights); }
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
 
   std::unique_ptr<RPUPulsed<num_t>> layer_pulsed;

--- a/src/rpucuda/cuda/rpucuda_simple_device.h
+++ b/src/rpucuda/cuda/rpucuda_simple_device.h
@@ -48,7 +48,6 @@ public:
       T *x_buffer,
       T *d_buffer) = 0;
   virtual bool hasDirectUpdate() const = 0;
-
   virtual int getHiddenUpdateIdx() const { return 0; };
   virtual void setHiddenUpdateIdx(int idx){};
 

--- a/src/rpucuda/cuda/rpucuda_simple_device_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_simple_device_test.cpp
@@ -44,8 +44,7 @@ template <typename DeviceParT> class RPUDeviceTestFixture : public ::testing::Te
 public:
   void SetUp() {
 
-    this->context_container = RPU::make_unique<CudaContext>(-1, false);
-    this->context = &*context_container;
+    context = &context_container;
 
     this->x_size = 253;
     this->d_size = 243;
@@ -229,7 +228,7 @@ public:
     Array_2D_Free(refweights);
   }
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
 
   std::unique_ptr<RPUPulsed<num_t>> pulsed;

--- a/src/rpucuda/cuda/rpucuda_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_test.cpp
@@ -35,8 +35,7 @@ template <typename T> class RPUCudaSimpleTestFixture : public ::testing::Test {
 public:
   void SetUp() {
 
-    context_container = RPU::make_unique<CudaContext>(-1, false);
-    context = &*context_container;
+    context = &context_container;
 
     is_test = true;
 
@@ -83,7 +82,7 @@ public:
     d_vec2.resize(d_size);
   }
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
 
   std::unique_ptr<RPUSimple<T>> layer_simple;

--- a/src/rpucuda/cuda/rpucuda_transfer_device_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_transfer_device_test.cpp
@@ -11,7 +11,9 @@
  */
 
 #include "cuda_util.h"
+#include "rpu_pulsed.h"
 #include "rpucuda_constantstep_device.h"
+#include "rpucuda_pulsed.h"
 #include "rpucuda_transfer_device.h"
 #include "test_helper.h"
 #include "gtest/gtest.h"
@@ -35,11 +37,9 @@ class RPUDeviceCudaTestFixture : public ::testing::TestWithParam<float> {
 public:
   void SetUp() {
 
-    context_container = RPU::make_unique<CudaContext>(-1, false);
-    context = &*context_container;
-
-    x_size = 2;
+    x_size = 5;
     d_size = 3;
+    m_batch = 1;
 
     w_ref = Array_2D_Get<num_t>(d_size, x_size);
 
@@ -50,6 +50,21 @@ public:
     weights = Array_2D_Get<num_t>(d_size, x_size);
     for (int i = 0; i < d_size * x_size; i++) {
       weights[0][i] = 0;
+    }
+    rx.resize(x_size * m_batch);
+    rd.resize(d_size * m_batch);
+
+    unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
+    std::default_random_engine generator{seed};
+    std::uniform_real_distribution<num_t> udist(-1.2, 1.2);
+    auto urnd = std::bind(udist, generator);
+
+    // just assign some numbers from the weight matrix
+    for (int i = 0; i < x_size * m_batch; i++)
+      rx[i] = urnd();
+
+    for (int j = 0; j < d_size * m_batch; j++) {
+      rd[j] = urnd();
     }
 
     up.pulse_type =
@@ -75,7 +90,8 @@ public:
     dp->gamma = GetParam(); // meaning fully hidden
     dp->transfer_lr = 1;
     dp->transfer_every = x_size;
-    dp->n_cols_per_transfer = 1;
+    dp->n_reads_per_transfer = 1;
+    dp->transfer_columns = true;
     dp->units_in_mbatch = false;
 
     dp->transfer_io.inp_res = -1;
@@ -85,29 +101,28 @@ public:
     dp->transfer_up = up;
     dp->transfer_up.pulse_type = PulseType::None; // perfect transfer
 
-    rng = new RNG<num_t>(0);
-
-    up_pwu = RPU::make_unique<PulsedWeightUpdater<num_t>>(context, x_size, d_size);
+    up_pwu = RPU::make_unique<PulsedWeightUpdater<num_t>>(&context, x_size, d_size);
 
     rpu_device = this->dp->createDeviceUnique(x_size, d_size, &rw_rng);
-    rpucuda_device = AbstractRPUDeviceCuda<num_t>::createFromUnique(context, *rpu_device);
+    rpucuda_device = AbstractRPUDeviceCuda<num_t>::createFromUnique(&context, *rpu_device);
 
-    dev_weights = RPU::make_unique<CudaArray<num_t>>(context, x_size * d_size);
+    dev_weights = RPU::make_unique<CudaArray<num_t>>(&context, x_size * d_size);
     dev_weights->assignTranspose(weights[0], d_size, x_size);
-    context->synchronize();
+    context.synchronize();
   };
 
   void TearDown() {
     Array_2D_Free<num_t>(weights);
     Array_2D_Free<num_t>(w_ref);
     delete dp;
-    delete rng;
   };
+  CudaContext context{-1, false};
 
-  int x_size, d_size, colidx;
+  int x_size, d_size, colidx, m_batch;
   num_t lifetime;
   num_t **weights;
   num_t **w_ref;
+  std::vector<num_t> rx, rd, w, w2;
   PulsedUpdateMetaParameter<num_t> up;
   TransferRPUDeviceMetaParameter<num_t> *dp;
   ConstantStepRPUDeviceMetaParameter<num_t> dp_cs;
@@ -116,11 +131,6 @@ public:
   RealWorldRNG<num_t> rw_rng;
   std::unique_ptr<AbstractRPUDevice<num_t>> rpu_device;
   std::unique_ptr<AbstractRPUDeviceCuda<num_t>> rpucuda_device;
-
-  RNG<num_t> *rng;
-
-  std::unique_ptr<CudaContext> context_container;
-  CudaContext *context;
 };
 
 // define the tests
@@ -136,14 +146,14 @@ TEST_P(RPUDeviceCudaTestFixture, onSetWeights) {
   for (int i = 0; i < this->x_size * this->d_size; i++) {
     this->weights[0][i] = w_ref[0][i];
   }
-  dev_weights = RPU::make_unique<CudaArray<num_t>>(context, x_size * d_size);
+  dev_weights = RPU::make_unique<CudaArray<num_t>>(&context, x_size * d_size);
   dev_weights->assignTranspose(weights[0], d_size, x_size);
-  context->synchronize();
+  context.synchronize();
 
   if (rpu_device->onSetWeights(this->weights)) {
     rpucuda_device->populateFrom(*rpu_device); // device pars have changed (due to onSetWeights)
   }
-  context->synchronize();
+  context.synchronize();
 
   std::vector<num_t> w_vec =
       static_cast<TransferRPUDeviceCuda<num_t> *>(&*rpucuda_device)->getHiddenWeights();
@@ -167,18 +177,18 @@ TEST_P(RPUDeviceCudaTestFixture, Update) {
   dp->transfer_lr = 0; // no transfer here
   // just newly create from paramerers
   rpu_device = dp->createDeviceUnique(this->x_size, this->d_size, &this->rw_rng);
-  rpucuda_device = AbstractRPUDeviceCuda<num_t>::createFromUnique(context, *rpu_device);
+  rpucuda_device = AbstractRPUDeviceCuda<num_t>::createFromUnique(&context, *rpu_device);
 
-  CudaArray<num_t> dev_x(context, this->x_size);
+  CudaArray<num_t> dev_x(&context, this->x_size);
   dev_x.setConst(1.0);
-  CudaArray<num_t> dev_d(context, this->d_size);
+  CudaArray<num_t> dev_d(&context, this->d_size);
   dev_d.setConst(-1.0);
-  context->synchronize();
+  context.synchronize();
 
   if (rpu_device->onSetWeights(this->weights)) {
     rpucuda_device->populateFrom(*rpu_device); // device pars have changed (due to onSetWeights)
   }
-  context->synchronize();
+  context.synchronize();
 
   up_pwu->update(
       dev_x.getDataConst(), dev_d.getDataConst(), dev_weights->getData(), &*rpucuda_device,
@@ -188,7 +198,7 @@ TEST_P(RPUDeviceCudaTestFixture, Update) {
       false, // trans
       false);
   // should update all weight values of the hidden weight by -1
-  context->synchronize();
+  context.synchronize();
   auto w_vec = static_cast<TransferRPUDeviceCuda<num_t> *>(&*rpucuda_device)->getHiddenWeights();
 
   // update only on fast [nothing to transfer for first row]
@@ -200,7 +210,7 @@ TEST_P(RPUDeviceCudaTestFixture, Update) {
                                            // should actually be exactly one
     s += w_vec[i];
   }
-  std::cout << "Average weight " << s / size << " (Expected is 1.0)" << std::endl;
+  // std::cout << "Average weight " << s / size << " (Expected is 1.0)" << std::endl;
 
   // visible  weights  not
   for (int i = 0; i < size; i++) {
@@ -217,18 +227,18 @@ TEST_P(RPUDeviceCudaTestFixture, Update) {
   }
 }
 
-TEST_P(RPUDeviceCudaTestFixture, UpdateAndTransfer) {
+TEST_P(RPUDeviceCudaTestFixture, UpdateAndTransferColumns) {
 
-  CudaArray<num_t> dev_x(context, this->x_size);
+  CudaArray<num_t> dev_x(&context, this->x_size);
   dev_x.setConst(1.0);
-  CudaArray<num_t> dev_d(context, this->d_size);
+  CudaArray<num_t> dev_d(&context, this->d_size);
   dev_d.setConst(-1.0);
-  context->synchronize();
+  context.synchronize();
 
   if (rpu_device->onSetWeights(this->weights)) {
     rpucuda_device->populateFrom(*rpu_device); // device pars have changed (due to onSetWeights)
   }
-  context->synchronize();
+  context.synchronize();
 
   for (int k = 0; k < this->x_size; k++) {
     up_pwu->update(
@@ -241,7 +251,7 @@ TEST_P(RPUDeviceCudaTestFixture, UpdateAndTransfer) {
   }
   // weight values of the hidden weights should be x_size and first
   // col should be transfered once (that is set to x_size also)
-  context->synchronize();
+  context.synchronize();
   auto w_vec = static_cast<TransferRPUDeviceCuda<num_t> *>(&*rpucuda_device)->getHiddenWeights();
   dev_weights->copyTo(weights[0]);
   dev_weights->assignTranspose(weights[0], x_size, d_size);
@@ -255,10 +265,11 @@ TEST_P(RPUDeviceCudaTestFixture, UpdateAndTransfer) {
     ASSERT_EQ(w_vec[i], (num_t)this->x_size);
     s += w_vec[i];
   }
-  std::cout << "Average weight " << s / size << " (Expected is " << this->x_size << ")"
-            << std::endl;
-
   // only first col of  weights should be transferred
+  // for (int i = 0; i < size; i++) {
+  //   std::cout << "[" << i / x_size << "," << i % x_size << "]: " << w_vec[i] << ", "
+  //  	      << w_vec[i + size] << ", " << this->weights[0][i] << std::endl;
+  // }
 
   for (int i = 0; i < size; i++) {
     if (GetParam()) {
@@ -271,19 +282,214 @@ TEST_P(RPUDeviceCudaTestFixture, UpdateAndTransfer) {
   // reduce to weight.
   std::vector<num_t> rw =
       static_cast<TransferRPUDeviceCuda<num_t> *>(&*rpucuda_device)->getReduceWeightening();
-  std::cout << "RW: " << rw[0] << "," << rw[1] << std::endl;
-  for (int i = 0; i < size; i++) {
-    std::cout << "[" << i / x_size << "," << i % x_size << "]: " << w_vec[i] << ", "
-              << w_vec[i + size] << ", " << this->weights[0][i] << std::endl;
-  }
+  // std::cout << "RW: " << rw[0] << "," << rw[1] << std::endl;
+  // for (int i = 0; i < size; i++) {
+  //   std::cout << "[" << i / x_size << "," << i % x_size << "]: " << w_vec[i] << ", "
+  // 	      << w_vec[i + size] << ", " << this->weights[0][i] << std::endl;
+  // }
 
   for (int i = 0; i < size; i++) {
     if (GetParam()) {
-      std::cout << "[" << i / x_size << "," << i % x_size << "]: " << w_vec[i + size] << std::endl;
+      // std::cout << "[" << i / x_size << "," << i % x_size << "]: " << w_vec[i + size] <<
+      // std::endl;
       ASSERT_FLOAT_EQ(this->weights[0][i], rw[0] * w_vec[i] + rw[1] * w_vec[i + size]);
     } else {
       ASSERT_FLOAT_EQ(this->weights[0][i], i % x_size ? 0.0 : (num_t)this->x_size * rw[1]);
     }
+  }
+}
+
+TEST_P(RPUDeviceCudaTestFixture, UpdateAndTransferRows) {
+
+  dp->transfer_every = d_size;
+  dp->transfer_columns = false;
+  rpu_device = this->dp->createDeviceUnique(x_size, d_size, &rw_rng);
+  rpucuda_device = AbstractRPUDeviceCuda<num_t>::createFromUnique(&context, *rpu_device);
+
+  CudaArray<num_t> dev_x(&context, this->x_size);
+  dev_x.setConst(1.0);
+  CudaArray<num_t> dev_d(&context, this->d_size);
+  dev_d.setConst(-1.0);
+  context.synchronize();
+
+  if (rpu_device->onSetWeights(this->weights)) {
+    rpucuda_device->populateFrom(*rpu_device); // device pars have changed (due to onSetWeights)
+  }
+  context.synchronize();
+
+  for (int k = 0; k < d_size; k++) {
+    up_pwu->update(
+        dev_x.getDataConst(), dev_d.getDataConst(), dev_weights->getData(), &*rpucuda_device,
+        this->up,
+        1.0,   // lr
+        1,     // batch
+        false, // trans
+        false);
+  }
+  // weight values of the hidden weights should be d_size and first
+  // row should be transfered once thus also d_size
+  context.synchronize();
+  auto w_vec = static_cast<TransferRPUDeviceCuda<num_t> *>(&*rpucuda_device)->getHiddenWeights();
+  dev_weights->copyTo(weights[0]);
+  dev_weights->assignTranspose(weights[0], x_size, d_size);
+  dev_weights->copyTo(weights[0]);
+
+  // update only on fast [nothing to transfer for first row]
+  int size = this->d_size * this->x_size;
+  // hidden weights updated
+  num_t s = 0;
+  for (int i = 0; i < size; i++) {
+    ASSERT_EQ(w_vec[i], (num_t)this->d_size);
+    s += w_vec[i];
+  }
+  // only first row of  weights should be transferred
+  // for (int i = 0; i < size; i++) {
+  //   std::cout << "[" << i / x_size << "," << i % x_size << "]: " << w_vec[i] << ", "
+  //  	      << w_vec[i + size] << ", " << this->weights[0][i] << std::endl;
+  // }
+
+  for (int i = 0; i < size; i++) {
+    // wvec should be x_size major
+    if (GetParam()) {
+      ASSERT_FLOAT_EQ(w_vec[i + size], i >= x_size ? 0.0 : (num_t)this->d_size);
+    } else {
+      ASSERT_FLOAT_EQ(w_vec[i + size], 0.0); // should not be used
+    }
+  }
+
+  // reduce to weight.
+  std::vector<num_t> rw =
+      static_cast<TransferRPUDeviceCuda<num_t> *>(&*rpucuda_device)->getReduceWeightening();
+
+  for (int i = 0; i < size; i++) {
+    if (GetParam()) {
+      ASSERT_FLOAT_EQ(this->weights[0][i], rw[0] * w_vec[i] + rw[1] * w_vec[i + size]);
+    } else {
+      ASSERT_FLOAT_EQ(this->weights[0][i], i >= x_size ? 0.0 : (num_t)this->d_size * rw[1]);
+    }
+  }
+}
+
+TEST_P(RPUDeviceCudaTestFixture, CUDAvsCPU) {
+
+  PulsedMetaParameter<num_t> p;
+  p.up = up;
+  p.up.x_res_implicit = 0.01;
+  p.up.d_res_implicit = 0.01;
+  p.up.pulse_type = PulseType::DeterministicImplicit;
+
+  dp->transfer_up.pulse_type = PulseType::DeterministicImplicit;
+  dp->transfer_up.x_res_implicit = 0.01;
+  dp->transfer_up.d_res_implicit = 0.01;
+  dp->transfer_up.desired_BL = 10;
+
+  dp->transfer_io.is_perfect = true;
+
+  CudaArray<num_t> dev_x(&context, x_size * m_batch, rx.data());
+  CudaArray<num_t> dev_d(&context, d_size * m_batch, rd.data());
+  context.synchronize();
+
+  auto *rpu = new RPUPulsed<num_t>(x_size, d_size);
+  rpu->populateParameter(&p, dp);
+  rpu->setWeights(this->weights[0]);
+
+  rpu->setLearningRate(1.0);
+  auto *rpucuda = new RPUCudaPulsed<num_t>(context.getStream(), *rpu);
+  rpucuda->setLearningRate(1.0);
+  context.synchronize();
+
+  int size = this->d_size * this->x_size;
+  // double check whether weights are correct
+  w.resize(x_size * d_size);
+  rpu->getWeights(w.data());
+  w2.resize(x_size * d_size);
+  rpucuda->getWeights(w2.data());
+
+  for (int i = 0; i < size; i++) {
+    ASSERT_NEAR(w[i], w2[i], 1.0e-4);
+  }
+
+  context.synchronize();
+  for (int k = 0; k < size; k++) {
+    rpu->update(rx.data(), rd.data(), false, m_batch, false, false);
+    rpucuda->update(dev_x.getData(), dev_d.getData(), false, m_batch, false, false);
+  }
+  // weight values of the hidden weights should be x_size and first
+  // col should be transfered once (that is set to dw_min)
+  context.synchronize();
+  w.resize(x_size * d_size);
+  rpu->getWeights(w.data());
+  w2.resize(x_size * d_size);
+  rpucuda->getWeights(w2.data());
+
+  for (int i = 0; i < size; i++) {
+    ASSERT_NEAR(w[i], w2[i], 1.0e-4);
+  }
+}
+
+TEST_P(RPUDeviceCudaTestFixture, CUDAvsCPURows) {
+
+  PulsedMetaParameter<num_t> p;
+  p.up = up;
+  p.up.x_res_implicit = 0.01;
+  p.up.d_res_implicit = 0.01;
+  p.up.pulse_type = PulseType::DeterministicImplicit;
+
+  dp->transfer_columns = false;
+  dp->transfer_up.pulse_type = PulseType::DeterministicImplicit;
+  dp->transfer_up.x_res_implicit = 0.01;
+  dp->transfer_up.d_res_implicit = 0.01;
+  dp->transfer_up.desired_BL = 10;
+
+  dp->transfer_io.is_perfect = true;
+
+  CudaArray<num_t> dev_x(&context, x_size * m_batch, rx.data());
+  CudaArray<num_t> dev_d(&context, d_size * m_batch, rd.data());
+  context.synchronize();
+
+  auto *rpu = new RPUPulsed<num_t>(x_size, d_size);
+  rpu->populateParameter(&p, dp);
+  rpu->setWeights(this->weights[0]);
+  // rpu->disp();
+  // rpu->dispParameter();
+  rpu->setLearningRate(1.0);
+  auto *rpucuda = new RPUCudaPulsed<num_t>(context.getStream(), *rpu);
+  rpucuda->setLearningRate(1.0);
+  context.synchronize();
+  // rpucuda->disp();
+  // rpucuda->dispParameter();
+
+  int size = this->d_size * this->x_size;
+  // double check whether weights are correct
+  w.resize(x_size * d_size);
+  rpu->getWeights(w.data());
+  w2.resize(x_size * d_size);
+  rpucuda->getWeights(w2.data());
+
+  for (int i = 0; i < size; i++) {
+    ASSERT_NEAR(w[i], w2[i], 1.0e-4);
+  }
+
+  context.synchronize();
+  for (int k = 0; k < size; k++) {
+    rpu->update(rx.data(), rd.data(), false, m_batch, false, false);
+    rpucuda->update(dev_x.getData(), dev_d.getData(), false, m_batch, false, false);
+  }
+  // weight values of the hidden weights should be x_size and first
+  // col should be transfered once (that is set to dw_min)
+  context.synchronize();
+  w.resize(x_size * d_size);
+  rpu->getWeights(w.data());
+  w2.resize(x_size * d_size);
+  rpucuda->getWeights(w2.data());
+
+  // std::cout << "CPU vs CUDA" << std::endl;
+  // for (int i = 0; i < size; i++) {
+  //   std::cout << "[" << i / x_size << "," << i % x_size << "]: " << w[i] << " vs. " << w2[i] <<
+  //   std::endl;
+  // }
+  for (int i = 0; i < size; i++) {
+    ASSERT_NEAR(w[i], w2[i], 1.0e-4);
   }
 }
 

--- a/src/rpucuda/cuda/rpucuda_vector_device.cu
+++ b/src/rpucuda/cuda/rpucuda_vector_device.cu
@@ -124,6 +124,7 @@ VectorRPUDeviceCuda<T> &VectorRPUDeviceCuda<T>::operator=(VectorRPUDeviceCuda<T>
   context_vec_ = std::move(other.context_vec_);
   other.context_vec_.clear();
 
+  rw_rng_ = std::move(other.rw_rng_);
   return *this;
 };
 
@@ -275,6 +276,7 @@ void VectorRPUDeviceCuda<T>::runUpdateKernel(
     int m_batch,
     const BitLineMaker<T> *blm,
     const PulsedUpdateMetaParameter<T> &up,
+    const T lr,
     curandState_t *dev_states,
     int one_sided,
     uint32_t *x_counts_chunk,

--- a/src/rpucuda/cuda/rpucuda_vector_device.h
+++ b/src/rpucuda/cuda/rpucuda_vector_device.h
@@ -42,6 +42,7 @@ public:
     swap(a.current_device_idx_, b.current_device_idx_);
     swap(a.current_update_idx_, b.current_update_idx_);
     swap(a.dev_reduce_weightening_, b.dev_reduce_weightening_);
+    swap(a.rw_rng_, b.rw_rng_);
   };
 
   // implement abstract functions
@@ -74,6 +75,7 @@ public:
       int m_batch,
       const BitLineMaker<T> *blm,
       const PulsedUpdateMetaParameter<T> &up,
+      const T lr,
       curandState_t *dev_states,
       int one_sided = 0,
       uint32_t *x_counts_chunk = nullptr,
@@ -89,9 +91,9 @@ public:
   std::vector<T> getReduceWeightening() const;
 
 protected:
-  int n_devices_ = 0;
-
   virtual void reduceToWeights(CudaContext *c, T *dev_weights);
+
+  int n_devices_ = 0;
   RealWorldRNG<T> rw_rng_{0};
   std::vector<T *> dev_weights_ptrs_;
   std::unique_ptr<CudaArray<T>> dev_weights_vec_ = nullptr;

--- a/src/rpucuda/cuda/rpucuda_vector_device_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_vector_device_test.cpp
@@ -54,7 +54,7 @@ template <> void setAdditionalValues(TransferRPUDeviceMetaParameter<num_t> *vp, 
   vp->transfer_io.out_res = -1;
   vp->transfer_every = 1;
   vp->transfer_lr = 0.5;
-  vp->n_cols_per_transfer = 1;
+  vp->n_reads_per_transfer = 1;
   vp->gamma = value;
 }
 
@@ -62,8 +62,7 @@ template <typename VectorDeviceParT> class RPUDeviceTestFixture : public ::testi
 public:
   void SetUp() {
 
-    this->context_container = RPU::make_unique<CudaContext>(-1, false);
-    this->context = &*context_container;
+    context = &context_container;
 
     this->x_size = 4;
     this->d_size = 5;
@@ -261,7 +260,7 @@ public:
   };
   void TearDown() { Array_2D_Free(refweights); }
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
 
   std::unique_ptr<RPUPulsed<num_t>> layer_pulsed;

--- a/src/rpucuda/cuda/weight_clipper_cuda_test.cpp
+++ b/src/rpucuda/cuda/weight_clipper_cuda_test.cpp
@@ -36,8 +36,7 @@ class WeightClipperTestFixture : public ::testing::TestWithParam<bool> {
 public:
   void SetUp() {
 
-    context_container = RPU::make_unique<CudaContext>(-1, false);
-    context = &*context_container;
+    context = &context_container;
 
     x_size = 100;
     d_size = 130;
@@ -69,7 +68,7 @@ public:
     delete[] v;
   }
 
-  std::unique_ptr<CudaContext> context_container;
+  CudaContext context_container{-1, false};
   CudaContext *context;
 
   int x_size, d_size;

--- a/src/rpucuda/dense_bit_line_maker.cpp
+++ b/src/rpucuda/dense_bit_line_maker.cpp
@@ -282,14 +282,16 @@ int *DenseBitLineMaker<T>::makeCoincidences(
   T A = 0;
   T B = 0;
   int BL = 0;
+  // negative lr allowed in the below, thus fabs(lr)
   if (up.update_bl_management || up.update_management) {
 
     T x_abs_max = Find_Absolute_Max<T>(x_in, x_size_, x_inc);
     T d_abs_max = Find_Absolute_Max<T>(d_in, d_size_, d_inc);
 
-    up.performUpdateManagement(BL, A, B, up.desired_BL, x_abs_max, d_abs_max, lr, dw_min);
+    up.performUpdateManagement(BL, A, B, up.desired_BL, x_abs_max, d_abs_max, fabs(lr), dw_min);
   } else {
-    up.calculateBlAB(BL, A, B, lr, dw_min);
+
+    up.calculateBlAB(BL, A, B, fabs(lr), dw_min);
   }
 
   if (!containers_allocated_) {

--- a/src/rpucuda/rpu_forward_backward_pass.h
+++ b/src/rpucuda/rpu_forward_backward_pass.h
@@ -24,12 +24,6 @@ public:
   explicit ForwardBackwardPass(int x_size, int d_size) : x_size_(x_size), d_size_(d_size){};
   ForwardBackwardPass(){};
 
-  friend void swap(ForwardBackwardPass<T> &a, ForwardBackwardPass<T> &b) noexcept {
-    using std::swap;
-    swap(a.x_size_, b.x_size_);
-    swap(a.d_size_, b.d_size_);
-  }
-
   virtual void forwardVector(
       T **weights,
       const T *x_input,
@@ -53,26 +47,6 @@ template <typename T> class ForwardBackwardPassIOManaged : public ForwardBackwar
 public:
   explicit ForwardBackwardPassIOManaged(int x_size, int d_size, std::shared_ptr<RNG<T>> rng);
   ForwardBackwardPassIOManaged(){};
-  virtual ~ForwardBackwardPassIOManaged();
-
-  ForwardBackwardPassIOManaged(const ForwardBackwardPassIOManaged<T> &);
-  ForwardBackwardPassIOManaged<T> &operator=(const ForwardBackwardPassIOManaged<T> &);
-  ForwardBackwardPassIOManaged(ForwardBackwardPassIOManaged<T> &&);
-  ForwardBackwardPassIOManaged<T> &operator=(ForwardBackwardPassIOManaged<T> &&);
-
-  friend void
-  swap(ForwardBackwardPassIOManaged<T> &a, ForwardBackwardPassIOManaged<T> &b) noexcept {
-    using std::swap;
-    swap(static_cast<ForwardBackwardPass<T> &>(a), static_cast<ForwardBackwardPass<T> &>(b));
-    swap(a.containers_allocated_, b.containers_allocated_);
-    swap(a.f_io_, b.f_io_);
-    swap(a.b_io_, b.b_io_);
-    swap(a.tmp_x_values_, b.tmp_x_values_);
-    swap(a.tmp_d_values_, b.tmp_d_values_);
-    swap(a.aux_nm_value_, b.aux_nm_value_);
-    swap(a.rng_, b.rng_);
-    swap(a.checked_implemented_, b.checked_implemented_);
-  }
 
   void forwardVector(
       T **weights,
@@ -89,19 +63,40 @@ public:
 
   void setIOPar(const IOMetaParameter<T> &f_io_, const IOMetaParameter<T> &b_io_);
 
+protected:
+  void applyOutputWeightNoise(
+      T **weights,
+      T *out_values,
+      const int out_size,
+      const int out_inc,
+      const T *in_values,
+      const int in_size,
+      IOMetaParameter<T> &io,
+      bool transposed);
+
+  void applyIrDrop(
+      T **weights,
+      T *out_values,
+      int out_size,
+      const int out_inc,
+      const T *in_values,
+      const int in_size,
+      IOMetaParameter<T> &io,
+      bool transposed);
+
 private:
   void ensureImplemented();
 
-  void freeContainers();
-  void allocateContainers();
+  std::vector<T> tmp_d_values_;
+  std::vector<T> tmp_x_values_;
 
-  T *tmp_x_values_ = nullptr;
-  T *tmp_d_values_ = nullptr;
+  std::vector<T> tmp_in_values_;
+  std::vector<T> tmp_out_values_;
+  std::vector<T> tmp_c_values_;
 
   T aux_nm_value_ = -1.0;
   IOMetaParameter<T> f_io_;
   IOMetaParameter<T> b_io_;
-  bool containers_allocated_ = false;
   bool checked_implemented_ = false;
   std::shared_ptr<RNG<T>> rng_ = nullptr;
 };

--- a/src/rpucuda/rpu_pulsed_device.h
+++ b/src/rpucuda/rpu_pulsed_device.h
@@ -159,6 +159,7 @@ public:
       T **weights, const PulsedUpdateMetaParameter<T> &up, T current_lr, int m_batch_info){};
 
   inline T getWeightGranularity() const { return weight_granularity_; };
+  virtual T getPulseCountLearningRate(T learning_rate) { return learning_rate; };
 
 protected:
   inline void setWeightGranularity(T weight_granularity) {

--- a/src/rpucuda/rpu_pulsed_meta_parameter.cpp
+++ b/src/rpucuda/rpu_pulsed_meta_parameter.cpp
@@ -148,6 +148,7 @@ void PulsedUpdateMetaParameter<T>::calculateBlAB(
     A = (T)0.0;
     B = (T)0.0;
     BL = 0;
+    return;
   }
 
   if (fixed_BL || update_bl_management) {
@@ -158,7 +159,7 @@ void PulsedUpdateMetaParameter<T>::calculateBlAB(
     if ((weight_granularity * desired_BL) < lr) {
       A = (T)1.0;
       B = (T)1.0;
-      BL = (int)ceil(lr / weight_granularity);
+      BL = MAX((int)ceil(lr / weight_granularity), 1);
     } else {
       BL = desired_BL;
       A = sqrt(lr / (weight_granularity * BL));

--- a/src/rpucuda/rpu_pulsed_meta_parameter.h
+++ b/src/rpucuda/rpu_pulsed_meta_parameter.h
@@ -29,7 +29,7 @@ enum class NoiseManagementType {
   AverageAbsMaxSingleValue
 };
 
-enum class BoundManagementType { None, Iterative, IterativeWorstCase, Shift, SignalChannel };
+enum class BoundManagementType { None, Iterative, IterativeWorstCase, Shift };
 
 enum class OutputWeightNoiseType { None, AdditiveConstant, PCMRead };
 
@@ -48,6 +48,8 @@ template <typename T> struct IOMetaParameter {
   bool is_perfect = false; // short-cut to use pure floating point (only out_scale will be applied)
 
   OutputWeightNoiseType w_noise_type = OutputWeightNoiseType::None;
+  T ir_drop = (T)0.0;
+  T ir_drop_Gw_div_gmax = (T)5.7143e5; // physical ratio of wire conductance to physical gmax
 
   T inp_bound = (T)1.0;
   T inp_res = (T)1.0 / (pow((T)2.0, (T)7.0) - (T)2.0);
@@ -109,6 +111,10 @@ template <typename T> struct IOMetaParameter {
           ss << "\t w_noise_type:\t\t" << (int)OutputWeightNoiseType::PCMRead << " (PCMRead) "
              << std::endl;
         }
+      }
+      if (ir_drop > 0.0) {
+        ss << "\t ir_drop [scale]:\t" << ir_drop << "  (ir_drop_Gw_div_gmax is "
+           << ir_drop_Gw_div_gmax << ")" << std::endl;
       }
     }
     if (out_scale != 1.0) {

--- a/src/rpucuda/rpu_transfer_device.cpp
+++ b/src/rpucuda/rpu_transfer_device.cpp
@@ -65,6 +65,12 @@ void TransferRPUDeviceMetaParameter<T>::printToStream(std::stringstream &ss) con
   ss << std::endl;
 
   // lr
+  if (fast_lr > 0) {
+    ss << "\tfast_lr:\t\t";
+    ss << fast_lr;
+    ss << std::endl;
+  }
+
   ss << "\ttransfer_lr: \t\t";
   if (this->_par_initialized)
     for (size_t k = 0; k < transfer_lr_vec.size(); k++) {
@@ -74,16 +80,23 @@ void TransferRPUDeviceMetaParameter<T>::printToStream(std::stringstream &ss) con
     ss << transfer_lr;
   }
   if (scale_transfer_lr) {
-    ss << " [scaled with current LR]";
+    ss << "\t[scaled with current LR]";
   }
   ss << std::endl;
 
-  ss << "\tn_cols_per_transfer: \t" << n_cols_per_transfer;
+  ss << "\tn_reads_per_transfer: \t" << n_reads_per_transfer;
+  if (transfer_columns) {
+    ss << "\t[reading columns]";
+  } else {
+    ss << "\t[reading rows]";
+  }
+  ss << std::endl;
+
   if (with_reset_prob) {
     ss << "\t[with reset p=" << with_reset_prob << "]";
   }
-  if (random_column) {
-    ss << "\t[random column]";
+  if (random_selection) {
+    ss << "\t[random selection]";
   }
   ss << std::endl;
 
@@ -110,6 +123,14 @@ void TransferRPUDeviceMetaParameter<T>::initializeWithSize(int x_size, int d_siz
   if (n_devices < 2) {
     // makes no sense
     RPU_FATAL("Need at least 2 devices");
+  }
+
+  if (transfer_columns) {
+    _in_size = x_size;
+    _out_size = d_size;
+  } else {
+    _in_size = d_size;
+    _out_size = x_size;
   }
 
   this->update_policy = VectorDeviceUpdatePolicy::SingleFixed;
@@ -155,10 +176,10 @@ void TransferRPUDeviceMetaParameter<T>::initializeWithSize(int x_size, int d_siz
     RPU_FATAL("Expect transfer_lr_vec of size n_devices.");
   }
 
-  if (n_cols_per_transfer > x_size) {
+  if (n_reads_per_transfer > _in_size) {
     // should not be needed anyway
-    n_cols_per_transfer = x_size;
-    RPU_WARNING("too many transfers in one shot. Use x_size instead.");
+    n_reads_per_transfer = _in_size;
+    RPU_WARNING("too many transfers in one shot. Using full transfer instead.");
   }
 
   // TODO: make an default value, where the value of the transfer depends on  x_size
@@ -167,7 +188,7 @@ void TransferRPUDeviceMetaParameter<T>::initializeWithSize(int x_size, int d_siz
     T n = transfer_every;
     for (size_t i = 0; i < n_devices; i++) {
       transfer_every_vec.push_back(n);
-      n *= (T)x_size / n_cols_per_transfer;
+      n *= (T)_in_size / n_reads_per_transfer;
     }
     if (no_self_transfer) {
       transfer_every_vec[n_devices - 1] = 0;
@@ -178,8 +199,16 @@ void TransferRPUDeviceMetaParameter<T>::initializeWithSize(int x_size, int d_siz
     RPU_FATAL("Expect transfer_every_vec to be of length n_devices");
   }
 
+  if (with_reset_prob > 0 && !transfer_columns) {
+    RPU_FATAL("Reset prob is only implemented for column-transfer so far.");
+  }
+
   // IO
-  transfer_io.initializeForForward();
+  if (transfer_columns) {
+    transfer_io.initializeForForward();
+  } else {
+    transfer_io.initializeForBackward();
+  }
 
   // we turn BM off.
   if (transfer_io.bound_management != BoundManagementType::None) {
@@ -230,10 +259,11 @@ TransferRPUDevice<T>::TransferRPUDevice(const TransferRPUDevice<T> &other)
   transfer_fb_pass_ = make_unique<ForwardBackwardPassIOManaged<T>>(*other.transfer_fb_pass_);
   transfer_pwu_ = make_unique<PulsedRPUWeightUpdater<T>>(*other.transfer_pwu_);
 
-  current_col_indices_ = other.current_col_indices_;
+  current_slice_indices_ = other.current_slice_indices_;
   transfer_vecs_ = other.transfer_vecs_;
   transfer_every_ = other.transfer_every_;
   fully_hidden_ = other.fully_hidden_;
+  last_weight_ = other.last_weight_;
 }
 
 // copy assignment
@@ -255,27 +285,30 @@ template <typename T>
 TransferRPUDevice<T> &TransferRPUDevice<T>::operator=(TransferRPUDevice<T> &&other) {
   VectorRPUDevice<T>::operator=(std::move(other));
 
-  current_col_indices_ = std::move(other.current_col_indices_);
+  current_slice_indices_ = std::move(other.current_slice_indices_);
   transfer_vecs_ = std::move(other.transfer_vecs_);
   transfer_every_ = std::move(other.transfer_every_);
   transfer_fb_pass_ = std::move(other.transfer_fb_pass_);
   transfer_pwu_ = std::move(other.transfer_pwu_);
-
+  last_weight_ = std::move(other.last_weight_);
   fully_hidden_ = other.fully_hidden_;
 
   return *this;
 }
 
 template <typename T> void TransferRPUDevice<T>::setTransferVecs(const T *transfer_vecs) {
-  transfer_vecs_.resize(this->x_size_ * this->x_size_); //!!  square matrix
+  T in_size = getPar().getInSize();
+
+  transfer_vecs_.resize(in_size * in_size); //!!  square matrix
   std::fill(transfer_vecs_.begin(), transfer_vecs_.end(), (T)0.0);
 
   if (transfer_vecs == nullptr) {
     // initialize transfer vectors with unit vectors. This might be overridden
-    for (size_t i = 0; i < transfer_vecs_.size(); i += this->x_size_ + 1) {
+    for (size_t i = 0; i < transfer_vecs_.size(); i += in_size + 1) {
       transfer_vecs_[i] = 1.0;
     }
   } else {
+    // Caution: No size check!
     for (size_t i = 0; i < transfer_vecs_.size(); i++) {
       transfer_vecs_[i] = transfer_vecs[i];
     }
@@ -284,8 +317,8 @@ template <typename T> void TransferRPUDevice<T>::setTransferVecs(const T *transf
 
 template <typename T> int TransferRPUDevice<T>::resetCounters(bool force) {
 
-  current_col_indices_.resize(this->n_devices_);
-  std::fill(current_col_indices_.begin(), current_col_indices_.end(), (int)0);
+  current_slice_indices_.resize(this->n_devices_);
+  std::fill(current_slice_indices_.begin(), current_slice_indices_.end(), (int)0);
   return VectorRPUDevice<T>::resetCounters(force);
 }
 /*********************************************************************************/
@@ -304,7 +337,6 @@ void TransferRPUDevice<T>::populate(
       RPU::make_unique<ForwardBackwardPassIOManaged<T>>(this->x_size_, this->d_size_, shared_rng);
 
   transfer_fb_pass_->setIOPar(par.transfer_io, par.transfer_io);
-  // TODO: the OUT_SCALE might be different for the transfer!! How to account for that?!?
 
   transfer_pwu_ =
       RPU::make_unique<PulsedRPUWeightUpdater<T>>(this->x_size_, this->d_size_, shared_rng);
@@ -318,6 +350,22 @@ void TransferRPUDevice<T>::populate(
   setTransferVecs();
   transfer_every_ = par.transfer_every_vec; // already checked for length
   fully_hidden_ = getPar().fullyHidden();   // save
+}
+
+/*********************************************************************************/
+/* getPulseCountLearningRate */
+/* Here we compute the LR for the A matrix (the SGD update). Because
+   of the device properties it is beneficial to use a constant LR
+   here, but scale the buffer with the scheduled SGD learning rate
+   later*/
+template <typename T> T TransferRPUDevice<T>::getPulseCountLearningRate(T learning_rate) {
+  const auto &par = getPar();
+
+  if (par.fast_lr > 0) {
+    return par.fast_lr;
+  } else {
+    return learning_rate;
+  }
 }
 
 /*********************************************************************************/
@@ -342,17 +390,42 @@ int TransferRPUDevice<T>::getTransferEvery(int from_device_idx, int m_batch) con
 }
 
 template <typename T>
-void TransferRPUDevice<T>::forwardUpdate(
+void TransferRPUDevice<T>::readVector(int device_idx, const T *in_vec, T *out_vec, T alpha) {
+  T **W = getDeviceWeights(device_idx);
+  if (getPar().transfer_columns) {
+    transfer_fb_pass_->forwardVector(W, in_vec, 1, out_vec, 1, alpha, false);
+  } else {
+    transfer_fb_pass_->backwardVector(W, in_vec, 1, out_vec, 1, alpha);
+  }
+}
+
+template <typename T>
+void TransferRPUDevice<T>::writeVector(
+    int device_idx, const T *in_vec, const T *out_vec, const T lr, const int m_batch_info) {
+
+  T **W = getDeviceWeights(device_idx);
+  if (getPar().transfer_columns) {
+    // in_vec is x_input
+    transfer_pwu_->updateVectorWithDevice(
+        W, in_vec, 1, out_vec, 1, lr, m_batch_info, &*this->rpu_device_vec_[device_idx]);
+  } else {
+    // in_vec is d_input
+    transfer_pwu_->updateVectorWithDevice(
+        W, out_vec, 1, in_vec, 1, lr, m_batch_info, &*this->rpu_device_vec_[device_idx]);
+  }
+}
+
+template <typename T>
+void TransferRPUDevice<T>::readAndUpdate(
     int to_device_idx,
     int from_device_idx,
     const T lr,
-    const T *x_input,
+    const T *vec, // these are the selected transfer vecs
     const int n_vec,
-    const bool trans,
     const T reset_prob,
-    const int i_col) {
+    const int i_slice) {
 
-  if (!lr) {
+  if (lr == 0.0) {
     return;
   }
 
@@ -360,68 +433,66 @@ void TransferRPUDevice<T>::forwardUpdate(
     // self update not supported per default
     return;
   }
+  const auto &par = getPar();
 
-  if (transfer_tmp_.size() < (size_t)this->d_size_) {
-    transfer_tmp_.resize(this->d_size_);
-  }
+  int in_size = par.getInSize();
+  int out_size = par.getOutSize();
 
-  // forward / update
-  T **W;
+  transfer_tmp_.resize(out_size);
+
+  // forward or backward / update
   for (int i = 0; i < n_vec; i++) {
-    const T *x = x_input + i * this->x_size_;
+    const T *v = vec + i * in_size;
 
-    transfer_fb_pass_->forwardVector(
-        this->weights_vec_[from_device_idx], x, 1, &transfer_tmp_[0], 1, (T)1.0, false);
+    readVector(from_device_idx, v, transfer_tmp_.data(), -1.0); // scale -1 for pos update
 
-    // potentially reset here (because of possible same device to-from):
-    // NOTE that with_reset_prob is COL-wise prob (elem device prob is 1)
-    if (this->rw_rng_.sampleUniform() < reset_prob) {
-      W = getDeviceWeights(from_device_idx);
-      this->rpu_device_vec_[from_device_idx]->resetCols(W, i_col, n_vec, 1, this->rw_rng_);
+    if (this->rw_rng_.sampleUniform() < reset_prob && par.transfer_columns) {
+      // potentially reset here (because of possible same device to-from):
+      // NOTE that with_reset_prob is COL-wise prob (elem device prob is 1)
+      T **W_from = getDeviceWeights(from_device_idx);
+      this->rpu_device_vec_[from_device_idx]->resetCols(W_from, i_slice, n_vec, 1, this->rw_rng_);
     }
 
     // update according to device
-    W = getDeviceWeights(to_device_idx);
-
-    transfer_pwu_->updateVectorWithDevice(
-        W, x, 1, &transfer_tmp_[0], 1,
-        -fabs(lr), // need to be negative...
-        n_vec, &*this->rpu_device_vec_[to_device_idx]);
+    writeVector(to_device_idx, v, transfer_tmp_.data(), lr, n_vec);
   }
 }
 
 template <typename T>
 void TransferRPUDevice<T>::transfer(int to_device_idx, int from_device_idx, T current_lr) {
-  int i_col = current_col_indices_[from_device_idx];
+
+  int i_slice = current_slice_indices_[from_device_idx];
   const auto &par = getPar();
-  if (par.random_column) {
-    i_col = MAX(MIN(floor(this->rw_rng_.sampleUniform() * this->x_size_), this->x_size_ - 1), 0);
+
+  int in_size = par.getInSize();
+
+  if (par.random_selection) {
+    i_slice = MAX(MIN(floor(this->rw_rng_.sampleUniform() * in_size), in_size - 1), 0);
   }
 
-  // transfer_vecs_ is always x_size-major (that is trans==false)
-  T *tvec = &transfer_vecs_[0] + i_col * this->x_size_;
-  int n_rest = this->x_size_ - i_col; // actually always x_size
+  // transfer_vecs_ is always in_size-major (that is trans==false)
+  T *tvec = &transfer_vecs_[0] + i_slice * in_size;
+  int n_rest = in_size - i_slice;
 
   T lr = par.getTransferLR(to_device_idx, from_device_idx, current_lr);
 
-  int n_transfer = MIN(par.n_cols_per_transfer, this->x_size_);
+  int n_transfer = MIN(par.n_reads_per_transfer, in_size);
 
   if (n_rest < n_transfer) {
     // rest
 
-    forwardUpdate(
-        to_device_idx, from_device_idx, lr, tvec, n_rest, false, par.with_reset_prob, i_col);
+    readAndUpdate(to_device_idx, from_device_idx, lr, tvec, n_rest, par.with_reset_prob, i_slice);
     // from beginning
-    forwardUpdate(
-        to_device_idx, from_device_idx, lr, &transfer_vecs_[0], n_transfer - n_rest, false,
+    readAndUpdate(
+        to_device_idx, from_device_idx, lr, &transfer_vecs_[0], n_transfer - n_rest,
         par.with_reset_prob, 0);
 
   } else {
-    forwardUpdate(
-        to_device_idx, from_device_idx, lr, tvec, n_transfer, false, par.with_reset_prob, i_col);
+    readAndUpdate(
+        to_device_idx, from_device_idx, lr, tvec, n_transfer, par.with_reset_prob, i_slice);
   }
 
-  current_col_indices_[from_device_idx] = (i_col + n_transfer) % this->x_size_;
+  current_slice_indices_[from_device_idx] = (i_slice + n_transfer) % in_size;
 }
 
 /*********************************************************************************/
@@ -434,6 +505,13 @@ void TransferRPUDevice<T>::doSparseUpdate(
   this->rpu_device_vec_[0]->doSparseUpdate(
       this->weights_vec_[0], i, x_signed_indices, x_count, d_sign, rng);
 
+  // we do reduce to weights in the finishUpdateCycle, because transfer is done there, too.
+}
+
+template <typename T>
+void TransferRPUDevice<T>::doDenseUpdate(T **weights, int *coincidences, RNG<T> *rng) {
+
+  this->rpu_device_vec_[0]->doDenseUpdate(this->weights_vec_[0], coincidences, rng);
   // we do reduce to weights in the finishUpdateCycle, because transfer is done there, too.
 }
 

--- a/src/rpucuda/rpu_transfer_device.h
+++ b/src/rpucuda/rpu_transfer_device.h
@@ -51,6 +51,10 @@ template <typename T> class TransferRPUDevice;
    is same for all the tranfers. However, it can be set individually
    by using the vector transfer_lr_vec (with size n_devices-1)
 
+   fast_lr: if defined, it will fix and set the first LR
+   (onto the A matrix). Otherwise the SGD learing
+   rate will be taken
+
  */
 
 template <typename T> struct TransferRPUDeviceMetaParameter : VectorRPUDeviceMetaParameter<T> {
@@ -58,14 +62,17 @@ template <typename T> struct TransferRPUDeviceMetaParameter : VectorRPUDeviceMet
   T gamma = (T)0.0; // weightening factor. [gamma vec optionally inherited from vector]
   T transfer_every = (T)1.0;
   bool units_in_mbatch = false;
-  int n_cols_per_transfer = 1;
+  int n_reads_per_transfer = 1;
   T with_reset_prob = (T)0.0;
   bool no_self_transfer = true;
-  bool random_column = false;
-
+  bool random_selection = false;
+  T fast_lr = 0.0;
   T transfer_lr = (T)1.0;
   std::vector<T> transfer_lr_vec;
   bool scale_transfer_lr = true;
+  bool transfer_columns = true; // or rows
+  int _in_size = 0;
+  int _out_size = 0;
 
   std::vector<T> transfer_every_vec;
 
@@ -85,6 +92,9 @@ template <typename T> struct TransferRPUDeviceMetaParameter : VectorRPUDeviceMet
   void initialize() override{/* do nothing */};
 
   inline bool fullyHidden() const { return (!gamma && this->gamma_vec.back() == 1.0); };
+
+  inline int getInSize() const { return _in_size; };
+  inline int getOutSize() const { return _out_size; };
 
   std::string getName() const override {
     std::ostringstream ss;
@@ -141,8 +151,9 @@ public:
     swap(a.transfer_fb_pass_, b.transfer_fb_pass_);
     swap(a.transfer_vecs_, b.transfer_vecs_);
     swap(a.transfer_every_, b.transfer_every_);
-    swap(a.current_col_indices_, b.current_col_indices_);
+    swap(a.current_slice_indices_, b.current_slice_indices_);
     swap(a.fully_hidden_, b.fully_hidden_);
+    swap(a.last_weight_, b.last_weight_);
   }
 
   TransferRPUDeviceMetaParameter<T> &getPar() const override {
@@ -165,24 +176,29 @@ public:
 
   void finishUpdateCycle(
       T **weights, const PulsedUpdateMetaParameter<T> &up, T current_lr, int m_batch_info) override;
+  T getPulseCountLearningRate(T learning_rate) override;
 
   virtual int getTransferEvery(int from_device_idx, int m_batch) const;
   virtual void setTransferVecs(const T *transfer_vecs = nullptr);
   virtual void transfer(int to_device_idx, int from_device_idx, T current_lr);
-  virtual void forwardUpdate(
+  virtual void readAndUpdate(
       int to_device_idx,
       int from_device_idx,
       const T lr,
       const T *x_input,
       const int n_vec,
-      const bool trans,
       const T reset_prob,
       const int i_col);
   virtual const T *getTransferVecs() const { return &transfer_vecs_[0]; };
+  virtual void writeVector(
+      int device_idx, const T *in_vec, const T *out_vec, const T lr, const int m_batch_info);
+  virtual void readVector(int device_idx, const T *in_vec, T *out_vec, T alpha);
 
   void doSparseUpdate(
       T **weights, int i, const int *x_signed_indices, int x_count, int d_sign, RNG<T> *rng)
       override;
+
+  void doDenseUpdate(T **weights, int *coincidences, RNG<T> *rng) override;
 
 protected:
   void populate(const TransferRPUDeviceMetaParameter<T> &par, RealWorldRNG<T> *rng);
@@ -194,12 +210,12 @@ protected:
   std::unique_ptr<PulsedRPUWeightUpdater<T>> transfer_pwu_ = nullptr;
   std::vector<T> transfer_vecs_;
   std::vector<T> transfer_every_;
-  std::vector<int> current_col_indices_;
+  std::vector<int> current_slice_indices_;
+  bool fully_hidden_ = false;
+  T **last_weight_ = nullptr;
 
   // no need to swap/copy.
-  T **last_weight_ = nullptr;
   std::vector<T> transfer_tmp_;
-  bool fully_hidden_ = false;
 };
 
 } // namespace RPU

--- a/src/rpucuda/rpu_vector_device.cpp
+++ b/src/rpucuda/rpu_vector_device.cpp
@@ -452,6 +452,20 @@ void VectorRPUDevice<T>::doSparseUpdate(
 }
 
 template <typename T>
+void VectorRPUDevice<T>::doDenseUpdate(T **weights, int *coincidences, RNG<T> *rng) {
+  if (getPar().singleDeviceUpdate()) {
+    rpu_device_vec_[current_device_idx_]->doDenseUpdate(
+        weights_vec_[current_device_idx_], coincidences, rng);
+  } else {
+
+    for (size_t k = 0; k < rpu_device_vec_.size(); k++) {
+      rpu_device_vec_[k]->doDenseUpdate(weights_vec_[k], coincidences, rng);
+    }
+  }
+  this->reduceToWeights(weights);
+}
+
+template <typename T>
 void VectorRPUDevice<T>::finishUpdateCycle(
     T **weights, const PulsedUpdateMetaParameter<T> &up, T current_lr, int m_batch_info) {
 

--- a/src/rpucuda/rpu_vector_device.h
+++ b/src/rpucuda/rpu_vector_device.h
@@ -199,6 +199,7 @@ public:
   void doSparseUpdate(
       T **weights, int i, const int *x_signed_indices, int x_count, int d_sign, RNG<T> *rng)
       override;
+  void doDenseUpdate(T **weights, int *coincidences, RNG<T> *rng) override;
 
 protected:
   void populate(const VectorRPUDeviceMetaParameter<T> &par, RealWorldRNG<T> *rng);

--- a/src/rpucuda/rpu_weight_updater.h
+++ b/src/rpucuda/rpu_weight_updater.h
@@ -94,6 +94,7 @@ public:
       uint32_t *d_counts);
 
   void setUpPar(const PulsedUpdateMetaParameter<T> &up);
+  inline const PulsedUpdateMetaParameter<T> &getUpPar() const { return up_; };
 
 private:
   void freeContainers();

--- a/src/rpucuda/weight_modifier.cpp
+++ b/src/rpucuda/weight_modifier.cpp
@@ -126,6 +126,7 @@ void WeightModifier<T>::apply(
         new_weights[i] += amax * sig * rw_rng_.sampleGauss();
       }
     }
+
     break;
   }
 

--- a/tests/helpers/testcases.py
+++ b/tests/helpers/testcases.py
@@ -23,17 +23,17 @@ from aihwkit.simulator.rpu_base import cuda
 class AihwkitTestCase(TestCase):
     """Test case that contains common asserts and functions for aihwkit."""
 
-    def assertTensorAlmostEqual(self, tensor_a, tensor_b):
+    def assertTensorAlmostEqual(self, tensor_a, tensor_b, decimal=6):
         """Assert that two tensors are almost equal."""
         # pylint: disable=invalid-name
         array_a = tensor_a.detach().cpu().numpy()
         array_b = tensor_b.detach().cpu().numpy()
-        assert_array_almost_equal(array_a, array_b)
+        assert_array_almost_equal(array_a, array_b, decimal=decimal)
 
-    def assertNotAlmostEqualTensor(self, tensor_a, tensor_b):
+    def assertNotAlmostEqualTensor(self, tensor_a, tensor_b, decimal=6):
         """Assert that two tensors are not equal."""
         # pylint: disable=invalid-name
-        assert_raises(AssertionError, self.assertTensorAlmostEqual, tensor_a, tensor_b)
+        assert_raises(AssertionError, self.assertTensorAlmostEqual, tensor_a, tensor_b, decimal)
 
 
 class ParametrizedTestCase(AihwkitTestCase):


### PR DESCRIPTION
## Related issues

closes #309,  closes #308, closes #310 

## Description

Update of the C++ backend enabling more analog non-idealities and new features in the `TransferCompound` 
Note that some parameter names have changed for `TransferCompound` (those referring to `columns` due to now supporting also rows) 

## Details
New features include: 
* Transposed read for transfer device (`transfer_columns`)
* PCM weight noise 
* IR drop along columns 
* enable dense updates with more devices
