### PR TITLE
Fixed hierachical setting of hidden weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Map location keyword for load / save observed. (\#293)
 * Fixed issue with CUDA buffer allocation when batch size changed. (\#294)
 * Fixed missing load statedict for AnalogSequential. (\#295) 
+* Fixed issue with hierachical hidden parameter settings. (\#313)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Map location keyword for load / save observed. (\#293)
 * Fixed issue with CUDA buffer allocation when batch size changed. (\#294)
 * Fixed missing load statedict for AnalogSequential. (\#295) 
-* Fixed issue with hierachical hidden parameter settings. (\#313)
+* Fixed issue with hierarchical hidden parameter settings. (\#313)
 
 ### Changed
 

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -661,7 +661,7 @@ class BaseTile(Generic[RPUConfigGeneric]):
         Usually this is ignored and fixed to 0 as only one device is
         present per cross-point. Other devices, might not allow
         explicit setting as it would interfere with the implemented
-        learning However rule. However, some tiles have internally
+        learning rule. However, some tiles have internally
         multiple devices per cross-point (eg. unit cell) that can be
         chosen depending on the update policy.
 

--- a/src/rpucuda/cuda/rpucuda_pulsed.cu
+++ b/src/rpucuda/cuda/rpucuda_pulsed.cu
@@ -413,11 +413,12 @@ template <typename T> void RPUCudaPulsed<T>::setDeviceParameter(const std::vecto
 
   // Note: for now setting the device just keeps the old meta parameter.
   // however weight_granularity is at least estimated.
-  rpu_device_->setDeviceParameter(data_ptrs);
-
+  this->copyWeightsToHost();
+  rpu_device_->setDeviceParameter(this->getWeightsPtr(), data_ptrs);
   rpucuda_device_->populateFrom(*rpu_device_);
 
-  this->setWeights(this->copyWeightsToHost()[0]); // might re-copy device. Ignore
+  // set device weights which might have been updated because of the hidden parameters
+  RPUCudaSimple<T>::setWeights(this->getWeightsPtr()[0]);
 };
 
 template <typename T> int RPUCudaPulsed<T>::getHiddenUpdateIdx() const {

--- a/src/rpucuda/rpu_linearstep_device.h
+++ b/src/rpucuda/rpu_linearstep_device.h
@@ -36,7 +36,7 @@ BUILD_PULSED_DEVICE_META_PARAMETER(
     ,
     /*print body*/
 
-    ss << "\t ls_mult_noise:\t\t\t" << std::boolalpha << ls_mult_noise << std::endl;
+    ss << "\t ls_mult_noise:\t\t" << std::boolalpha << ls_mult_noise << std::endl;
     ss << "\t ls_mean_bound_reference:\t" << std::boolalpha << ls_mean_bound_reference << std::endl;
     ss << "\t ls_decrease_up   [rel. decrease at max]: " << ls_decrease_up
        << " (dtod=" << ls_decrease_up_dtod << ")" << std::endl;
@@ -92,7 +92,7 @@ struct SoftBoundsRPUDeviceMetaParameter : LinearStepRPUDeviceMetaParameter<T> {
     PulsedRPUDeviceMetaParameter<T>::printToStream(ss);
     // ss << "   ";
     // ss << getName() << " parameter:" << std::endl;
-    ss << "\t ls_mult_noise:\t\t\t" << std::boolalpha << this->ls_mult_noise << std::endl;
+    ss << "\t ls_mult_noise:\t\t" << std::boolalpha << this->ls_mult_noise << std::endl;
   };
 };
 

--- a/src/rpucuda/rpu_mixedprec_device_base.cpp
+++ b/src/rpucuda/rpu_mixedprec_device_base.cpp
@@ -387,10 +387,11 @@ template <typename T> void MixedPrecRPUDeviceBase<T>::setHiddenWeights(const std
 }
 
 template <typename T>
-void MixedPrecRPUDeviceBase<T>::setDeviceParameter(const std::vector<T *> &data_ptrs) {
+void MixedPrecRPUDeviceBase<T>::setDeviceParameter(
+    T **out_weights, const std::vector<T *> &data_ptrs) {
 
   CHECK_RPU_DEVICE_INIT;
-  rpu_device_->setDeviceParameter(data_ptrs);
+  rpu_device_->setDeviceParameter(out_weights, data_ptrs);
 };
 
 template <typename T> void MixedPrecRPUDeviceBase<T>::printDP(int x_count, int d_count) const {

--- a/src/rpucuda/rpu_mixedprec_device_base.h
+++ b/src/rpucuda/rpu_mixedprec_device_base.h
@@ -116,7 +116,7 @@ public:
   void printDP(int x_count, int d_count) const override;
   void getDPNames(std::vector<std::string> &names) const override;
   void getDeviceParameter(std::vector<T *> &data_ptrs) const override;
-  void setDeviceParameter(const std::vector<T *> &data_ptrs) override;
+  void setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) override;
   int getHiddenWeightsCount() const override;
   void setHiddenWeights(const std::vector<T> &data) override;
 

--- a/src/rpucuda/rpu_pulsed.cpp
+++ b/src/rpucuda/rpu_pulsed.cpp
@@ -374,8 +374,7 @@ template <typename T> void RPUPulsed<T>::getDeviceParameter(std::vector<T *> &da
 template <typename T> void RPUPulsed<T>::setDeviceParameter(const std::vector<T *> &data_ptrs) {
   // note that memory (x_sz*d_sz per ptr) assumed to be initialized from outside !!
   CHECK_RPU_DEVICE_INIT;
-  rpu_device_->setDeviceParameter(data_ptrs);
-  rpu_device_->onSetWeights(this->getWeightsPtr());
+  rpu_device_->setDeviceParameter(this->getWeightsPtr(), data_ptrs);
 };
 
 template <typename T> void RPUPulsed<T>::setHiddenUpdateIdx(int idx) {

--- a/src/rpucuda/rpu_pulsed_device.cpp
+++ b/src/rpucuda/rpu_pulsed_device.cpp
@@ -294,7 +294,7 @@ void PulsedRPUDevice<T>::getDeviceParameter(std::vector<T *> &data_ptrs) const {
 };
 
 template <typename T>
-void PulsedRPUDevice<T>::setDeviceParameter(const std::vector<T *> &data_ptrs) {
+void PulsedRPUDevice<T>::setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) {
 
   std::vector<std::string> names;
   getDPNames(names);
@@ -348,6 +348,9 @@ void PulsedRPUDevice<T>::setDeviceParameter(const std::vector<T *> &data_ptrs) {
     getPar().dw_min = dw_min; //!! update par. Should be possible since unique
     this->setWeightGranularity(getPar().calcWeightGranularity());
   }
+
+  // update the weights according to the bounds
+  this->onSetWeights(out_weights);
 };
 
 /********************************************************************************/

--- a/src/rpucuda/rpu_pulsed_device.h
+++ b/src/rpucuda/rpu_pulsed_device.h
@@ -224,7 +224,7 @@ public:
 
   void getDPNames(std::vector<std::string> &names) const override;
   void getDeviceParameter(std::vector<T *> &data_ptrs) const override;
-  void setDeviceParameter(const std::vector<T *> &data_ptrs) override;
+  void setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) override;
   void printDP(int x_count, int d_count) const override;
 
   inline T **getPersistentWeights() const { return w_persistent_; };
@@ -372,12 +372,13 @@ public:                                                                         
     {DP2V_BODY};                                                                                   \
   };                                                                                               \
                                                                                                    \
-  void setDeviceParameter(const std::vector<T *> &data_ptrs) override {                            \
-    PulsedRPUDevice<T>::setDeviceParameter(data_ptrs);                                             \
+  void setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) override {           \
+    PulsedRPUDevice<T>::setDeviceParameter(out_weights, data_ptrs);                                \
                                                                                                    \
     std::vector<std::string> names;                                                                \
     PulsedRPUDevice<T>::getDPNames(names);                                                         \
     {V2DP_BODY};                                                                                   \
+    this->onSetWeights(out_weights);                                                               \
   }
 
 #define BUILD_PULSED_DEVICE_META_PARAMETER(                                                        \

--- a/src/rpucuda/rpu_simple_device.h
+++ b/src/rpucuda/rpu_simple_device.h
@@ -119,7 +119,7 @@ public:
   };
   virtual void getDPNames(std::vector<std::string> &names) const = 0;
   virtual void getDeviceParameter(std::vector<T *> &data_ptrs) const = 0;
-  virtual void setDeviceParameter(const std::vector<T *> &data_ptrs) = 0;
+  virtual void setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) = 0;
   virtual int getHiddenWeightsCount() const = 0;
   virtual void setHiddenWeights(const std::vector<T> &data) = 0;
   virtual int getHiddenUpdateIdx() const { return 0; };
@@ -205,7 +205,7 @@ public:
 
   void getDPNames(std::vector<std::string> &names) const override { names.clear(); };
   void getDeviceParameter(std::vector<T *> &data_ptrs) const override{};
-  void setDeviceParameter(const std::vector<T *> &data_ptrs) override{};
+  void setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) override{};
   int getHiddenWeightsCount() const override { return 0; };
   void setHiddenWeights(const std::vector<T> &data) override{};
   void printDP(int x_count, int d_count) const override{};

--- a/src/rpucuda/rpu_transfer_device.cpp
+++ b/src/rpucuda/rpu_transfer_device.cpp
@@ -632,8 +632,14 @@ void TransferRPUDevice<T>::resetCols(
 #undef LOOP_WITH_HIDDEN
 
 template <typename T>
-void TransferRPUDevice<T>::setDeviceParameter(const std::vector<T *> &data_ptrs) {
-  VectorRPUDevice<T>::setDeviceParameter(data_ptrs);
+void TransferRPUDevice<T>::setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) {
+  VectorRPUDevice<T>::setDeviceParameter(out_weights, data_ptrs);
+
+  if (fully_hidden_) {
+    // weight might have changed because of hidden weight change
+    RPU::math::copy<T>(
+        this->size_, this->weights_vec_[this->n_devices_ - 1][0], 1, out_weights[0], 1);
+  }
 }
 
 template class TransferRPUDevice<float>;

--- a/src/rpucuda/rpu_transfer_device.h
+++ b/src/rpucuda/rpu_transfer_device.h
@@ -171,7 +171,7 @@ public:
   void
   resetCols(T **weights, int start_col, int n_cols, T reset_prob, RealWorldRNG<T> &rng) override;
 
-  void setDeviceParameter(const std::vector<T *> &data_ptrs) override;
+  void setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) override;
   void setHiddenUpdateIdx(int idx) override{};
 
   void finishUpdateCycle(

--- a/src/rpucuda/rpu_vector_device.h
+++ b/src/rpucuda/rpu_vector_device.h
@@ -156,7 +156,7 @@ public:
 
   void getDPNames(std::vector<std::string> &names) const override;
   void getDeviceParameter(std::vector<T *> &data_ptrs) const override;
-  void setDeviceParameter(const std::vector<T *> &data_ptrs) override;
+  void setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) override;
   int getHiddenWeightsCount() const override;
   void setHiddenWeights(const std::vector<T> &data) override;
   int getHiddenUpdateIdx() const override;

--- a/tests/test_specific_tiles.py
+++ b/tests/test_specific_tiles.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Some more tests for specific tiles."""
+
+from torch import ones
+
+from aihwkit.simulator.configs.devices import (
+    TransferCompound,
+    ReferenceUnitCell,
+    SoftBoundsDevice
+)
+from aihwkit.simulator.configs.configs import UnitCellRPUConfig
+
+from .helpers.decorators import parametrize_over_layers
+from .helpers.layers import Linear, LinearCuda
+from .helpers.testcases import ParametrizedTestCase
+from .helpers.tiles import FloatingPoint
+
+
+@parametrize_over_layers(
+    layers=[Linear, LinearCuda],
+    tiles=[FloatingPoint],
+    biases=[True, False],
+    digital_biases=[True, False]
+)
+class TransferCompoundTest(ParametrizedTestCase):
+    """Tests for transfer compound."""
+
+    @staticmethod
+    def get_transfer_compound(gamma):
+        """Get a Tiki-taka compound with reference cell """
+        def custom_device():
+            """Custom device """
+            return SoftBoundsDevice(w_max_dtod=0.0, w_min_dtod=0.0, w_max=1.0, w_min=-1.0)
+
+        rpu_config = UnitCellRPUConfig(
+            device=TransferCompound(
+
+                # Devices that compose the Tiki-taka compound.
+                unit_cell_devices=[
+                    ReferenceUnitCell([custom_device(), custom_device()]),  # fast "A" matrix
+                    ReferenceUnitCell([custom_device(), custom_device()])   # slow "C" matrix
+                ],
+                gamma=gamma,
+            )
+        )
+        return rpu_config
+
+    def test_hidden_parameter_setting(self):
+        """Test hidden parameter set."""
+        # pylint: disable=invalid-name
+
+        for gamma in [0.0, 0.1]:
+            model = self.get_layer(rpu_config=self.get_transfer_compound(gamma))
+
+            weight, bias = model.get_weights()
+            model.set_weights(weight * 0.0, bias * 0.0 if bias is not None else None)
+
+            params = model.analog_tile.get_hidden_parameters()
+            shape = params['hidden_weights_0_0'].shape
+
+            # just dummy settings
+            a, b, c, d = 0.47, 0.21, 0.64, 0.12
+            params['hidden_weights_0_0'] = a*ones(*shape)  # A
+            params['hidden_weights_1_0'] = b*ones(*shape)  # A ref
+            params['hidden_weights_0_1'] = c*ones(*shape)  # C
+            params['hidden_weights_1_1'] = d*ones(*shape)  # C_ref
+
+            model.analog_tile.set_hidden_parameters(params)
+
+            print(model.analog_tile.tile)
+            weight, bias = model.get_weights()
+
+            # should be
+            if self.digital_bias:
+                self.assertEqual(bias[0], 0.0)
+            if self.bias and not self.digital_bias:
+                self.assertEqual(bias[0], gamma*(a - b) + c - d)
+
+            self.assertEqual(weight[0][0], gamma*(a - b) + c - d)


### PR DESCRIPTION
## Related issues

closes #303,  Hierarchical hidden parameter settings would not update the weight properly.  
related to #302 

## Description

The hidden weights now update the weights. Note that for multiple hidden weights hierachy the lowest will determine the upper (higher) levels.  

## Details

Now the explicit setting of the hidden weights is possible (see below). 

Note, however, that in case of `gamma=0`, the reading of the slow matrix might be impacted (shows zeros when get_hidden_parameters). In this case, the matrix needs to be read with `getWeights()`.    

Note also that the setting of the weights with lowest level (e.g. `hidden_weights_0_1`) will determine (and overwrite) the weight on the next level (e.g. `hidden_weight_1`).


Here an example:

```python


from torch import ones
from aihwkit.nn import AnalogLinear
from aihwkit.simulator.configs import UnitCellRPUConfig
from aihwkit.simulator.configs.devices import (
    TransferCompound,
    ReferenceUnitCell,
    SoftBoundsDevice)


# The Tiki-taka learning rule can be implemented using the transfer device.
def SBdevice():
    """Custom device """
    return SoftBoundsDevice(w_max_dtod=0.0, w_min_dtod=0.0, w_max=1.0, w_min=-1.0)

# arbitrary
gamma = 0.2

rpu_config = UnitCellRPUConfig(
    device=TransferCompound(

        # Devices that compose the Tiki-taka compound.
        unit_cell_devices=[
            ReferenceUnitCell([SBdevice(), SBdevice()]),  # fast "A" matrix
            ReferenceUnitCell([SBdevice(), SBdevice()])   # slow "C" matrix
        ],
        gamma=gamma,
    )
)

# print the config
print(rpu_config)

# construct the model
in_features = 4
out_features = 2
model = AnalogLinear(in_features, out_features, bias=True, rpu_config=rpu_config)

# set the reference devices to some values
params = model.analog_tile.get_hidden_parameters()
shape = params['hidden_weights_0_0'].shape

# just dummy settings
a, b, c, d = 0.4, 0.2, 0.6, 0.1
params['hidden_weights_0_0'] = a*ones(*shape)  # A
params['hidden_weights_1_0'] = b*ones(*shape)  # A ref
params['hidden_weights_0_1'] = c*ones(*shape)  # C
params['hidden_weights_1_1'] = d*ones(*shape)  # C_ref

model.analog_tile.set_hidden_parameters(params)

weight, bias = model.get_weights()

# should be true for all weights
print(weight == gamma*(a - b) + c - d)

```
 

<!-- A more elaborate description of the changes, if needed. -->
