### PR TITLE
Tiki-taka version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,16 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 * Load model state dict into a new model with modified `RPUConfig`. (\#276)
 * Visualization for noise models for analog inference hardware simulation. (\#278)
-* State indipendent inference noise model. (\# 284)
+* State independent inference noise model. (\# 284)
 * Transfer LR parameter for ``MixedPrecisionCompound``. (\#283)
 * The bias term can now be handled either by the analog or digital domain by controlling
   the `digital_bias` layer parameter. (\#307)
 * PCM short-term weight noise. (\#312)
 * IR-drop simulation across columns during analog mat-vec. (\#312)
 * Transposed-read for ``TransferCompound``. (\#312)
+* ``BufferedTranferCompound`` and TTv2 presets. (\#???)
+* Stochastic rounding for ``MixedPrecisionCompound``. (\#???)
+
 
 ### Fixed
 
@@ -43,6 +46,8 @@ The format is based on [Keep a Changelog], and this project adheres to
   changed. (\#312)
 * New fast learning rate parameter for TransferCompound, SGD learning
   rate then is applied on the slow matrix (\#312). 
+* The ``fixed_value`` of ``WeightClipParameter`` is now  applied for all clipping
+  types if set larger than zero. (\#???)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 * PCM short-term weight noise. (\#312)
 * IR-drop simulation across columns during analog mat-vec. (\#312)
 * Transposed-read for ``TransferCompound``. (\#312)
-* ``BufferedTranferCompound`` and TTv2 presets. (\#???)
-* Stochastic rounding for ``MixedPrecisionCompound``. (\#???)
+* ``BufferedTranferCompound`` and TTv2 presets. (\#318)
+* Stochastic rounding for ``MixedPrecisionCompound``. (\#318)
 
 
 ### Fixed
@@ -47,7 +47,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * New fast learning rate parameter for TransferCompound, SGD learning
   rate then is applied on the slow matrix (\#312). 
 * The ``fixed_value`` of ``WeightClipParameter`` is now  applied for all clipping
-  types if set larger than zero. (\#???)
+  types if set larger than zero. (\#318)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ functionalities such as:
   based on models in the literature, along with configuration that specifies a particular device and optimizer choice.
 * A module for executing high-level use cases ("experiments"), such as neural
   network training with minimal code overhead.
-* A utility to automatically convert a downloaded model (e.g., pre-trained) to its equivalent Analog 
+* A utility to automatically convert a downloaded model (e.g., pre-trained) to its equivalent Analog
   model by replacing all linear/conv layers to Analog layers (e.g., for convenient hardware-aware training).
 * Integration with the [AIHW Composer] platform, a no-code web experience, that allows executing
   experiments in the cloud.

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -562,8 +562,15 @@ class WeightClipParameter(_PrintableMixin):
 
     bindings_class: ClassVar[Type] = tiles.WeightClipParameter
 
-    fixed_value: float = 1.0
-    """Clipping value in case of ``FixedValue`` type."""
+    fixed_value: float = -1.0
+    """Clipping value in case of ``FixedValue`` type.
+
+    Caution:
+
+        If ``fixed_value > 0`` it will be also applied during other
+        clipping types.
+
+    """
 
     sigma: float = 2.5
     """Sigma value for clipping for the ``LayerGaussian`` type."""

--- a/src/aihwkit/simulator/presets/__init__.py
+++ b/src/aihwkit/simulator/presets/__init__.py
@@ -25,6 +25,9 @@ from .configs import (
     # Tiki-taka configs.
     TikiTakaReRamESPreset, TikiTakaReRamSBPreset, TikiTakaCapacitorPreset,
     TikiTakaEcRamPreset, TikiTakaEcRamMOPreset, TikiTakaIdealizedPreset,
+    # TTv2 configs.
+    TTv2ReRamESPreset, TTv2ReRamSBPreset, TTv2CapacitorPreset,
+    TTv2EcRamPreset, TTv2EcRamMOPreset, TTv2IdealizedPreset,
     # MixedPrecision configs.
     MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset, MixedPrecisionCapacitorPreset,
     MixedPrecisionEcRamPreset, MixedPrecisionEcRamMOPreset, MixedPrecisionIdealizedPreset,

--- a/src/aihwkit/simulator/presets/configs.py
+++ b/src/aihwkit/simulator/presets/configs.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=too-many-lines
+
 """RPU configurations presets for resistive processing units."""
 
 from dataclasses import dataclass, field
@@ -19,7 +21,8 @@ from aihwkit.simulator.configs.configs import (
 )
 from aihwkit.simulator.configs.devices import (
     PulsedDevice, TransferCompound, UnitCell, VectorUnitCell,
-    DigitalRankUpdateCell, MixedPrecisionCompound
+    DigitalRankUpdateCell, MixedPrecisionCompound,
+    BufferedTransferCompound
 )
 from aihwkit.simulator.configs.utils import (
     IOParameters, UpdateParameters, VectorUnitCellUpdatePolicy
@@ -685,8 +688,178 @@ class TikiTakaIdealizedPreset(UnitCellRPUConfig):
     backward: IOParameters = field(default_factory=PresetIOParameters)
     update: UpdateParameters = field(default_factory=PresetUpdateParameters)
 
+# TTv2 configs.
+
+
+@dataclass
+class TTv2ReRamESPreset(UnitCellRPUConfig):
+    """Configuration using TTv2 with
+    :class:`~aihwkit.simulator.presets.devices.ReRamESPresetDevice`.
+
+    See :class:`~aihwkit.simulator.configs.devices.BufferedTransferCompound`
+    for details on TTv2-like optimizers.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: BufferedTransferCompound(
+            unit_cell_devices=[ReRamESPresetDevice(), ReRamESPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class TTv2ReRamSBPreset(UnitCellRPUConfig):
+    """Configuration using TTv2 with
+    :class:`~aihwkit.simulator.presets.devices.ReRamSBPresetDevice`.
+
+    See :class:`~aihwkit.simulator.configs.devices.BufferedTransferCompound`
+    for details on TTv2-like optimizers.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: BufferedTransferCompound(
+            unit_cell_devices=[ReRamSBPresetDevice(), ReRamSBPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class TTv2CapacitorPreset(UnitCellRPUConfig):
+    """Configuration using TTv2 with
+    :class:`~aihwkit.simulator.presets.devices.CapacitorPresetDevice`.
+
+    See :class:`~aihwkit.simulator.configs.devices.BufferedTransferCompound`
+    for details on TTv2-like optimizers.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: BufferedTransferCompound(
+            unit_cell_devices=[CapacitorPresetDevice(), CapacitorPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class TTv2EcRamPreset(UnitCellRPUConfig):
+    """Configuration using TTv2 with
+    :class:`~aihwkit.simulator.presets.devices.EcRamPresetDevice`.
+
+    See :class:`~aihwkit.simulator.configs.devices.BufferedTransferCompound`
+    for details on TTv2-like optimizers.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: BufferedTransferCompound(
+            unit_cell_devices=[EcRamPresetDevice(), EcRamPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class TTv2EcRamMOPreset(UnitCellRPUConfig):
+    """Configuration using TTv2 with
+    :class:`~aihwkit.simulator.presets.devices.EcRamMOPresetDevice`.
+
+    See :class:`~aihwkit.simulator.configs.devices.BufferedTransferCompound`
+    for details on TTv2-like optimizers.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: BufferedTransferCompound(
+            unit_cell_devices=[EcRamMOPresetDevice(), EcRamMOPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
+
+
+@dataclass
+class TTv2IdealizedPreset(UnitCellRPUConfig):
+    """Configuration using TTv2 with
+    :class:`~aihwkit.simulator.presets.devices.IdealizedPresetDevice`.
+
+    See :class:`~aihwkit.simulator.configs.devices.BufferedTransferCompound`
+    for details on TTv2-like optimizers.
+
+    The default peripheral hardware
+    (:class:`~aihwkit.simulator.presets.utils.PresetIOParameters`) and
+    analog update
+    (:class:`~aihwkit.simulator.presets.utils.PresetUpdateParameters`)
+    configuration is used otherwise.
+    """
+
+    device: UnitCell = field(
+        default_factory=lambda: BufferedTransferCompound(
+            unit_cell_devices=[IdealizedPresetDevice(), IdealizedPresetDevice()],
+            transfer_forward=PresetIOParameters(),
+            transfer_update=PresetUpdateParameters(),
+            transfer_every=1.0,
+            units_in_mbatch=True,
+            ))
+    forward: IOParameters = field(default_factory=PresetIOParameters)
+    backward: IOParameters = field(default_factory=PresetIOParameters)
+    update: UpdateParameters = field(default_factory=PresetUpdateParameters)
 
 # Mixed precision presets
+
 
 @dataclass
 class MixedPrecisionReRamESPreset(DigitalRankUpdateRPUConfig):

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base.h
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base.h
@@ -11,6 +11,7 @@
  */
 #pragma once
 #include "rpu.h"
+#include "rpu_buffered_transfer_device.h"
 #include "rpu_constantstep_device.h"
 #include "rpu_expstep_device.h"
 #include "rpu_linearstep_device.h"

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -27,6 +27,7 @@ void declare_rpu_devices(py::module &m) {
   using TransferParam = RPU::TransferRPUDeviceMetaParameter<T>;
   using MixedPrecParam = RPU::MixedPrecRPUDeviceMetaParameter<T>;
   using PowStepParam = RPU::PowStepRPUDeviceMetaParameter<T>;
+  using BufferedTransferParam = RPU::BufferedTransferRPUDeviceMetaParameter<T>;
 
   /*
    * Trampoline classes for allowing inheritance.
@@ -276,6 +277,28 @@ void declare_rpu_devices(py::module &m) {
     }
     T calcWeightGranularity() const override {
       PYBIND11_OVERLOAD(T, PowStepParam, calcWeightGranularity, );
+    }
+  };
+
+  class PyBufferedTransferParam : public BufferedTransferParam {
+  public:
+    std::string getName() const override {
+      PYBIND11_OVERLOAD(std::string, BufferedTransferParam, getName, );
+    }
+    BufferedTransferParam *clone() const override {
+      PYBIND11_OVERLOAD(BufferedTransferParam *, BufferedTransferParam, clone, );
+    }
+    RPU::DeviceUpdateType implements() const override {
+      PYBIND11_OVERLOAD(RPU::DeviceUpdateType, BufferedTransferParam, implements, );
+    }
+    RPU::BufferedTransferRPUDevice<T> *
+    createDevice(int x_size, int d_size, RPU::RealWorldRNG<T> *rng) override {
+      PYBIND11_OVERLOAD(
+          RPU::BufferedTransferRPUDevice<T> *, BufferedTransferParam, createDevice, x_size, d_size,
+          rng);
+    }
+    T calcWeightGranularity() const override {
+      PYBIND11_OVERLOAD(T, BufferedTransferParam, calcWeightGranularity, );
     }
   };
 
@@ -636,6 +659,28 @@ void declare_rpu_devices(py::module &m) {
           })
       .def(
           "calc_weight_granularity", &PowStepParam::calcWeightGranularity,
+          R"pbdoc(
+        Calculates the granularity of the weights (typically ``dw_min``)
+
+        Returns:
+           float: weight granularity
+        )pbdoc");
+
+  py::class_<BufferedTransferParam, PyBufferedTransferParam, TransferParam>(
+      m, "BufferedTransferResistiveDeviceParameter")
+      .def(py::init<>())
+      .def_readwrite("thres_scale", &BufferedTransferParam::thres_scale)
+      .def_readwrite("momentum", &BufferedTransferParam::momentum)
+      .def_readwrite("step", &BufferedTransferParam::step)
+      .def(
+          "__str__",
+          [](BufferedTransferParam &self) {
+            std::stringstream ss;
+            self.printToStream(ss);
+            return ss.str();
+          })
+      .def(
+          "calc_weight_granularity", &BufferedTransferParam::calcWeightGranularity,
           R"pbdoc(
         Calculates the granularity of the weights (typically ``dw_min``)
 

--- a/src/rpucuda/cuda/cuda_util.cu
+++ b/src/rpucuda/cuda/cuda_util.cu
@@ -103,8 +103,9 @@ CublasEnvironment::~CublasEnvironment() {
 CublasEnvironment::CublasEnvironment(int gpu_id) {
 
   DEBUG_OUT("GET BLAS env.");
-  if (gpu_id >= 0)
+  if (gpu_id >= 0) {
     CUDA_CALL(cudaSetDevice(gpu_id));
+  }
 
   // create host
   cublasStatus_t stat = cublasCreate(&handle_);
@@ -289,6 +290,7 @@ void CudaContext::init() {
   } else {
     CUDA_CALL(cudaGetDevice(&gpu_id_));
   }
+  CUDA_CALL(cudaDeviceSynchronize());
   DEBUG_OUT("Create context on GPU " << gpu_id_);
   env_ = new CublasEnvironment(gpu_id_);
   stream_id_ = 0;
@@ -301,6 +303,7 @@ void CudaContext::init() {
 
   prop_ = new cudaDeviceProp();
   CUDA_CALL(cudaGetDeviceProperties(prop_, gpu_id_));
+  CUDA_CALL(cudaDeviceSynchronize());
 }
 
 CudaContext::CudaContext(int gpu_id, bool non_blocking)

--- a/src/rpucuda/cuda/cuda_util.h
+++ b/src/rpucuda/cuda/cuda_util.h
@@ -39,6 +39,7 @@
 #undef CUB_NS_POSTFIX
 #define CUB_NS_PREFIX namespace RPU {
 #define CUB_NS_POSTFIX }
+#define CUB_NS_QUALIFIER ::RPU::cub
 
 #define CUBLAS_CALL(X)                                                                             \
   if (X != CUBLAS_STATUS_SUCCESS) {                                                                \

--- a/src/rpucuda/cuda/noise_manager.h
+++ b/src/rpucuda/cuda/noise_manager.h
@@ -71,11 +71,13 @@ private:
   std::unique_ptr<CudaArray<float>> dev_scale_values_ = nullptr;     // need float here
   std::unique_ptr<CudaArray<float>> dev_ravg_scale_value_ = nullptr; // need float here
   std::unique_ptr<CudaArray<float>> dev_avgmax_value_ = nullptr;     // need float here
+  std::unique_ptr<CudaArray<float>> dev_nzeros_value_ = nullptr;     // need float here
   std::unique_ptr<Maximizer<T>> amaximizer_ = nullptr;
   std::unique_ptr<Maximizer<T>> maximizer_ = nullptr;
 
   NoiseManagementType nm_type_ = NoiseManagementType::None;
   int buffer_m_batch_ = 0;
+  int last_m_batch_ = 0;
   int size_ = 0;
   CudaContext *context_ = nullptr;
   bool const_set_if_ = false;

--- a/src/rpucuda/cuda/rpucuda_buffered_transfer_device.cu
+++ b/src/rpucuda/cuda/rpucuda_buffered_transfer_device.cu
@@ -1,0 +1,254 @@
+/**
+ * (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#include "forward_backward_pass.h"
+#include "rpu_pulsed_meta_parameter.h"
+#include "rpucuda_buffered_transfer_device.h"
+#include <memory>
+
+namespace RPU {
+
+/******************************************************************************************/
+/* BufferedTransferRPUDeviceCuda
+
+   CUDA implementation of BufferedTransferRPUDevice
+
+*/
+
+template <typename T>
+BufferedTransferRPUDeviceCuda<T>::BufferedTransferRPUDeviceCuda(
+    CudaContext *c, const BufferedTransferRPUDevice<T> &rpu_device) {
+  this->context_ = c;
+  populateFrom(rpu_device); // use populate to call parent
+};
+
+// copy construcutor
+template <typename T>
+BufferedTransferRPUDeviceCuda<T>::BufferedTransferRPUDeviceCuda(
+    const BufferedTransferRPUDeviceCuda<T> &other)
+    : TransferRPUDeviceCuda<T>(other) {
+
+  if (other.transfer_buffer_vec_.size()) {
+    int n = other.transfer_buffer_vec_.size();
+    transfer_buffer_vec_.resize(n);
+
+    for (int i = 0; i < n; i++) {
+      if (other.transfer_buffer_vec_[i]) {
+        transfer_buffer_vec_[i] = RPU::make_unique<CudaArray<T>>(*(other.transfer_buffer_vec_[i]));
+      }
+    }
+  }
+  this->context_->synchronize();
+};
+
+// copy assignment
+template <typename T>
+BufferedTransferRPUDeviceCuda<T> &
+BufferedTransferRPUDeviceCuda<T>::operator=(const BufferedTransferRPUDeviceCuda<T> &other) {
+  BufferedTransferRPUDeviceCuda<T> tmp(other);
+  swap(*this, tmp);
+  return *this;
+};
+
+// move constructor
+template <typename T>
+BufferedTransferRPUDeviceCuda<T>::BufferedTransferRPUDeviceCuda(
+    BufferedTransferRPUDeviceCuda<T> &&other) {
+  *this = std::move(other);
+};
+
+// move assignment
+template <typename T>
+BufferedTransferRPUDeviceCuda<T> &
+BufferedTransferRPUDeviceCuda<T>::operator=(BufferedTransferRPUDeviceCuda<T> &&other) {
+  TransferRPUDeviceCuda<T>::operator=(std::move(other));
+
+  transfer_buffer_vec_ = std::move(other.transfer_buffer_vec_);
+  transfer_out_ = std::move(other.transfer_out_);
+
+  return *this;
+};
+
+template <typename T>
+void BufferedTransferRPUDeviceCuda<T>::populateFrom(const AbstractRPUDevice<T> &rpu_device_in) {
+
+  const auto &rpu_device = dynamic_cast<const BufferedTransferRPUDevice<T> &>(rpu_device_in);
+  if (&rpu_device == nullptr) {
+    RPU_FATAL("populateFrom expects BufferedTransferRPUDevice.");
+  }
+
+  TransferRPUDeviceCuda<T>::populateFrom(rpu_device_in);
+
+  std::vector<std::vector<T>> t_vec = rpu_device.getTransferBuffers();
+  if (t_vec.size() != (size_t)(this->n_devices_ - 1)) {
+    RPU_FATAL("Wrong number of buffers to populate from.");
+  }
+
+  transfer_buffer_vec_.resize(this->n_devices_ - 1);
+  const auto &par = getPar();
+
+  for (int k = 0; k < this->n_devices_ - 1; k++) {
+    if (t_vec[k].size() != this->size_) {
+      RPU_FATAL("Wrong number of elements in buffers to populate from.");
+    }
+    transfer_buffer_vec_[k] = RPU::make_unique<CudaArray<T>>(this->context_, this->size_);
+    this->context_->synchronize();
+    if (par.transfer_columns) {
+      // d_major
+      transfer_buffer_vec_[k]->assignTranspose(t_vec[k].data(), this->d_size_, this->x_size_);
+    } else {
+      // x_major in this case. Always out-size-major
+      transfer_buffer_vec_[k]->assign(t_vec[k].data());
+    }
+  }
+  this->context_->synchronize();
+}
+
+/* partially transfer using the given "readout" transfer vectors
+   (with io-managed forward) and buffer the results in
+   digital. Transfer only to next device if threshold is reached. */
+
+template <typename T>
+__global__ void kernelBufferedTransfer(
+    T *transfer_out,
+    T *W_buffer,
+    T *transfer_in,
+    const int size,
+    const T transfer_lr,
+    const T buffer_granularity,
+    const T step,
+    const T sub_momentum,
+    const int desired_BL_in) {
+
+  T desired_BL = (T)desired_BL_in;
+
+  RPU_CUDA_1D_KERNEL_LOOP(idx, size) {
+    T omega = W_buffer[idx];
+    T x = transfer_in[idx];
+    omega += x * transfer_lr;
+
+    transfer_in[idx] = (T)0.0; // reset to zero for next round
+
+    T n_steps = truncf(omega / buffer_granularity);
+    n_steps = MIN(MAX(n_steps, -desired_BL), desired_BL);
+
+    W_buffer[idx] = omega - sub_momentum * n_steps * buffer_granularity;
+    transfer_out[idx] = -n_steps; // negative because of LR has reverse meaning
+  }
+}
+
+template <typename T>
+void BufferedTransferRPUDeviceCuda<T>::readAndUpdate(
+    int to_device_idx,
+    int from_device_idx,
+    int i_slice_start,
+    const T lr,
+    const T *vec,
+    const int n_vec,
+    const PulsedUpdateMetaParameter<T> &up) {
+  if (lr == (T)0.0) {
+    return;
+  }
+
+  if (!transfer_buffer_vec_.size()) {
+    RPU_FATAL("First populate device.");
+  }
+  const auto &par = this->getPar();
+
+  int in_size = par.getInSize();
+  int out_size = par.getOutSize();
+
+  int t_size = n_vec * out_size; // transfer size
+  if ((this->transfer_tmp_ == nullptr) || this->transfer_tmp_->getSize() < t_size) {
+    this->transfer_tmp_ = RPU::make_unique<CudaArray<T>>(this->context_, t_size);
+    this->transfer_tmp_->setConst((T)0.0);
+  }
+  // init second tmp as well, no need to zero this.
+  if ((transfer_out_ == nullptr) || transfer_out_->getSize() < t_size) {
+    transfer_out_ = RPU::make_unique<CudaArray<T>>(this->context_, t_size);
+  }
+
+  // forward/backward with transfer vectors into tmp
+  this->readMatrix(from_device_idx, vec, this->transfer_tmp_->getData(), n_vec, 1.0);
+
+  // 1) add tmp to buffer (tmp is forced to be trans==false)
+  // 2) set tmp to 0
+  // 3) check thres on buffer
+  // 4) write step-wise transfer_out for next device
+  T *B =
+      transfer_buffer_vec_[from_device_idx]->getData() + i_slice_start * out_size; // out-size major
+
+  T weight_granularity = this->rpucuda_device_vec_[to_device_idx]->getWeightGranularity();
+  T thres = par.thres_scale * weight_granularity;
+  T step = par.step;
+
+  int nthreads = this->context_->getNThreads();
+  int nblocks = this->context_->getNBlocks(t_size, nthreads);
+  T sub_momentum = (T)1.0 - MAX(MIN(par.momentum, (T)1.0), (T)0.0);
+
+  kernelBufferedTransfer<T><<<nblocks, nthreads, 0, this->context_->getStream()>>>(
+      transfer_out_->getData(), B, this->transfer_tmp_->getData(), t_size, fabs(lr), thres, step,
+      sub_momentum, up.desired_BL);
+
+  // in reality one might want to check whether some updates are
+  // actually made and don't do anything if not. However, for that
+  // one would need to copy the sum of transfer_out_ to CPU which
+  // would need to synchronize the cuda streams and thus would not
+  // have any benefits. Thus we just start the update in any case,
+  // even if transfer_out_ turns out to be all zero.
+
+  // update according to device
+  this->writeMatrix(
+      to_device_idx, vec, transfer_out_->getDataConst(), n_vec, fabs(step * weight_granularity),
+      up);
+}
+
+template <typename T> std::vector<T> BufferedTransferRPUDeviceCuda<T>::getHiddenWeights() const {
+  std::vector<T> data;
+  if (!this->n_devices_ || !transfer_buffer_vec_.size()) {
+    // not populated?
+    return data;
+  }
+
+  data = TransferRPUDeviceCuda<T>::getHiddenWeights();
+
+  int offset = data.size();
+  data.resize(offset + (this->n_devices_ - 1) * this->size_);
+  bool transpose = this->getPar().transfer_columns;
+
+  for (int k = 0; k < this->n_devices_ - 1; k++) {
+    std::vector<T> w_vec(this->size_);
+
+    transfer_buffer_vec_[k]->copyTo(w_vec.data());
+
+    if (transpose) {
+      for (int i = 0; i < this->size_; i++) {
+        // transpose d_size maj -> x_size maj
+        data[offset + i] = w_vec[TRANSPOSE_X2D(i, this->x_size_, this->d_size_)];
+      }
+    } else {
+      // already x-major
+      for (int i = 0; i < this->size_; i++) {
+        data[offset + i] = w_vec[i];
+      }
+    }
+    offset += this->size_;
+  }
+
+  return data;
+}
+
+template class BufferedTransferRPUDeviceCuda<float>;
+#ifdef RPU_USE_DOUBLE
+template class BufferedTransferRPUDeviceCuda<double>;
+#endif
+} // namespace RPU

--- a/src/rpucuda/cuda/rpucuda_buffered_transfer_device.h
+++ b/src/rpucuda/cuda/rpucuda_buffered_transfer_device.h
@@ -1,0 +1,68 @@
+/**
+ * (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#pragma once
+
+#include "io_manager.h"
+#include "pulsed_weight_updater.h"
+#include "rpu_buffered_transfer_device.h"
+#include "rpucuda_transfer_device.h"
+
+namespace RPU {
+
+template <typename T> class BufferedTransferRPUDeviceCuda : public TransferRPUDeviceCuda<T> {
+
+public:
+  explicit BufferedTransferRPUDeviceCuda(){};
+  explicit BufferedTransferRPUDeviceCuda(CudaContext *c, const BufferedTransferRPUDevice<T> &other);
+
+  ~BufferedTransferRPUDeviceCuda(){};
+  BufferedTransferRPUDeviceCuda(const BufferedTransferRPUDeviceCuda<T> &other);
+  BufferedTransferRPUDeviceCuda<T> &operator=(const BufferedTransferRPUDeviceCuda<T> &other);
+  BufferedTransferRPUDeviceCuda(BufferedTransferRPUDeviceCuda<T> &&other);
+  BufferedTransferRPUDeviceCuda<T> &operator=(BufferedTransferRPUDeviceCuda<T> &&other);
+
+  friend void
+  swap(BufferedTransferRPUDeviceCuda<T> &a, BufferedTransferRPUDeviceCuda<T> &b) noexcept {
+    using std::swap;
+    swap(static_cast<TransferRPUDeviceCuda<T> &>(a), static_cast<TransferRPUDeviceCuda<T> &>(b));
+    swap(a.transfer_buffer_vec_, b.transfer_buffer_vec_);
+    swap(a.transfer_out_, b.transfer_out_);
+  };
+
+  void populateFrom(const AbstractRPUDevice<T> &rpu_device) override;
+  BufferedTransferRPUDeviceMetaParameter<T> &getPar() const {
+    return static_cast<BufferedTransferRPUDeviceMetaParameter<T> &>(
+        SimpleRPUDeviceCuda<T>::getPar());
+  };
+  BufferedTransferRPUDeviceCuda<T> *clone() const override {
+    return new BufferedTransferRPUDeviceCuda<T>(*this);
+  };
+
+  void readAndUpdate(
+      int to_device_idx,
+      int from_device_idx,
+      int i_col_start,
+      const T lr,
+      const T *x_input,
+      const int n_vec,
+      const PulsedUpdateMetaParameter<T> &up) override;
+
+  std::vector<T> getHiddenWeights() const override;
+
+private:
+  std::vector<std::unique_ptr<CudaArray<T>>> transfer_buffer_vec_;
+
+  std::unique_ptr<CudaArray<T>> transfer_out_ = nullptr; // no need to copy
+};
+
+} // namespace RPU

--- a/src/rpucuda/cuda/rpucuda_buffered_transfer_device_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_buffered_transfer_device_test.cpp
@@ -1,0 +1,335 @@
+/**
+ * (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#include "cuda_util.h"
+#include "rpu_pulsed.h"
+#include "rpucuda_buffered_transfer_device.h"
+#include "rpucuda_constantstep_device.h"
+#include "rpucuda_pulsed.h"
+#include "test_helper.h"
+#include "gtest/gtest.h"
+#include <chrono>
+#include <memory>
+#include <random>
+
+#define TOLERANCE 1e-5
+
+#ifdef RPU_USE_DOUBLE
+typedef double num_t;
+#else
+typedef float num_t;
+#endif
+
+namespace {
+
+using namespace RPU;
+
+class RPUDeviceCudaTestFixture : public ::testing::TestWithParam<bool> {
+public:
+  void SetUp() {
+    x_size = 4;
+    d_size = 3;
+    m_batch = 1;
+
+    w_ref = Array_2D_Get<num_t>(d_size, x_size);
+
+    for (int i = 0; i < x_size * d_size; i++) {
+      w_ref[0][i] = rw_rng.sampleGauss();
+    }
+
+    weights = Array_2D_Get<num_t>(d_size, x_size);
+    for (int i = 0; i < d_size * x_size; i++) {
+      weights[0][i] = 0;
+    }
+
+    up.pulse_type =
+        PulseType::StochasticCompressed; // nodevice would skip the entire transfer mechanism
+    up.update_bl_management = false;
+    up.update_management = false;
+    up.desired_BL = 10;
+    up.initialize();
+
+    dp_cs.dw_min = 0.1;
+    dp_cs.dw_min_dtod = 0.0;
+    dp_cs.dw_min_std = 0.0;
+    dp_cs.up_down_dtod = 0.0;
+    dp_cs.w_max = 100;
+    dp_cs.w_min = -100;
+    dp_cs.w_max_dtod = 0;
+    dp_cs.w_min_dtod = 0;
+    dp_cs.lifetime = 0.0;
+
+    dp = new BufferedTransferRPUDeviceMetaParameter<num_t>(dp_cs, 2);
+
+    dp->gamma = 0.0;
+    dp->thres_scale = 0.5 / dp_cs.dw_min;
+    dp->transfer_columns = GetParam();
+    dp->transfer_every = GetParam() ? x_size : d_size;
+    dp->n_reads_per_transfer = 1;
+    dp->units_in_mbatch = false;
+
+    dp->transfer_io.inp_res = -1;
+    dp->transfer_io.out_res = -1;
+    dp->transfer_io.out_noise = 0.0;
+
+    dp->transfer_up = up;
+    dp->transfer_up.pulse_type = PulseType::StochasticCompressed;
+    dp->transfer_up.update_bl_management = false;
+    dp->transfer_up.update_management = false;
+    dp->transfer_up.fixed_BL = true;
+    dp->transfer_up.desired_BL = 1; // to force exactly one pulse if x*d!=0
+    dp->step = 1.0;                 // step to accumulate on next device. Since
+                                    // BL=1, LR=1, UM=0, and UBLM=0 it should always
+                                    // be (+/-)dw_min
+    dp->transfer_lr = 1.0;
+    dp->scale_transfer_lr = false; // do not scale with current_lr
+    dp->random_selection = false;
+
+    rx.resize(x_size * m_batch);
+    rd.resize(d_size * m_batch);
+
+    unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
+    std::default_random_engine generator{seed};
+    std::uniform_real_distribution<num_t> udist(-1.2, 1.2);
+    auto urnd = std::bind(udist, generator);
+
+    // just assign some numbers from the weight matrix
+    for (int i = 0; i < x_size * m_batch; i++)
+      rx[i] = urnd();
+
+    for (int j = 0; j < d_size * m_batch; j++) {
+      rd[j] = urnd();
+    }
+
+    up_pwu = RPU::make_unique<PulsedWeightUpdater<num_t>>(&context, x_size, d_size);
+
+    rpu_device = this->dp->createDeviceUnique(x_size, d_size, &rw_rng);
+    rpucuda_device = AbstractRPUDeviceCuda<num_t>::createFromUnique(&context, *rpu_device);
+
+    dev_weights = RPU::make_unique<CudaArray<num_t>>(&context, x_size * d_size);
+    dev_weights->assignTranspose(weights[0], d_size, x_size);
+    context.synchronize();
+  };
+
+  void TearDown() {
+    Array_2D_Free<num_t>(weights);
+    Array_2D_Free<num_t>(w_ref);
+    delete dp;
+  };
+
+  int x_size, d_size, colidx, m_batch;
+  num_t lifetime;
+  num_t **weights;
+  num_t **w_ref;
+  std::vector<num_t> rx, rd, w, w2;
+  PulsedUpdateMetaParameter<num_t> up;
+  BufferedTransferRPUDeviceMetaParameter<num_t> *dp;
+  ConstantStepRPUDeviceMetaParameter<num_t> dp_cs;
+  std::unique_ptr<PulsedWeightUpdater<num_t>> up_pwu;
+  std::unique_ptr<CudaArray<num_t>> dev_weights;
+
+  CudaContext context{-1, false};
+  RealWorldRNG<num_t> rw_rng;
+  std::unique_ptr<AbstractRPUDevice<num_t>> rpu_device;
+  std::unique_ptr<AbstractRPUDeviceCuda<num_t>> rpucuda_device;
+};
+
+// define the tests
+INSTANTIATE_TEST_CASE_P(RowColumn, RPUDeviceCudaTestFixture, ::testing::Values(true, false));
+
+TEST_P(RPUDeviceCudaTestFixture, createDevice) {
+
+  ASSERT_TRUE(dynamic_cast<BufferedTransferRPUDeviceCuda<num_t> *>(&*rpucuda_device) != nullptr);
+}
+
+TEST_P(RPUDeviceCudaTestFixture, Update) {
+
+  dp->transfer_lr = 0; // no transfer here
+  // just newly create from paramerers
+  rpu_device = dp->createDeviceUnique(this->x_size, this->d_size, &this->rw_rng);
+  rpucuda_device = AbstractRPUDeviceCuda<num_t>::createFromUnique(&context, *rpu_device);
+
+  CudaArray<num_t> dev_x(&context, this->x_size);
+  dev_x.setConst(1.0);
+  CudaArray<num_t> dev_d(&context, this->d_size);
+  dev_d.setConst(-1.0);
+  context.synchronize();
+
+  if (rpu_device->onSetWeights(this->weights)) {
+    rpucuda_device->populateFrom(*rpu_device); // device pars have changed (due to onSetWeights)
+  }
+  context.synchronize();
+
+  up_pwu->update(
+      dev_x.getDataConst(), dev_d.getDataConst(), dev_weights->getData(), &*rpucuda_device,
+      this->up,
+      1.0,   // lr
+      1,     // batch
+      false, // trans
+      false);
+  // should update all weight values of the hidden weight by -0.1 (current dw_min)
+  context.synchronize();
+  auto w_vec = static_cast<TransferRPUDeviceCuda<num_t> *>(&*rpucuda_device)->getHiddenWeights();
+
+  // update only on fast [nothing to transfer for first row]
+  int size = this->d_size * this->x_size;
+  // hidden weights updated (should be about 1)
+  num_t s = 0;
+  for (int i = 0; i < size; i++) {
+    ASSERT_FLOAT_EQ(w_vec[i], (num_t)1.0); // although stochastic, since A,B and BL/dwmin is 1 it
+                                           // should actually be exactly one
+    s += w_vec[i];
+  }
+  // std::cout << "Average weight " << s / size << " (Expected is 0.1)" << std::endl;
+
+  // visible  weights  not
+  for (int i = 0; i < size; i++) {
+    ASSERT_FLOAT_EQ(w_vec[i + size], 0.0);
+  }
+
+  dev_weights->copyTo(weights[0]);
+  dev_weights->assignTranspose(weights[0], x_size, d_size);
+  dev_weights->copyTo(weights[0]);
+
+  // reduce to weight. Only if gamma is set
+  for (int i = 0; i < size; i++) {
+    ASSERT_FLOAT_EQ(this->weights[0][i], 0.0);
+  }
+}
+
+TEST_P(RPUDeviceCudaTestFixture, UpdateAndTransfer) {
+
+  CudaArray<num_t> dev_x(&context, this->x_size);
+  dev_x.setConst(1.0);
+  CudaArray<num_t> dev_d(&context, this->d_size);
+  dev_d.setConst(-1.0);
+  context.synchronize();
+
+  if (rpu_device->onSetWeights(this->weights)) {
+    rpucuda_device->populateFrom(*rpu_device); // device pars have changed (due to onSetWeights)
+  }
+  context.synchronize();
+  int max_size = GetParam() ? this->x_size : this->d_size;
+
+  for (int k = 0; k < max_size; k++) {
+    up_pwu->update(
+        dev_x.getDataConst(), dev_d.getDataConst(), dev_weights->getData(), &*rpucuda_device,
+        this->up,
+        1.0,   // lr
+        1,     // batch
+        false, // trans
+        false);
+  }
+  // weight values of the hidden weights should be x_size and first
+  // col should be transfered once (that is set to dw_min)
+  context.synchronize();
+  auto w_vec = static_cast<TransferRPUDeviceCuda<num_t> *>(&*rpucuda_device)->getHiddenWeights();
+  dev_weights->copyTo(weights[0]);
+  dev_weights->assignTranspose(weights[0], x_size, d_size);
+  dev_weights->copyTo(weights[0]);
+
+  // update only on fast [nothing to transfer for first row]
+  int size = this->d_size * this->x_size;
+  // hidden weights updated
+  num_t s = 0;
+  for (int i = 0; i < size; i++) {
+    ASSERT_EQ(w_vec[i], (num_t)max_size);
+    s += w_vec[i];
+  }
+  // only first col of  weights should be transferred
+
+  for (int i = 0; i < size; i++) {
+    ASSERT_FLOAT_EQ(w_vec[i + size], 0.0); // should not be used
+  }
+
+  // reduce to weight.
+  std::vector<num_t> rw =
+      static_cast<TransferRPUDeviceCuda<num_t> *>(&*rpucuda_device)->getReduceWeightening();
+
+  // always fully hidden this not A in C
+  for (int i = 0; i < size; i++) {
+    // std::cout << "[" << i / x_size << "," << i % x_size << "]: " << this->weights[0][i] <<
+    // std::endl;
+    if (GetParam()) {
+      ASSERT_FLOAT_EQ(this->weights[0][i], i % x_size ? 0.0 : dp_cs.dw_min * rw[1]);
+    } else {
+      ASSERT_FLOAT_EQ(this->weights[0][i], i >= x_size ? 0.0 : dp_cs.dw_min * rw[1]);
+    }
+  }
+}
+
+TEST_P(RPUDeviceCudaTestFixture, CUDAvsCPU) {
+
+  PulsedMetaParameter<num_t> p;
+  p.up = up;
+  p.up.x_res_implicit = 0.01;
+  p.up.d_res_implicit = 0.01;
+  p.up.pulse_type = PulseType::DeterministicImplicit;
+
+  dp->transfer_up.pulse_type = PulseType::DeterministicImplicit;
+  dp->transfer_up.x_res_implicit = 0.01;
+  dp->transfer_up.d_res_implicit = 0.01;
+  dp->transfer_up.desired_BL = 10;
+
+  dp->transfer_io.is_perfect = true;
+
+  CudaArray<num_t> dev_x(&context, x_size * m_batch, rx.data());
+  CudaArray<num_t> dev_d(&context, d_size * m_batch, rd.data());
+  context.synchronize();
+
+  auto *rpu = new RPUPulsed<num_t>(x_size, d_size);
+  rpu->populateParameter(&p, dp);
+  rpu->setWeights(this->weights[0]);
+
+  rpu->setLearningRate(1.0);
+  auto *rpucuda = new RPUCudaPulsed<num_t>(context.getStream(), *rpu);
+  rpucuda->setLearningRate(1.0);
+  context.synchronize();
+
+  int size = this->d_size * this->x_size;
+  // double check whether weights are correct
+  w.resize(x_size * d_size);
+  rpu->getWeights(w.data());
+  w2.resize(x_size * d_size);
+  rpucuda->getWeights(w2.data());
+
+  for (int i = 0; i < size; i++) {
+    ASSERT_NEAR(w[i], w2[i], 1.0e-5);
+  }
+
+  context.synchronize();
+  for (int k = 0; k < (this->d_size + 1) * (this->x_size + 1); k++) {
+    rpu->update(rx.data(), rd.data(), false, m_batch, false, false);
+    rpucuda->update(dev_x.getData(), dev_d.getData(), false, m_batch, false, false);
+  }
+  // weight values of the hidden weights should be x_size and first
+  // col should be transfered once (that is set to dw_min)
+  context.synchronize();
+  w.resize(x_size * d_size);
+  rpu->getWeights(w.data());
+  w2.resize(x_size * d_size);
+  rpucuda->getWeights(w2.data());
+
+  for (int i = 0; i < size; i++) {
+    // std::cout << "[" << i / x_size << "," << i % x_size << "]: " << w[i] << " vs. " << w2[i] <<
+    // std::endl;
+    ASSERT_NEAR(w[i], w2[i], 1.0e-5);
+  }
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  resetCuda();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/rpucuda/cuda/rpucuda_mixedprec_device.h
+++ b/src/rpucuda/cuda/rpucuda_mixedprec_device.h
@@ -37,8 +37,6 @@ public:
         static_cast<MixedPrecRPUDeviceBaseCuda<T> &>(b));
 
     swap(a.dev_chi_, b.dev_chi_);
-    swap(a.chi_scale_, b.chi_scale_);
-    swap(a.nblocks_batch_max_, b.nblocks_batch_max_);
   };
   bool hasDirectUpdate() const override { return true; };
   void doDirectUpdate(
@@ -55,7 +53,6 @@ public:
       T *d_buffer) override;
 
   std::vector<T> getHiddenWeights() const override;
-
   void populateFrom(const AbstractRPUDevice<T> &rpu_device) override;
 
   MixedPrecRPUDeviceMetaParameter<T> &getPar() const override {
@@ -83,11 +80,10 @@ private:
       int n_bins,
       int size,
       int m_batch,
-      bool trans);
+      bool trans,
+      bool stochastic_rounding);
 
   std::unique_ptr<CudaArray<T>> dev_chi_ = nullptr;
-  int32_t chi_scale_ = 0;
-  int nblocks_batch_max_ = 0;
 };
 
 } // namespace RPU

--- a/src/rpucuda/cuda/rpucuda_mixedprec_device_base.h
+++ b/src/rpucuda/cuda/rpucuda_mixedprec_device_base.h
@@ -58,7 +58,7 @@ public:
     swap(a.io_, b.io_);
     swap(a.up_ptr_, b.up_ptr_);
     swap(a.up_, b.up_);
-
+    swap(a.nblocks_batch_max_, b.nblocks_batch_max_);
     swap(a.granularity_, b.granularity_);
   };
   bool hasDirectUpdate() const override { return true; };
@@ -111,6 +111,7 @@ protected:
   std::unique_ptr<CudaArray<T>> dev_transfer_d_vecs_ = nullptr;
 
   T granularity_ = 0.0;
+  int nblocks_batch_max_;
 
 private:
   void allocateContainers();

--- a/src/rpucuda/cuda/rpucuda_pulsed_device_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_pulsed_device_test.cpp
@@ -17,6 +17,7 @@
 #include "rpu_pulsed.h"
 #include "rpucuda_constantstep_device.h"
 #include "rpucuda_expstep_device.h"
+#include "rpucuda_hidden_device.h"
 #include "rpucuda_linearstep_device.h"
 #include "rpucuda_pulsed.h"
 #include "rpucuda_pulsed_device.h"
@@ -244,6 +245,7 @@ public:
 
 // types
 typedef ::testing::Types<
+    HiddenStepRPUDeviceMetaParameter<num_t>,
     LinearStepRPUDeviceMetaParameter<num_t>,
     ExpStepRPUDeviceMetaParameter<num_t>,
     ConstantStepRPUDeviceMetaParameter<num_t>>

--- a/src/rpucuda/cuda/rpucuda_simple_device.cu
+++ b/src/rpucuda/cuda/rpucuda_simple_device.cu
@@ -15,6 +15,7 @@
 #include "rpucuda_pulsed_device.h"
 #include <memory>
 
+#include "rpucuda_buffered_transfer_device.h"
 #include "rpucuda_constantstep_device.h"
 #include "rpucuda_expstep_device.h"
 #include "rpucuda_linearstep_device.h"
@@ -49,6 +50,9 @@ AbstractRPUDeviceCuda<T>::createFrom(CudaContext *c, const AbstractRPUDevice<T> 
     return new OneSidedRPUDeviceCuda<T>(c, static_cast<const OneSidedRPUDevice<T> &>(rpu_device));
   case DeviceUpdateType::Transfer:
     return new TransferRPUDeviceCuda<T>(c, static_cast<const TransferRPUDevice<T> &>(rpu_device));
+  case DeviceUpdateType::BufferedTransfer:
+    return new BufferedTransferRPUDeviceCuda<T>(
+        c, static_cast<const BufferedTransferRPUDevice<T> &>(rpu_device));
   case DeviceUpdateType::FloatingPoint:
     return new SimpleRPUDeviceCuda<T>(c, static_cast<const SimpleRPUDevice<T> &>(rpu_device));
   case DeviceUpdateType::MixedPrec:

--- a/src/rpucuda/rpu_buffered_transfer_device.cpp
+++ b/src/rpucuda/rpu_buffered_transfer_device.cpp
@@ -1,0 +1,302 @@
+/**
+ * (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#include "rpu_buffered_transfer_device.h"
+#include "math_util.h"
+#include "utility_functions.h"
+#include <algorithm>
+#include <memory>
+#include <sstream>
+
+namespace RPU {
+
+/******************************************************************************************/
+/* BufferedTransferRPUDeviceMetaParameter*/
+
+template <typename T>
+void BufferedTransferRPUDeviceMetaParameter<T>::printToStream(std::stringstream &ss) const {
+
+  TransferRPUDeviceMetaParameter<T>::printToStream(ss);
+
+  ss << "--- Parameters special to BufferedTransfer --- " << std::endl;
+  // thres
+  ss << "\tthres_scale:\t\t";
+  ss << thres_scale;
+  ss << std::endl;
+
+  ss << "\tstep:\t\t\t";
+  ss << step;
+  ss << std::endl;
+
+  ss << "\tmomentum:\t\t";
+  ss << momentum;
+  ss << std::endl;
+};
+
+template <typename T>
+T BufferedTransferRPUDeviceMetaParameter<T>::getTransferLR(
+    int to_device_idx, int from_device_idx, T current_lr) const {
+
+  T lr_gamma =
+      TransferRPUDeviceMetaParameter<T>::getTransferLR(to_device_idx, from_device_idx, current_lr);
+
+  if (this->gamma_vec[to_device_idx] > 0 && this->gamma_vec[from_device_idx] > 0) {
+    lr_gamma *= this->gamma_vec[from_device_idx] / this->gamma_vec[to_device_idx];
+  }
+  return lr_gamma;
+}
+
+template struct BufferedTransferRPUDeviceMetaParameter<float>;
+#ifdef RPU_USE_DOUBLE
+template struct BufferedTransferRPUDeviceMetaParameter<double>;
+#endif
+
+/******************************************************************************************/
+// dtor
+template <typename T> BufferedTransferRPUDevice<T>::~BufferedTransferRPUDevice() {}
+
+// ctor
+template <typename T>
+BufferedTransferRPUDevice<T>::BufferedTransferRPUDevice(int x_sz, int d_sz)
+    : TransferRPUDevice<T>(x_sz, d_sz) {}
+
+template <typename T>
+BufferedTransferRPUDevice<T>::BufferedTransferRPUDevice(
+    int x_sz, int d_sz, const BufferedTransferRPUDeviceMetaParameter<T> &par, RealWorldRNG<T> *rng)
+    : BufferedTransferRPUDevice<T>(x_sz, d_sz) {
+  populate(par, rng);
+}
+
+// copy constructor
+template <typename T>
+BufferedTransferRPUDevice<T>::BufferedTransferRPUDevice(const BufferedTransferRPUDevice<T> &other)
+    : TransferRPUDevice<T>(other) {
+  transfer_buffer_vec_ = other.transfer_buffer_vec_;
+}
+
+// copy assignment
+template <typename T>
+BufferedTransferRPUDevice<T> &
+BufferedTransferRPUDevice<T>::operator=(const BufferedTransferRPUDevice<T> &other) {
+
+  BufferedTransferRPUDevice<T> tmp(other);
+  swap(*this, tmp);
+  return *this;
+}
+
+// move constructor
+template <typename T>
+BufferedTransferRPUDevice<T>::BufferedTransferRPUDevice(BufferedTransferRPUDevice<T> &&other) {
+  *this = std::move(other);
+}
+
+// move assignment
+template <typename T>
+BufferedTransferRPUDevice<T> &
+BufferedTransferRPUDevice<T>::operator=(BufferedTransferRPUDevice<T> &&other) {
+  TransferRPUDevice<T>::operator=(std::move(other));
+  transfer_buffer_vec_ = std::move(transfer_buffer_vec_);
+
+  return *this;
+}
+
+/*********************************************************************************/
+/* populate */
+
+template <typename T>
+void BufferedTransferRPUDevice<T>::populate(
+    const BufferedTransferRPUDeviceMetaParameter<T> &p, RealWorldRNG<T> *rng) {
+
+  TransferRPUDevice<T>::populate(p, rng);
+
+  transfer_buffer_vec_.resize(this->n_devices_ - 1);
+
+  // init buffers
+  for (int k = 0; k < this->n_devices_ - 1; k++) {
+    transfer_buffer_vec_[k].resize(this->size_);
+  }
+}
+
+/*********************************************************************************/
+/* transfer */
+template <typename T>
+void BufferedTransferRPUDevice<T>::readAndUpdate(
+    int to_device_idx,
+    int from_device_idx,
+    const T lr,
+    const T *vec,
+    const int n_vec,
+    const T reset_prob_in,
+    const int i_slice_start) {
+  if (lr == (T)0.0) {
+    return;
+  }
+
+  if (to_device_idx == from_device_idx || from_device_idx >= this->n_devices_ - 1) {
+    // self update and transfer from last device not supported
+    return;
+  }
+
+  this->transfer_tmp_.resize(this->d_size_);
+  const auto &par = getPar();
+  int in_size = par.getInSize();
+  int out_size = par.getOutSize();
+
+  T weight_granularity = this->rpu_device_vec_[to_device_idx]->getWeightGranularity();
+  T buffer_granularity = par.thres_scale * weight_granularity;
+  T sub_momentum = (T)1.0 - MAX(MIN(par.momentum, (T)1.0), (T)0.0);
+  T step = par.step;
+  T lr_abs = fabs(lr);
+  T *v_out = this->transfer_tmp_.data();
+
+  int max_steps = this->transfer_pwu_->getUpPar().desired_BL;
+
+  // buffer weight is x_size major, we need to write out_size
+  bool use_cols = par.transfer_columns;
+  int w_inc = use_cols ? in_size : 1;
+
+  // forward / update
+  for (int i = 0; i < n_vec; i++) {
+
+    const T *v_in = vec + i * in_size;
+
+    // first read into d (will overwrite d)
+    this->readVector(from_device_idx, v_in, v_out, 1.0);
+
+    // add into to FP buffer
+    T *fp_w = transfer_buffer_vec_[from_device_idx].data();
+    int i_w = use_cols ? i_slice_start + i : this->x_size_ * (i_slice_start + i);
+
+    int non_zero_count = 0;
+
+    PRAGMA_SIMD
+    for (int j = 0; j < out_size; j++) {
+      T omega = fp_w[i_w];
+      omega += v_out[j] * lr_abs; // multiplied with transfer LR
+
+      T n_steps = MAX(MIN(truncf(omega / buffer_granularity), max_steps), -max_steps);
+      fp_w[i_w] = omega - sub_momentum * n_steps * buffer_granularity;
+
+      non_zero_count += ((int)n_steps) != 0;
+
+      v_out[j] = -n_steps; // since positive update needed below
+      i_w += w_inc;
+    }
+
+    if (non_zero_count > 0) {
+      this->writeVector(to_device_idx, v_in, v_out, step * weight_granularity, 1);
+    }
+  }
+}
+
+template <typename T>
+void BufferedTransferRPUDevice<T>::getDPNames(std::vector<std::string> &names) const {
+
+  TransferRPUDevice<T>::getDPNames(names);
+
+  for (int k = 0; k < this->n_devices_ - 1; k++) {
+    std::ostringstream ss;
+    ss << "buffered_FP_weight_" << k;
+    names.push_back(ss.str());
+  }
+}
+
+template <typename T>
+void BufferedTransferRPUDevice<T>::getDeviceParameter(std::vector<T *> &data_ptrs) const {
+
+  std::vector<std::string> names;
+  getDPNames(names);
+
+  if (data_ptrs.size() < names.size()) {
+    RPU_FATAL("Expected " << names.size() << " data pointers!");
+  }
+
+  TransferRPUDevice<T>::getDeviceParameter(data_ptrs);
+
+  int add_n = this->n_devices_ - 1;
+  size_t m = names.size() - add_n;
+  for (int k = 0; k < add_n; k++) {
+
+    // "hidden weights"
+    for (int i = 0; i < this->size_; ++i) {
+      data_ptrs[m][i] = transfer_buffer_vec_[k][i];
+    }
+    m++;
+  }
+};
+
+template <typename T> int BufferedTransferRPUDevice<T>::getHiddenWeightsCount() const {
+
+  if (!this->n_devices_) {
+    return 0;
+  }
+  int m = TransferRPUDevice<T>::getHiddenWeightsCount();
+  return m + this->n_devices_ - 1;
+}
+
+template <typename T>
+void BufferedTransferRPUDevice<T>::setHiddenWeights(const std::vector<T> &data) {
+  /* hidden weights are expected in the usual row-major format (first x_size then d_size)*/
+
+  if (!this->n_devices_) {
+    return;
+  }
+
+  TransferRPUDevice<T>::setHiddenWeights(data);
+
+  // lastly,  set the FP buffers
+  int add_n = this->n_devices_ - 1;
+  int offset = (getHiddenWeightsCount() - add_n) * this->size_;
+  for (int k = 0; k < add_n; k++) {
+
+    if (data.size() < (size_t)offset + this->size_) {
+      RPU_FATAL("Size mismatch for hidden weights.");
+    }
+
+    for (int i = 0; i < this->size_; i++) {
+      transfer_buffer_vec_[k][i] = data[offset + i];
+    }
+    offset += this->size_;
+  }
+}
+
+template <typename T>
+void BufferedTransferRPUDevice<T>::setDeviceParameter(
+    T **out_weights, const std::vector<T *> &data_ptrs) {
+
+  std::vector<std::string> names;
+  getDPNames(names);
+
+  if (data_ptrs.size() < names.size()) {
+    RPU_FATAL("Expected " << names.size() << " data pointers!");
+  }
+
+  TransferRPUDevice<T>::setDeviceParameter(out_weights, data_ptrs);
+
+  int add_n = this->n_devices_ - 1;
+  size_t m = names.size() - add_n;
+
+  // lastly,  set the FP buffers
+  for (int k = 0; k < add_n; k++) {
+
+    for (int i = 0; i < this->size_; i++) {
+      transfer_buffer_vec_[k][i] = data_ptrs[m + k][i];
+    }
+  }
+};
+
+template class BufferedTransferRPUDevice<float>;
+#ifdef RPU_USE_DOUBLE
+template class BufferedTransferRPUDevice<double>;
+#endif
+
+} // namespace RPU

--- a/src/rpucuda/rpu_buffered_transfer_device.h
+++ b/src/rpucuda/rpu_buffered_transfer_device.h
@@ -1,0 +1,158 @@
+/**
+ * (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#pragma once
+
+#include "rpu_transfer_device.h"
+#include <sstream>
+#include <stdio.h>
+
+namespace RPU {
+
+template <typename T> class BufferedTransferRPUDevice;
+
+/* Defines the buffered transfer device.
+
+ */
+
+template <typename T>
+struct BufferedTransferRPUDeviceMetaParameter : TransferRPUDeviceMetaParameter<T> {
+
+  T thres_scale = 1.0;
+  // threshold for buffer to determine whether to
+  // transfer to next device. NOTE: Will be multiplied
+  // with dw_min
+
+  T step = 1.0; // step size to transfer to if buffer is above
+                // thres. Note, however, the step size is equal to
+                // dw_min by default (for anything step>dw_min)
+                // because of the below default update setting
+
+  T momentum = 0.0; // momentum on H. after transfer the momentum fraction stays on H
+
+  BufferedTransferRPUDeviceMetaParameter() : TransferRPUDeviceMetaParameter<T>() {
+    initDefaults();
+  };
+  BufferedTransferRPUDeviceMetaParameter(
+      const PulsedRPUDeviceMetaParameterBase<T> &dp, int n_devices)
+      : TransferRPUDeviceMetaParameter<T>(dp, n_devices) {
+    initDefaults();
+  };
+  BufferedTransferRPUDeviceMetaParameter(
+      const PulsedRPUDeviceMetaParameterBase<T> &dp_fast,
+      const PulsedRPUDeviceMetaParameterBase<T> &dp_rest,
+      int n_total_devices)
+      : TransferRPUDeviceMetaParameter<T>(dp_fast, dp_rest, n_total_devices) {
+    initDefaults();
+  };
+
+  void initDefaults() {
+
+    this->transfer_lr = (T)1.0;
+
+    this->transfer_up.update_bl_management = false;
+    this->transfer_up.update_management = false;
+    this->transfer_up.desired_BL = 1; // to set exactly one pulse if x*d!=0
+    this->transfer_up.fixed_BL = true;
+    this->scale_transfer_lr = true; // transfer should scale!
+
+    this->update_policy = VectorDeviceUpdatePolicy::SingleFixed;
+    this->first_update_idx = 0; // only first is updated
+    this->same_context = true;
+
+    this->with_reset_prob = 0.0;
+    this->random_selection = false;
+    this->no_self_transfer = true;
+  }
+
+  std::string getName() const override {
+    std::ostringstream ss;
+    ss << "BufferedTransfer(" << this->vec_par.size() << ")";
+    if (this->vec_par.size() > 1) {
+      ss << ": " << this->vec_par[0]->getName() << " -> " << this->vec_par[1]->getName();
+      ;
+    }
+    return ss.str();
+  };
+
+  BufferedTransferRPUDevice<T> *
+  createDevice(int x_size, int d_size, RealWorldRNG<T> *rng) override {
+    return new BufferedTransferRPUDevice<T>(x_size, d_size, *this, rng);
+  };
+
+  BufferedTransferRPUDeviceMetaParameter<T> *clone() const override {
+    return new BufferedTransferRPUDeviceMetaParameter<T>(*this);
+  };
+  DeviceUpdateType implements() const override { return DeviceUpdateType::BufferedTransfer; };
+  void printToStream(std::stringstream &ss) const override;
+
+  T getTransferLR(int to_device_idx, int from_device_idx, T current_lr) const override;
+};
+
+template <typename T> class BufferedTransferRPUDevice : public TransferRPUDevice<T> {
+
+public:
+  // constructor / destructor
+  BufferedTransferRPUDevice(){};
+  BufferedTransferRPUDevice(int x_size, int d_size);
+  BufferedTransferRPUDevice(
+      int x_size,
+      int d_size,
+      const BufferedTransferRPUDeviceMetaParameter<T> &par,
+      RealWorldRNG<T> *rng);
+  ~BufferedTransferRPUDevice();
+
+  BufferedTransferRPUDevice(const BufferedTransferRPUDevice<T> &);
+  BufferedTransferRPUDevice<T> &operator=(const BufferedTransferRPUDevice<T> &);
+  BufferedTransferRPUDevice(BufferedTransferRPUDevice<T> &&);
+  BufferedTransferRPUDevice<T> &operator=(BufferedTransferRPUDevice<T> &&);
+
+  friend void swap(BufferedTransferRPUDevice<T> &a, BufferedTransferRPUDevice<T> &b) noexcept {
+    using std::swap;
+    swap(static_cast<TransferRPUDevice<T> &>(a), static_cast<TransferRPUDevice<T> &>(b));
+
+    swap(a.transfer_buffer_vec_, b.transfer_buffer_vec_);
+  }
+
+  BufferedTransferRPUDeviceMetaParameter<T> &getPar() const override {
+    return static_cast<BufferedTransferRPUDeviceMetaParameter<T> &>(SimpleRPUDevice<T>::getPar());
+  };
+
+  BufferedTransferRPUDevice<T> *clone() const override {
+    return new BufferedTransferRPUDevice<T>(*this);
+  };
+
+  void getDPNames(std::vector<std::string> &names) const override;
+  void getDeviceParameter(std::vector<T *> &data_ptrs) const override;
+  void setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) override;
+  int getHiddenWeightsCount() const override;
+  void setHiddenWeights(const std::vector<T> &data) override;
+
+  void readAndUpdate(
+      int to_device_idx,
+      int from_device_idx,
+      const T lr,
+      const T *vec,
+      const int n_vec,
+      const T reset_prob,
+      const int i_col) override;
+
+  std::vector<std::vector<T>> getTransferBuffers() const { return transfer_buffer_vec_; };
+
+protected:
+  void populate(const BufferedTransferRPUDeviceMetaParameter<T> &par, RealWorldRNG<T> *rng);
+
+private:
+  std::vector<std::vector<T>> transfer_buffer_vec_;
+};
+
+} // namespace RPU

--- a/src/rpucuda/rpu_forward_backward_pass.h
+++ b/src/rpucuda/rpu_forward_backward_pass.h
@@ -23,6 +23,7 @@ template <typename T> class ForwardBackwardPass {
 public:
   explicit ForwardBackwardPass(int x_size, int d_size) : x_size_(x_size), d_size_(d_size){};
   ForwardBackwardPass(){};
+  virtual ~ForwardBackwardPass(){};
 
   virtual void forwardVector(
       T **weights,

--- a/src/rpucuda/rpu_mixedprec_device.h
+++ b/src/rpucuda/rpu_mixedprec_device.h
@@ -37,9 +37,11 @@ template <typename T> class MixedPrecRPUDevice;
 template <typename T>
 struct MixedPrecRPUDeviceMetaParameter : MixedPrecRPUDeviceBaseMetaParameter<T> {
 
-  int n_x_bins = 255;
-  int n_d_bins = 255;
-  float transfer_lr = 1.0;
+  int n_x_bins = 0;
+  int n_d_bins = 0;
+  bool stoc_round_d = false;
+  bool stoc_round_x = false;
+  T transfer_lr = 1.0;
 
   MixedPrecRPUDeviceMetaParameter() = default;
   ~MixedPrecRPUDeviceMetaParameter() = default;
@@ -53,6 +55,9 @@ struct MixedPrecRPUDeviceMetaParameter : MixedPrecRPUDeviceBaseMetaParameter<T> 
 
     swap(a.n_d_bins, b.n_d_bins);
     swap(a.n_x_bins, b.n_x_bins);
+    swap(a.transfer_lr, b.transfer_lr);
+    swap(a.stoc_round_x, b.stoc_round_x);
+    swap(a.stoc_round_d, b.stoc_round_d);
   }
 
   std::string getName() const override {

--- a/src/rpucuda/rpu_mixedprec_device_base.h
+++ b/src/rpucuda/rpu_mixedprec_device_base.h
@@ -162,6 +162,8 @@ protected:
   std::unique_ptr<PulsedRPUWeightUpdater<T>> transfer_pwu_ = nullptr;
   T granularity_ = 0.0f;
   std::vector<T> transfer_tmp_;
+  RealWorldRNG<T> rw_rng_{0};
+  RNG<T> rng_{0};
 
 private:
   int current_row_index_ = 0;
@@ -169,7 +171,6 @@ private:
   std::vector<T> transfer_d_vecs_;
   T avg_sparsity_ = 0.0f;
   const PulsedUpdateMetaParameter<T> *up_ptr_ = nullptr;
-  RealWorldRNG<T> rw_rng_{0};
 };
 
 } // namespace RPU

--- a/src/rpucuda/rpu_pulsed_meta_parameter.h
+++ b/src/rpucuda/rpu_pulsed_meta_parameter.h
@@ -26,7 +26,8 @@ enum class NoiseManagementType {
   Max,
   Constant,
   AverageAbsMax,
-  AverageAbsMaxSingleValue
+  AverageAbsMaxSingleValue,
+  AbsMaxSingleValue
 };
 
 enum class BoundManagementType { None, Iterative, IterativeWorstCase, Shift };

--- a/src/rpucuda/rpu_simple_device.h
+++ b/src/rpucuda/rpu_simple_device.h
@@ -42,6 +42,7 @@ enum DeviceUpdateType {
   Transfer,
   MixedPrec,
   PowStep,
+  BufferedTransfer
 };
 
 // inherit from Simple

--- a/src/rpucuda/weight_clipper.cpp
+++ b/src/rpucuda/weight_clipper.cpp
@@ -66,6 +66,10 @@ template <typename T> void WeightClipper<T>::apply(T *weights, const WeightClipP
 
     clip_value = fabs(sum_amax / d_size_);
 
+    if (wclpar.fixed_value > 0) {
+      clip_value = MIN(clip_value, wclpar.fixed_value);
+    }
+
     break;
   }
   case WeightClipType::LayerGaussian: {
@@ -90,6 +94,9 @@ template <typename T> void WeightClipper<T>::apply(T *weights, const WeightClipP
     std_value = sqrt(std_value);
 
     clip_value = std_value * wclpar.sigma;
+    if (wclpar.fixed_value > 0) {
+      clip_value = MIN(clip_value, wclpar.fixed_value);
+    }
     break;
   }
 
@@ -102,7 +109,9 @@ template <typename T> void WeightClipper<T>::apply(T *weights, const WeightClipP
   } // switch
 
   // do the clippping
-  clip(weights, clip_value);
+  if (clip_value > 0) {
+    clip(weights, clip_value);
+  }
 }
 
 template class WeightClipper<float>;

--- a/src/rpucuda/weight_clipper.h
+++ b/src/rpucuda/weight_clipper.h
@@ -28,7 +28,7 @@ enum class WeightClipType {
 struct WeightClipParameter {
 
   WeightClipType type = WeightClipType::None;
-  double fixed_value = 1.0;
+  double fixed_value = -1.0; // will always be applied if larger >0
   double sigma = 2.5;
 
   void print() const {
@@ -43,9 +43,7 @@ struct WeightClipParameter {
     if (type == WeightClipType::None) {
       return;
     }
-    if (type == WeightClipType::FixedValue) {
-      ss << "\t fixed value:\t\t" << fixed_value << std::endl;
-    }
+    ss << "\t fixed value:\t\t" << fixed_value << std::endl;
     if (type == WeightClipType::LayerGaussian) {
       ss << "\t sigma:\t\t" << sigma << std::endl;
     }

--- a/tests/helpers/tiles.py
+++ b/tests/helpers/tiles.py
@@ -27,6 +27,7 @@ from aihwkit.simulator.configs.devices import (
     OneSidedUnitCell,
     VectorUnitCell,
     TransferCompound,
+    BufferedTransferCompound,
     ReferenceUnitCell,
     MixedPrecisionCompound,
 )
@@ -248,6 +249,30 @@ class Transfer:
 
     def get_rpu_config(self):
         return UnitCellRPUConfig(device=TransferCompound(
+            unit_cell_devices=[
+                SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0),
+                SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0)
+            ],
+            transfer_forward=IOParameters(is_perfect=True),
+            transfer_every=1,
+            gamma=0.1
+
+        ))
+
+    def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
+        rpu_config = rpu_config or self.get_rpu_config()
+        return AnalogTile(out_size, in_size, rpu_config, **kwargs)
+
+
+class BufferedTransfer:
+    """AnalogTile with BufferedTransferCompound."""
+
+    simulator_tile_class = tiles.AnalogTile
+    first_hidden_field = 'max_bound_0'
+    use_cuda = False
+
+    def get_rpu_config(self):
+        return UnitCellRPUConfig(device=BufferedTransferCompound(
             unit_cell_devices=[
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0),
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0)
@@ -497,7 +522,7 @@ class OneSidedCuda:
 
 
 class TransferCuda:
-    """AnalogTile with TransferUnitCell."""
+    """AnalogTile with TransferCompound."""
 
     simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
     first_hidden_field = 'max_bound_0'
@@ -505,6 +530,29 @@ class TransferCuda:
 
     def get_rpu_config(self):
         return UnitCellRPUConfig(device=TransferCompound(
+            unit_cell_devices=[
+                SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0),
+                SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0)
+            ],
+            transfer_forward=IOParameters(is_perfect=True),
+            transfer_every=1,
+            gamma=0.1
+        ))
+
+    def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
+        rpu_config = rpu_config or self.get_rpu_config()
+        return AnalogTile(out_size, in_size, rpu_config, **kwargs).cuda()
+
+
+class BufferedTransferCuda:
+    """AnalogTile with BufferedTransferCompound."""
+
+    simulator_tile_class = getattr(tiles, 'CudaAnalogTile', None)
+    first_hidden_field = 'max_bound_0'
+    use_cuda = True
+
+    def get_rpu_config(self):
+        return UnitCellRPUConfig(device=BufferedTransferCompound(
             unit_cell_devices=[
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0),
                 SoftBoundsDevice(w_max_dtod=0, w_min_dtod=0)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -24,7 +24,8 @@ from aihwkit.simulator.presets import (
     TikiTakaCapacitorPreset, TikiTakaEcRamPreset, TikiTakaEcRamMOPreset, TikiTakaIdealizedPreset,
     MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset, MixedPrecisionCapacitorPreset,
     MixedPrecisionEcRamPreset, MixedPrecisionEcRamMOPreset, MixedPrecisionIdealizedPreset,
-    MixedPrecisionGokmenVlasovPreset, MixedPrecisionPCMPreset,
+    MixedPrecisionGokmenVlasovPreset, MixedPrecisionPCMPreset, TTv2ReRamESPreset, TTv2ReRamSBPreset,
+    TTv2CapacitorPreset, TTv2EcRamPreset, TTv2EcRamMOPreset, TTv2IdealizedPreset,
 )
 from .helpers.decorators import parametrize_over_presets
 from .helpers.testcases import AihwkitTestCase
@@ -41,7 +42,9 @@ from .helpers.testcases import AihwkitTestCase
         TikiTakaIdealizedPreset,
         MixedPrecisionReRamESPreset, MixedPrecisionReRamSBPreset, MixedPrecisionCapacitorPreset,
         MixedPrecisionEcRamPreset, MixedPrecisionEcRamMOPreset, MixedPrecisionIdealizedPreset,
-        MixedPrecisionGokmenVlasovPreset, MixedPrecisionPCMPreset,
+        MixedPrecisionGokmenVlasovPreset, MixedPrecisionPCMPreset, TTv2ReRamESPreset,
+        TTv2ReRamSBPreset, TTv2CapacitorPreset, TTv2EcRamPreset, TTv2EcRamMOPreset,
+        TTv2IdealizedPreset
     ]
 )
 class PresetTest(AihwkitTestCase):

--- a/tests/test_simulator_tiles.py
+++ b/tests/test_simulator_tiles.py
@@ -26,10 +26,11 @@ from .helpers.decorators import parametrize_over_tiles
 from .helpers.testcases import ParametrizedTestCase
 from .helpers.tiles import (
     FloatingPoint, Ideal, ConstantStep, LinearStep, SoftBounds,
-    ExpStep, Vector, OneSided, Transfer, MixedPrecision, Inference, Reference,
-    FloatingPointCuda, IdealCuda, ConstantStepCuda, LinearStepCuda,
-    SoftBoundsCuda, ExpStepCuda, VectorCuda, OneSidedCuda, TransferCuda,
-    InferenceCuda, ReferenceCuda, MixedPrecisionCuda
+    ExpStep, Vector, OneSided, Transfer, BufferedTransfer, MixedPrecision,
+    Inference, Reference, FloatingPointCuda, IdealCuda, ConstantStepCuda,
+    LinearStepCuda, SoftBoundsCuda, ExpStepCuda, VectorCuda, OneSidedCuda,
+    TransferCuda, BufferedTransferCuda, InferenceCuda, ReferenceCuda,
+    MixedPrecisionCuda
 )
 
 
@@ -43,6 +44,7 @@ from .helpers.tiles import (
     Vector,
     OneSided,
     Transfer,
+    BufferedTransfer,
     MixedPrecision,
     Inference,
     Reference,
@@ -55,6 +57,7 @@ from .helpers.tiles import (
     VectorCuda,
     OneSidedCuda,
     TransferCuda,
+    BufferedTransferCuda,
     MixedPrecisionCuda,
     InferenceCuda,
     ReferenceCuda,


### PR DESCRIPTION
## Related issues

#317

## Description

This introduces a `BufferedTransferCompound` that is similar to the `TransferCompound` but has an additional digital buffer matrix between readout from the fast A matrix and the transfer to the slow C matrix as described in the paper [Gokmen (2021)](https://www.frontiersin.org/articles/10.3389/frai.2021.699148/full).    

We will add more documentation and examples on this new learning rule soon.  

There are also some small changes to other devices in this PR, see below.

## Details

* TTv2 presets are added
* Stochastic rounding option for `MixedPrecision`
* Clipping behavior for hardware-aware training for inference as changed (`fixed_value` is always applied if set) 
