### PR TITLE
Decay to reset bias value 

### DIFF
--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -86,7 +86,7 @@ class PulsedDevice(_PrintableMixin):
 
     **Decay**:
 
-    .. math:: w_{ij} \leftarrow w_{ij}\,(1-\alpha_\text{decay}\delta_{ij})
+    .. math:: w_{ij} \leftarrow (w_{ij} - b_{ij})\,(1-\alpha_\text{decay}\delta_{ij}) + b_{ij}
 
     Weight decay is only activated by inserting a specific call to
     :meth:`~aihwkit.simulator.tiles.base.Base.decay_weights`, which is
@@ -96,6 +96,16 @@ class PulsedDevice(_PrintableMixin):
     are thus set and fixed during RPU
     initialization. :math:`\alpha_\text{decay}` is a scaling factor
     that can be given during run-time.
+
+    The bias :math:`b_{ij}` is given by the reset bias and which is
+    determined by the parameter ``reset`` (mean value) and
+    ``reset_dtod``  (device-to-device variability). Thus
+
+    .. math:: b_{ij} = \mu_\text{reset} \left(1 + \sigma_\text{reset-dtod}\xi\right)
+
+    Note that the reset bias is also applied in case the device is
+    reset (see above).
+
 
     **Diffusion**:
 
@@ -125,6 +135,7 @@ class PulsedDevice(_PrintableMixin):
         mini-batch but requires an explicit call to
         :meth:`~aihwkit.simulator.tiles.base.Base.drift_weights` each
         time the drift should be applied.
+
     """
 
     bindings_class: ClassVar[Type] = devices.PulsedResistiveDeviceParameter
@@ -186,7 +197,7 @@ class PulsedDevice(_PrintableMixin):
     """No up-down differences and device-to-device variability in the bounds
     for the devices in the bias row."""
 
-    reset: float = 0.01
+    reset: float = 0.0
     """The reset values and spread per cross-point ``ij`` when using reset
     functionality of the device."""
 

--- a/src/rpucuda/cuda/cuda_math_util.h
+++ b/src/rpucuda/cuda/cuda_math_util.h
@@ -121,15 +121,21 @@ void elemasb02(
     const T *B,
     float *dev_4params); // bounds in [0,2] // 4params and 2params always float !
 
-// sat(W *= A)
-template <typename T>
-void elemscale(const CudaContext *context, T *W, const int size, const T *A, float *dev_4params);
-
 // sat(W)
 template <typename T>
 void elemsat(const CudaContext *context, T *W, const int size, float *dev_4params);
 
-// sat(W *= 1+alpha*(A-1))
+// sat(W = (W - S) * A + S)
+template <typename T>
+void elemscale(
+    const CudaContext *context,
+    T *W,
+    const int size,
+    const T *A,
+    float *dev_4params,
+    const T *dev_shift = nullptr);
+
+// sat(W = (W - S) (1+(A-1)*alpha) + S)
 template <typename T>
 void elemscalealpha(
     const CudaContext *context,
@@ -137,7 +143,8 @@ void elemscalealpha(
     const int size,
     const T *A,
     float *dev_4params,
-    const T alpha);
+    const T alpha,
+    const T *dev_shift = nullptr);
 
 // W += A, A = W
 template <typename T> void elemaddcopy(const CudaContext *context, T *W, T *A, const int size);

--- a/src/rpucuda/cuda/rpucuda_pulsed.h
+++ b/src/rpucuda/cuda/rpucuda_pulsed.h
@@ -201,9 +201,6 @@ protected:
 private:
   PulsedMetaParameter<T> par_;
 
-  std::unique_ptr<CudaArray<T>> dev_decay_scale_ = nullptr;
-  std::unique_ptr<CudaArray<T>> dev_diffusion_rate_ = nullptr;
-
   // forward
   std::unique_ptr<CudaArray<T>> dev_f_x_vector_inc1_ = nullptr;
   std::unique_ptr<CudaArray<T>> dev_f_d_vector_inc1_ = nullptr;

--- a/src/rpucuda/cuda/rpucuda_pulsed_device_test.cpp
+++ b/src/rpucuda/cuda/rpucuda_pulsed_device_test.cpp
@@ -17,8 +17,8 @@
 #include "rpu_pulsed.h"
 #include "rpucuda_constantstep_device.h"
 #include "rpucuda_expstep_device.h"
-#include "rpucuda_hidden_device.h"
 #include "rpucuda_linearstep_device.h"
+#include "rpucuda_powstep_device.h"
 #include "rpucuda_pulsed.h"
 #include "rpucuda_pulsed_device.h"
 #include "utility_functions.h"
@@ -245,10 +245,11 @@ public:
 
 // types
 typedef ::testing::Types<
-    HiddenStepRPUDeviceMetaParameter<num_t>,
     LinearStepRPUDeviceMetaParameter<num_t>,
     ExpStepRPUDeviceMetaParameter<num_t>,
+    PowStepRPUDeviceMetaParameter<num_t>,
     ConstantStepRPUDeviceMetaParameter<num_t>>
+
     MetaPar;
 
 TYPED_TEST_CASE(RPUDeviceTestFixture, MetaPar);

--- a/src/rpucuda/rpu_linearstep_device.cpp
+++ b/src/rpucuda/rpu_linearstep_device.cpp
@@ -32,8 +32,6 @@ void LinearStepRPUDevice<T>::populate(
 
   for (int i = 0; i < this->d_size_; ++i) {
 
-    PulsedDPStruc<T> *s = this->sup_[i];
-
     for (int j = 0; j < this->x_size_; ++j) {
 
       T diff_slope_at_bound_up = par.ls_decrease_up + par.ls_decrease_up_dtod * rng->sampleGauss();
@@ -52,12 +50,14 @@ void LinearStepRPUDevice<T>::populate(
            bound, which does not make sense both slopes are negative
            (sign of scale_up/scale_down here both positive and later
            corrected in update rule) */
-        w_slope_up_[i][j] = -diff_slope_at_bound_up * s[j].scale_up / par.w_max;
-        w_slope_down_[i][j] = -diff_slope_at_bound_down * s[j].scale_down / par.w_min;
+        w_slope_up_[i][j] = -diff_slope_at_bound_up * this->w_scale_up_[i][j] / par.w_max;
+        w_slope_down_[i][j] = -diff_slope_at_bound_down * this->w_scale_down_[i][j] / par.w_min;
       } else {
         /* In this case slope depends on the bound*/
-        w_slope_up_[i][j] = -diff_slope_at_bound_up * s[j].scale_up / s[j].max_bound;
-        w_slope_down_[i][j] = -diff_slope_at_bound_down * s[j].scale_down / s[j].min_bound;
+        w_slope_up_[i][j] =
+            -diff_slope_at_bound_up * this->w_scale_up_[i][j] / this->w_max_bound_[i][j];
+        w_slope_down_[i][j] =
+            -diff_slope_at_bound_down * this->w_scale_down_[i][j] / this->w_min_bound_[i][j];
       }
     }
   }
@@ -78,14 +78,14 @@ template <typename T> void LinearStepRPUDevice<T>::printDP(int x_count, int d_co
     for (int j = 0; j < x_count; ++j) {
       std::cout.precision(5);
       std::cout << i << "," << j << ": ";
-      std::cout << "[<" << this->sup_[i][j].max_bound << ",";
-      std::cout << this->sup_[i][j].min_bound << ">,<";
-      std::cout << this->sup_[i][j].scale_up << ",";
-      std::cout << this->sup_[i][j].scale_down << ">,<";
+      std::cout << "[<" << this->w_max_bound_[i][j] << ",";
+      std::cout << this->w_min_bound_[i][j] << ">,<";
+      std::cout << this->w_scale_up_[i][j] << ",";
+      std::cout << this->w_scale_down_[i][j] << ">,<";
       std::cout << w_slope_up_[i][j] << ",";
       std::cout << w_slope_down_[i][j] << ">]";
       std::cout.precision(10);
-      std::cout << this->sup_[i][j].decay_scale << ", ";
+      std::cout << this->w_decay_scale_[i][j] << ", ";
       std::cout.precision(6);
       std::cout << this->w_diffusion_rate_[i][j] << ", ";
       std::cout << this->w_reset_bias_[i][j];

--- a/src/rpucuda/rpu_powstep_device.cpp
+++ b/src/rpucuda/rpu_powstep_device.cpp
@@ -70,14 +70,14 @@ template <typename T> void PowStepRPUDevice<T>::printDP(int x_count, int d_count
     for (int j = 0; j < x_count; ++j) {
       std::cout.precision(5);
       std::cout << i << "," << j << ": ";
-      std::cout << "[<" << this->sup_[i][j].max_bound << ",";
-      std::cout << this->sup_[i][j].min_bound << ">,<";
-      std::cout << this->sup_[i][j].scale_up << ",";
-      std::cout << this->sup_[i][j].scale_down << ">,<";
+      std::cout << "[<" << this->w_max_bound_[i][j] << ",";
+      std::cout << this->w_min_bound_[i][j] << ">,<";
+      std::cout << this->w_scale_up_[i][j] << ",";
+      std::cout << this->w_scale_down_[i][j] << ">,<";
       std::cout << w_gamma_up_[i][j] << ",";
       std::cout << w_gamma_down_[i][j] << ">]";
       std::cout.precision(10);
-      std::cout << this->sup_[i][j].decay_scale << ", ";
+      std::cout << this->w_decay_scale_[i][j] << ", ";
       std::cout.precision(6);
       std::cout << this->w_diffusion_rate_[i][j] << ", ";
       std::cout << this->w_reset_bias_[i][j];

--- a/src/rpucuda/rpu_pulsed_device.h
+++ b/src/rpucuda/rpu_pulsed_device.h
@@ -101,7 +101,6 @@ template <typename T> struct PulsedRPUDeviceMetaParameter : PulsedRPUDeviceMetaP
   virtual bool implementsWriteNoise() const { return false; }; // needs to be activated in derived
   inline bool usesPersistentWeight() const { return write_noise_std > 0; };
   inline T getScaledWriteNoise() const { return write_noise_std * this->dw_min; };
-  inline bool needsResetBias() const { return reset > 0 || reset_dtod > 0; };
 
   void initialize() override {
     PulsedRPUDeviceMetaParameterBase<T>::initialize();
@@ -110,7 +109,6 @@ template <typename T> struct PulsedRPUDeviceMetaParameter : PulsedRPUDeviceMetaP
     }
     reset_dtod = MAX(reset_dtod, (T)0.0);
     reset_std = MAX(reset_std, (T)0.0);
-    reset = MAX(reset, (T)0.0);
   };
 };
 
@@ -176,16 +174,6 @@ private:
   T weight_granularity_ = 0.0;
 };
 
-template <typename T> struct PulsedDPStruc {
-  T max_bound = (T)0.0;
-  T min_bound = (T)0.0;
-  T scale_up = (T)0.0;
-  T scale_down = (T)0.0;
-  T decay_scale = (T)0.0;
-  T diffusion_rate = (T)0.0;
-  T reset_bias = (T)0.0;
-};
-
 template <typename T> class PulsedRPUDevice : public PulsedRPUDeviceBase<T> {
 
 public:
@@ -215,7 +203,6 @@ public:
     swap(a.w_diffusion_rate_, b.w_diffusion_rate_);
     swap(a.w_persistent_, b.w_persistent_);
     swap(a.w_reset_bias_, b.w_reset_bias_);
-    swap(a.sup_, b.sup_);
 
     swap(a.containers_allocated_, b.containers_allocated_);
   }
@@ -235,7 +222,6 @@ public:
   inline T **getResetBias() const { return w_reset_bias_; };
   inline T **getScaleUp() const { return w_scale_up_; };
   inline T **getScaleDown() const { return w_scale_down_; };
-  inline PulsedDPStruc<T> **getDPStruc() const { return sup_; };
   PulsedRPUDeviceMetaParameter<T> &getPar() const override {
     return static_cast<PulsedRPUDeviceMetaParameter<T> &>(SimpleRPUDevice<T>::getPar());
   };
@@ -258,8 +244,6 @@ public:
 
 protected:
   void populate(const PulsedRPUDeviceMetaParameter<T> &par, RealWorldRNG<T> *rng);
-
-  PulsedDPStruc<T> **sup_ = nullptr;
 
   T **w_max_bound_ = nullptr;
   T **w_min_bound_ = nullptr;

--- a/tests/test_specific_tiles.py
+++ b/tests/test_specific_tiles.py
@@ -82,7 +82,6 @@ class TransferCompoundTest(ParametrizedTestCase):
 
             model.analog_tile.set_hidden_parameters(params)
 
-            print(model.analog_tile.tile)
             weight, bias = model.get_weights()
 
             # should be
@@ -99,9 +98,11 @@ class TransferCompoundTest(ParametrizedTestCase):
 
         lifetime = 100.  # initial setting (needs to be larger 1)
         gamma = 0.1
+        reset_bias = 0.1  # decay shift
         rpu_config = self.get_transfer_compound(gamma=gamma,
                                                 lifetime=lifetime,
-                                                lifetime_dtod=0.0)
+                                                lifetime_dtod=0.0,
+                                                reset=reset_bias)
 
         model = self.get_layer(in_features=2, out_features=1, rpu_config=rpu_config)
 
@@ -145,10 +146,10 @@ class TransferCompoundTest(ParametrizedTestCase):
         weight, bias = model.get_weights()
 
         # reference values
-        a = a * pow(a_dcy, epochs)
-        b = b * pow(b_dcy, epochs)
-        c = c * pow(c_dcy, epochs)
-        d = d * pow(d_dcy, epochs)
+        a = (a - reset_bias) * pow(a_dcy, epochs) + reset_bias
+        b = (b - reset_bias) * pow(b_dcy, epochs) + reset_bias
+        c = (c - reset_bias) * pow(c_dcy, epochs) + reset_bias
+        d = (d - reset_bias) * pow(d_dcy, epochs) + reset_bias
 
         if self.digital_bias:
             self.assertEqual(bias[0], 0.0)


### PR DESCRIPTION
## Related issues

closes #315 

## Description

Decay (set with lifetime) is now changed for pulsed devices  to decay to the `reset_bias` which is given by the `reset` (mean) and `reset_dtod` parameters. 

## Details

Please take a look at this [test](https://github.com/IBM/aihwkit/blob/master/tests/test_specific_tiles.py#L96) to see how one could set arbitrary decay points by setting the `reset_bias`.
