### PR TITLE
Linear layer mapped to multiple tiles of given physical size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Transposed-read for ``TransferCompound``. (\#312)
 * ``BufferedTranferCompound`` and TTv2 presets. (\#318)
 * Stochastic rounding for ``MixedPrecisionCompound``. (\#318)
-
+* Linear layer ``AnalogLinerMapped`` which mapped a large weight
+  matrix onto multiple analog tiles. (\#320)
 
 ### Fixed
 
@@ -35,8 +36,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Fixed issue in transfer counter for mixed precision in case of GPU. (\#283)
 * Map location keyword for load / save observed. (\#293)
 * Fixed issue with CUDA buffer allocation when batch size changed. (\#294)
-* Fixed missing load statedict for AnalogSequential. (\#295) 
+* Fixed missing load statedict for AnalogSequential. (\#295)
 * Fixed issue with hierarchical hidden parameter settings. (\#313)
+* Fixed serious issue that loaded model would not update analog gradients. (\#320)
 
 ### Changed
 
@@ -45,9 +47,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Some of the parameter names of the``TransferCompound`` have
   changed. (\#312)
 * New fast learning rate parameter for TransferCompound, SGD learning
-  rate then is applied on the slow matrix (\#312). 
+  rate then is applied on the slow matrix (\#312).
 * The ``fixed_value`` of ``WeightClipParameter`` is now  applied for all clipping
   types if set larger than zero. (\#318)
+* Gererator for analog tiles of an AnalogModule. (\#320)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Transposed-read for ``TransferCompound``. (\#312)
 * ``BufferedTranferCompound`` and TTv2 presets. (\#318)
 * Stochastic rounding for ``MixedPrecisionCompound``. (\#318)
-* Decay with arbitrary decay point (to reset bias). (\#319) 
+* Decay with arbitrary decay point (to reset bias). (\#319)
 * Linear layer ``AnalogLinerMapped`` which mapped a large weight
   matrix onto multiple analog tiles. (\#320)
 
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Fixed missing load statedict for AnalogSequential. (\#295)
 * Fixed issue with hierarchical hidden parameter settings. (\#313)
 * Fixed serious issue that loaded model would not update analog gradients. (\#320)
+* Fixed cuda import in examples. (\#320)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Transposed-read for ``TransferCompound``. (\#312)
 * ``BufferedTranferCompound`` and TTv2 presets. (\#318)
 * Stochastic rounding for ``MixedPrecisionCompound``. (\#318)
+* Decay with arbitrary decay point (to reset bias). (\#319) 
 * Linear layer ``AnalogLinerMapped`` which mapped a large weight
   matrix onto multiple analog tiles. (\#320)
 

--- a/examples/04_lenet5_training.py
+++ b/examples/04_lenet5_training.py
@@ -35,12 +35,13 @@ from aihwkit.nn import AnalogConv2d, AnalogLinear, AnalogSequential
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import SingleRPUConfig, FloatingPointRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice, FloatingPointDevice
+from aihwkit.simulator.rpu_base import cuda
 
 # Check device
 USE_CUDA = 0
-DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-if torch.cuda.is_available():
+if cuda.is_compiled():
     USE_CUDA = 1
+DEVICE = torch.device('cuda' if USE_CUDA else 'cpu')
 
 # Path to store datasets
 PATH_DATASET = os.path.join('data', 'DATASET')

--- a/examples/06_lenet5_hardware_aware.py
+++ b/examples/06_lenet5_hardware_aware.py
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # Imports from PyTorch.
-from torch import nn, device, cuda, manual_seed, no_grad
+from torch import nn, device, manual_seed, no_grad
 from torch import max as torch_max
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
@@ -34,12 +34,13 @@ from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import InferenceRPUConfig
 from aihwkit.simulator.configs.utils import BoundManagementType, WeightNoiseType
 from aihwkit.inference import PCMLikeNoiseModel
+from aihwkit.simulator.rpu_base import cuda
 
 # Check device
 USE_CUDA = 0
-DEVICE = device('cuda' if cuda.is_available() else 'cpu')
-if cuda.is_available():
+if cuda.is_compiled():
     USE_CUDA = 1
+DEVICE = device('cuda' if USE_CUDA else 'cpu')
 
 # Path to store datasets
 PATH_DATASET = os.path.join('data', 'DATASET')

--- a/examples/11_vgg8_training.py
+++ b/examples/11_vgg8_training.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # Imports from PyTorch.
-from torch import nn, Tensor, cuda, device, no_grad, manual_seed
+from torch import nn, Tensor, device, no_grad, manual_seed
 from torch import max as torch_max
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
@@ -34,13 +34,13 @@ from torchvision import datasets, transforms
 from aihwkit.nn import AnalogConv2d, AnalogLinear, AnalogSequential
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.presets.configs import GokmenVlasovPreset
-
+from aihwkit.simulator.rpu_base import cuda
 
 # Check device
 USE_CUDA = 0
-DEVICE = device('cuda' if cuda.is_available() else 'cpu')
-if cuda.is_available():
+if cuda.is_compiled():
     USE_CUDA = 1
+DEVICE = device('cuda' if USE_CUDA else 'cpu')
 
 # Path to store datasets
 PATH_DATASET = os.path.join('data', 'DATASET')

--- a/examples/13_experiment_3fc.py
+++ b/examples/13_experiment_3fc.py
@@ -31,12 +31,13 @@ from aihwkit.experiments.runners import LocalRunner
 from aihwkit.nn import AnalogLinear, AnalogSequential
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
+from aihwkit.simulator.rpu_base import cuda
 
 # Check device
 USE_CUDA = 0
-DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-if torch.cuda.is_available():
+if cuda.is_compiled():
     USE_CUDA = 1
+DEVICE = torch.device('cuda' if USE_CUDA else 'cpu')
 
 # Path where the datasets will be stored.
 PATH_DATASET = os.path.join('data', 'DATASET')

--- a/examples/14_experiment_custom_scheduler.py
+++ b/examples/14_experiment_custom_scheduler.py
@@ -32,12 +32,13 @@ from aihwkit.experiments.runners import LocalRunner
 from aihwkit.nn import AnalogLinear, AnalogSequential
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
+from aihwkit.simulator.rpu_base import cuda
 
 # Check device
 USE_CUDA = 0
-DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-if torch.cuda.is_available():
+if cuda.is_compiled():
     USE_CUDA = 1
+DEVICE = torch.device('cuda' if USE_CUDA else 'cpu')
 
 # Path where the datasets will be stored.
 PATH_DATASET = os.path.join('data', 'DATASET')

--- a/examples/16_mnist_gan.py
+++ b/examples/16_mnist_gan.py
@@ -43,6 +43,7 @@ from matplotlib import animation
 from aihwkit.nn import AnalogLinear, AnalogSequential
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.presets import MixedPrecisionEcRamMOPreset
+from aihwkit.simulator.rpu_base import cuda
 
 # Select the device model to use in the training.
 
@@ -64,9 +65,9 @@ LR = 2e-2
 
 # Check device
 USE_CUDA = 0
-DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-if torch.cuda.is_available():
+if cuda.is_compiled():
     USE_CUDA = 1
+DEVICE = torch.device('cuda' if USE_CUDA else 'cpu')
 
 # Path where the datasets will be stored.
 PATH_DATASET = os.path.join('data', 'DATASET')

--- a/examples/18_cifar10_on_resnet.py
+++ b/examples/18_cifar10_on_resnet.py
@@ -22,7 +22,7 @@ import os
 from datetime import datetime
 
 # Imports from PyTorch.
-from torch import nn, Tensor, cuda, device, no_grad, manual_seed, save
+from torch import nn, Tensor, device, no_grad, manual_seed, save
 from torch import max as torch_max
 from torch.utils.data import DataLoader
 import torch.nn.functional as F
@@ -33,12 +33,13 @@ from torchvision import datasets, transforms
 from aihwkit.optim import AnalogSGD
 from aihwkit.nn.conversion import convert_to_analog
 from aihwkit.simulator.presets import TikiTakaEcRamPreset
+from aihwkit.simulator.rpu_base import cuda
 
 # Device to use
 USE_CUDA = 0
-DEVICE = device('cuda' if cuda.is_available() else 'cpu')
-if cuda.is_available():
+if cuda.is_compiled():
     USE_CUDA = 1
+DEVICE = device('cuda' if USE_CUDA else 'cpu')
 
 # Path to store datasets
 PATH_DATASET = os.path.join(os.getcwd(), 'data', 'DATASET')

--- a/src/aihwkit/nn/__init__.py
+++ b/src/aihwkit/nn/__init__.py
@@ -18,3 +18,4 @@ from aihwkit.nn.modules.container import AnalogSequential
 from aihwkit.nn.modules.conv import AnalogConv1d, AnalogConv2d, AnalogConv3d
 from aihwkit.nn.modules.linear import AnalogLinear
 from aihwkit.nn.modules.lstm import AnalogLSTM
+from aihwkit.nn.modules.linear_mapped import AnalogLinearMapped

--- a/src/aihwkit/nn/modules/linear_mapped.py
+++ b/src/aihwkit/nn/modules/linear_mapped.py
@@ -1,0 +1,348 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Analog mapped layers."""
+
+from typing import Optional, Tuple, List
+
+from torch import Tensor, cat, split, no_grad
+from torch.nn import Linear
+
+from aihwkit.nn.modules.base import RPUConfigAlias
+from aihwkit.nn.functions import AnalogFunction
+from aihwkit.nn.modules.base import AnalogModuleBase
+from aihwkit.simulator.configs import SingleRPUConfig
+from aihwkit.exceptions import ModuleError
+
+
+class AnalogLinearMapped(AnalogModuleBase, Linear):
+    """Linear layer that uses an analog tile.
+
+    Linear layer that uses an analog tile during its forward, backward
+    and update passes. In contrast to
+    :class:`~aihwkit.bb.modules.linear.Linear` the maximal in and/or
+    out dimension can be restricted, in which case the linear layer is
+    split into multiple parts and computed on multiple tiles of given
+    max sizes.
+
+    In contrast to :class:`~aihwkit.bb.modules.linear.Linear`, the
+    bias vector (if requested) is always handled in digital (floating
+    point).
+
+    Note:
+        Mapping is controlled by the :class:`aihwkit.simulator.configs.utils.MappingParameter`.
+
+    Note:
+        The tensor parameters of this layer (``.weight`` and ``.bias``) are not
+        guaranteed to contain the same values as the internal weights and biases
+        stored in the analog tile. Please use ``set_weights`` and
+        ``get_weights`` when attempting to read or modify the weight/bias. This
+        read/write process can simulate the (noisy and inexact) analog writing
+        and reading of the resistive elements.
+
+    Args:
+        in_features: input vector size (number of columns).
+        out_features: output vector size (number of rows).
+        rpu_config: resistive processing unit configuration.
+        bias: whether to use a bias row on the analog tile or not
+        realistic_read_write: whether to enable realistic read/write
+            for setting initial weights and read out of weights
+        weight_scaling_omega: the weight value where the max
+            weight will be scaled to. If zero, no weight scaling will
+            be performed
+
+    """
+    # pylint: disable=abstract-method, too-many-locals, too-many-instance-attributes
+
+    __constants__ = ['in_features', 'out_features', 'realistic_read_write', 'weight_scaling_omega',
+                     'digital_bias', 'analog_bias', 'use_bias']
+    in_features: int
+    out_features: int
+    realistic_read_write: bool
+    weight_scaling_omega: float
+    digital_bias: bool
+    analog_bias: bool
+    use_bias: bool
+    in_sizes: List[int]
+    out_sizes: List[int]
+
+    def __init__(
+            self,
+            in_features: int,
+            out_features: int,
+            bias: bool = True,
+            rpu_config: Optional[RPUConfigAlias] = None,
+            realistic_read_write: bool = False,
+            weight_scaling_omega: float = 0.0,
+            digital_bias: bool = True,
+    ):
+
+        AnalogModuleBase.__init__(self)
+
+        if bias and not digital_bias:
+            raise ModuleError("AnalogMappedLayer only supports digital bias.")
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_bias = bias
+        self.analog_bias = False
+        self.digital_bias = bias
+
+        self.realistic_read_write = realistic_read_write
+        self.weight_scaling_omega = weight_scaling_omega
+
+        if not rpu_config:
+            rpu_config = SingleRPUConfig()
+
+        # Call super() after tile creation, including ``reset_parameters``.
+        Linear.__init__(self, in_features, out_features, bias=bias)
+
+        # Create the tile(s)
+        # More than one tile may need to be created. If so, divide
+        # weight matrix into equal pieces along input dimension with
+        # as many tiles as needed
+        max_input_size = rpu_config.mapping.max_input_size
+        max_output_size = rpu_config.mapping.max_output_size
+        self.in_sizes = self.get_split_sizes(in_features, max_input_size)
+        self.out_sizes = self.get_split_sizes(out_features, max_output_size)
+
+        self.analog_tile_array = []
+        for i, in_tile_size in enumerate(self.in_sizes):
+            in_tiles = []
+            for j, out_tile_size in enumerate(self.out_sizes):
+                tile = rpu_config.tile_class(out_tile_size,
+                                             in_tile_size,
+                                             rpu_config,
+                                             bias=self.analog_bias)
+                self.register_analog_tile(tile, name=f"{i}_{j}")
+                in_tiles.append(tile)
+            self.analog_tile_array.append(in_tiles)
+
+        # Set weights from the reset_parameters call (since only now the
+        # analog_tiles are registered)
+        self.set_weights(self.weight, self.bias)
+
+        # Unregister weight/bias as a parameter but keep it as a
+        # field (needed for syncing still)
+        self.unregister_parameter('weight')
+
+        if self.analog_bias:
+            self.unregister_parameter('bias')
+
+    def get_split_sizes(self, size: int, split_max_size: int) -> List[int]:
+        """ Computed the split sizes.
+
+        Args:
+            size: number of elements of the layer in one dimension
+            split_max_size: max size of the split
+
+        Returns:
+            List of split sizes
+        """
+        n_splits = (size + split_max_size - 1) // split_max_size
+        base, extra = divmod(size, n_splits)
+        return [base + (i < extra) for i in range(n_splits)]
+
+    def set_weights(
+            self,
+            weight: Tensor,
+            bias: Optional[Tensor] = None,
+            force_exact: bool = False
+    ) -> None:
+        """Set the weight (and bias) with given Tensors.
+
+        This uses an realistic write if the property ``realistic_read_write``
+        of the layer is set, unless it is overwritten by ``force_exact``. It
+        uses a scaled write if ``weight_scaling_omega`` is positive (see
+        :meth:`~aihwkit.simulator.tiles.base.BaseTile.set_weights_scaled`).
+
+        Note:
+            This is the recommended way for setting the weight/bias matrix of
+            the analog tile, as it will correctly store the weights into the
+            internal memory. Directly writing to ``self.weight`` and
+            ``self.bias`` might yield wrong results as they are not always in
+            sync with the analog tile Parameters, for performance reasons.
+
+        Args:
+            weight: weight matrix
+            bias: bias vector
+            force_exact: forces an exact write to the analog tiles
+
+        """
+        shape = [self.out_features, self.in_features]
+        weight = weight.clone().reshape(shape)
+
+        realistic = self.realistic_read_write and not force_exact
+
+        in_start = in_end = 0
+        for in_size, in_tiles in zip(self.in_sizes, self.analog_tile_array):
+            in_end += in_size
+            out_start = out_end = 0
+            for out_size, analog_tile in zip(self.out_sizes, in_tiles):
+                out_end += out_size
+
+                tile_weight = weight[out_start:out_end, in_start:in_end]
+
+                if self.weight_scaling_omega > 0.0:
+                    analog_tile.set_weights_scaled(tile_weight, None,
+                                                   realistic=realistic,
+                                                   omega=self.weight_scaling_omega)
+                else:
+                    analog_tile.set_weights(tile_weight, None, realistic=realistic)
+
+                out_start = out_end
+            in_start = in_end
+
+        if self.use_bias and bias is not None:
+            with no_grad():
+                self.bias.data[:] = bias[:]
+
+        self._sync_weights_from_tile()
+
+    def get_weights(self, force_exact: bool = False) -> Tuple[Tensor, Optional[Tensor]]:
+        """Get the weight (and bias) tensors.
+
+        This uses an realistic read if the property ``realistic_read_write`` of
+        the layer is set, unless it is overwritten by ``force_exact``. It
+        scales the analog weights by the digital alpha scale if
+        ``weight_scaling_omega`` is positive (see
+        :meth:`~aihwkit.simulator.tiles.base.BaseTile.get_weights_scaled`).
+
+        Note:
+            This is the recommended way for setting the weight/bias matrix from
+            the analog tile, as it will correctly fetch the weights from the
+            internal memory. Accessing ``self.weight`` and ``self.bias`` might
+            yield wrong results as they are not always in sync with the
+            analog tile library, for performance reasons.
+
+        Args:
+            force_exact: forces an exact read to the analog tiles
+
+        Returns:
+            tuple: weight matrix, bias vector
+
+        """
+
+        realistic = self.realistic_read_write and not force_exact
+
+        weight_lst = []
+        for in_tiles in self.analog_tile_array:
+            in_tile_weight = []
+            for analog_tile in in_tiles:
+                if self.weight_scaling_omega > 0.0:
+                    tile_weight, _ = analog_tile.get_weights_scaled(realistic=realistic)
+                else:
+                    tile_weight, _ = analog_tile.get_weights(realistic=realistic)
+                in_tile_weight.append(tile_weight)
+            weight_lst.append(cat(in_tile_weight, 0))
+
+        weight = cat(weight_lst, 1)
+
+        if self.digital_bias:
+            with no_grad():
+                return weight, self.bias.data.detach().cpu()
+        return weight, None
+
+    def reset_parameters(self) -> None:
+        """Reset the parameters (weight and bias)."""
+        super().reset_parameters()
+        if self.analog_tile_count():
+            self.set_weights(self.weight, self.bias)
+
+    def forward(self, x_input: Tensor) -> Tensor:
+        """Compute the forward pass."""
+        # pylint: disable=arguments-differ,arguments-renamed
+
+        if self.analog_tile_count() == 1:
+            out = AnalogFunction.apply(
+                self.analog_tile_array[0][0].get_analog_ctx(), x_input,
+                self.analog_tile_array[0][0].shared_weights, not self.training)
+
+            if self.digital_bias:
+                return out + self.bias
+            return out
+
+        # mapped version
+        last_dim = x_input.ndim - 1
+        splits = split(x_input, self.in_sizes, dim=last_dim)
+        result = None  # type: Tensor
+        for idx, (x, in_tiles) in enumerate(zip(splits, self.analog_tile_array)):
+            out_result = []
+
+            for analog_tile in in_tiles:
+                output = AnalogFunction.apply(
+                    analog_tile.get_analog_ctx(), x,
+                    analog_tile.shared_weights, not self.training)
+                out_result.append(output)
+
+            if idx == 0:
+                result = cat(out_result, last_dim)
+            else:
+                result.add_(cat(out_result, last_dim))
+
+        # add bias to final result
+        if self.digital_bias:
+            return result.add_(self.bias)
+        return result
+
+    def extra_repr(self) -> str:
+        """Set the extra representation of the module.
+
+        Returns:
+            A string with the extra representation.
+        """
+        output = AnalogModuleBase.extra_repr(self)[:-1]
+        output += ', mapping={}'.format((len(self.in_sizes), len(self.out_sizes)))
+
+        return output
+
+    @classmethod
+    def from_digital(
+            cls,
+            module: Linear,
+            rpu_config: Optional[RPUConfigAlias] = None,
+            realistic_read_write: bool = False,
+            weight_scaling_omega: float = 0.0,
+            digital_bias: bool = False,
+    ) -> 'AnalogLinearMapped':
+        """Return an AnalogLinearMapped layer from a torch Linear layer.
+
+        Args:
+            module: The torch module to convert. All layers that are
+                defined in the ``conversion_map``.
+            rpu_config: RPU config to apply to all converted tiles.
+                Applied to all converted tiles.
+            realistic_read_write: Whether to use closed-loop programming
+                when setting the weights. Applied to all converted tiles.
+            weight_scaling_omega: If non-zero, applied weights of analog
+                layers will be scaled by ``weight_scaling_omega`` divided by
+                the absolute maximum value of the original weight matrix.
+            digital_bias: decide whether the bias term is handled by the analog tile
+                or kept in digital.
+
+                Note:
+                    Make sure that the weight max and min setting of the
+                    device support the desired analog weight range.
+
+        Returns:
+            an AnalogLinearMapped layer based on the digital Linear ``module``.
+        """
+        analog_module = cls(module.in_features,
+                            module.out_features,
+                            module.bias is not None,
+                            rpu_config,
+                            realistic_read_write,
+                            weight_scaling_omega,
+                            digital_bias)
+
+        analog_module.set_weights(module.weight, module.bias)
+        return analog_module

--- a/src/aihwkit/optim/analog_optimizer.py
+++ b/src/aihwkit/optim/analog_optimizer.py
@@ -85,6 +85,7 @@ class AnalogOptimizerMixin:
             # Use analog_tile object.
             for param in group['params']:
                 if isinstance(param, AnalogContext):
+
                     # Handle internal analog update.
                     analog_ctx = param
                     analog_tile = analog_ctx.analog_tile

--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -24,7 +24,7 @@ from aihwkit.simulator.configs.helpers import (
 )
 from aihwkit.simulator.configs.utils import (
     IOParameters, PulseType, UpdateParameters, WeightClipParameter,
-    WeightModifierParameter
+    WeightModifierParameter, MappingParameter
 )
 from aihwkit.inference import (
     BaseDriftCompensation, BaseNoiseModel, GlobalDriftCompensation,
@@ -36,18 +36,26 @@ from aihwkit.simulator.tiles import AnalogTile, FloatingPointTile, InferenceTile
 
 
 @dataclass
-class FloatingPointRPUConfig(_PrintableMixin):
+class BaseRPUConfig(_PrintableMixin):
+    """ Base class  for RPUConfigs """
+
+    mapping: MappingParameter = field(default_factory=MappingParameter)
+    """Parameter related to mapping weights to tiles for supporting modules."""
+
+
+@dataclass
+class FloatingPointRPUConfig(BaseRPUConfig):
     """Configuration for a floating point resistive processing unit."""
 
     tile_class: ClassVar[Type] = FloatingPointTile
     """Tile class that correspond to this RPUConfig."""
 
     device: FloatingPointDevice = field(default_factory=FloatingPointDevice)
-    """Parameters that modify the behavior of the pulsed device."""
+    """Parameter that modify the behavior of the pulsed device."""
 
 
 @dataclass
-class SingleRPUConfig(_PrintableMixin):
+class SingleRPUConfig(BaseRPUConfig):
     """Configuration for an analog (pulsed device) resistive processing unit."""
 
     tile_class: ClassVar[Type] = AnalogTile
@@ -56,7 +64,7 @@ class SingleRPUConfig(_PrintableMixin):
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 
     device: PulsedDevice = field(default_factory=ConstantStepDevice)
-    """Parameters that modify the behavior of the pulsed device."""
+    """Parameter that modify the behavior of the pulsed device."""
 
     forward: IOParameters = field(default_factory=IOParameters)
     """Input-output parameter setting for the forward direction."""
@@ -73,7 +81,7 @@ class SingleRPUConfig(_PrintableMixin):
 
 
 @dataclass
-class UnitCellRPUConfig(_PrintableMixin):
+class UnitCellRPUConfig(BaseRPUConfig):
     """Configuration for an analog (unit cell) resistive processing unit."""
 
     tile_class: ClassVar[Type] = AnalogTile
@@ -82,7 +90,7 @@ class UnitCellRPUConfig(_PrintableMixin):
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 
     device: UnitCell = field(default_factory=UnitCell)
-    """Parameters that modify the behavior of the pulsed device."""
+    """Parameter that modify the behavior of the pulsed device."""
 
     forward: IOParameters = field(default_factory=IOParameters)
     """Input-output parameter setting for the forward direction."""
@@ -99,7 +107,7 @@ class UnitCellRPUConfig(_PrintableMixin):
 
 
 @dataclass
-class InferenceRPUConfig(_PrintableMixin):
+class InferenceRPUConfig(BaseRPUConfig):
     """Configuration for an analog tile that is used only for inference.
 
     Training is done in *hardware-aware* manner, thus using only the
@@ -126,17 +134,17 @@ class InferenceRPUConfig(_PrintableMixin):
     """For compensating the drift during inference only."""
 
     clip: WeightClipParameter = field(default_factory=WeightClipParameter)
-    """Parameters for weight clip."""
+    """Parameter for weight clip."""
 
     modifier: WeightModifierParameter = field(default_factory=WeightModifierParameter)
-    """Parameters for weight modifier."""
+    """Parameter for weight modifier."""
 
     # The following fields are not included in `__init__`, and should be
     # treated as read-only.
 
     device: IdealDevice = field(default_factory=IdealDevice,
                                 init=False)
-    """Parameters that modify the behavior of the pulsed device: ideal device."""
+    """Parameter that modify the behavior of the pulsed device: ideal device."""
 
     backward: IOParameters = field(
         default_factory=lambda: IOParameters(is_perfect=True),
@@ -156,7 +164,7 @@ class InferenceRPUConfig(_PrintableMixin):
 
 
 @dataclass
-class DigitalRankUpdateRPUConfig(_PrintableMixin):
+class DigitalRankUpdateRPUConfig(BaseRPUConfig):
     """Configuration for an analog (unit cell) resistive processing unit
     where the rank update is done in digital.
 
@@ -171,7 +179,7 @@ class DigitalRankUpdateRPUConfig(_PrintableMixin):
     bindings_class: ClassVar[Type] = devices.AnalogTileParameter
 
     device: DigitalRankUpdateCell = field(default_factory=DigitalRankUpdateCell)
-    """Parameters that modify the behavior of the pulsed device."""
+    """Parameter that modify the behavior of the pulsed device."""
 
     forward: IOParameters = field(default_factory=IOParameters)
     """Input-output parameter setting for the forward direction."""

--- a/src/aihwkit/simulator/configs/helpers.py
+++ b/src/aihwkit/simulator/configs/helpers.py
@@ -25,7 +25,7 @@ def parameters_to_bindings(params: Any) -> Any:
     result = params.bindings_class()
     for field, value in params.__dict__.items():
         # Convert enums to the bindings enums.
-        if field in ('unit_cell_devices', 'device'):
+        if field in ('unit_cell_devices', 'device', 'mapping'):
             # Exclude special fields that are not present in the bindings.
             continue
 
@@ -49,7 +49,7 @@ def tile_parameters_to_bindings(params: Any) -> Any:
     field_map = {'forward': 'forward_io',
                  'backward': 'backward_io'}
     excluded_fields = ('device', 'noise_model', 'drift_compensation',
-                       'clip', 'modifier')
+                       'clip', 'modifier', 'mapping')
 
     result = params.bindings_class()
     for field, value in params.__dict__.items():

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -243,7 +243,7 @@ class VectorUnitCellUpdatePolicy(Enum):
 
 @dataclass
 class IOParameters(_PrintableMixin):
-    """Parameters that modify the IO behavior."""
+    """Parameter that modify the IO behavior."""
 
     bindings_class: ClassVar[Type] = devices.AnalogTileInputOutputParameter
 
@@ -699,3 +699,22 @@ class DriftParameter(SimpleDriftParameter):
     w_noise_std: float = 0.0
     """Additional weight noise (Gaussian diffusion) added to the weights
     after the drift is applied."""
+
+
+@dataclass
+class MappingParameter(_PrintableMixin):
+    """Parameter related to the mapping of logical weights to physical tiles.
+
+    Note:
+
+        These parameters have only an affect for modules that
+        support mappings.
+    """
+
+    max_input_size: int = 512
+    """Maximal size of the physical in the input dimension.
+    """
+
+    max_output_size: int = 512
+    """Maximal size of the physical in the output dimension.
+    """

--- a/src/rpucuda/cuda/cuda_util.cu
+++ b/src/rpucuda/cuda/cuda_util.cu
@@ -447,7 +447,7 @@ void CudaContext::enforceDeviceId() const {
   int gpu_id;
   CUDA_CALL(cudaGetDevice(&gpu_id));
   if (gpu_id != gpu_id_) {
-    std::cout << "WARNING wrong device detected: " << gpu_id << " vs. " << gpu_id_ << std::endl;
+    // std::cout << "WARNING wrong device detected: " << gpu_id << " vs. " << gpu_id_ << std::endl;
     CUDA_CALL(cudaSetDevice(gpu_id_));
   }
 #endif

--- a/tests/helpers/decorators.py
+++ b/tests/helpers/decorators.py
@@ -72,6 +72,7 @@ def parametrize_over_layers(layers: List, tiles: List, biases: List, digital_bia
         ret['get_rpu_config'] = tile.get_rpu_config
         ret['bias'] = bias
         ret['digital_bias'] = digital_bias
+        ret['tile_class'] = tile
 
         return ret
 

--- a/tests/helpers/layers.py
+++ b/tests/helpers/layers.py
@@ -10,11 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=missing-function-docstring,too-few-public-methods
+# pylint: disable=missing-function-docstring, too-few-public-methods, no-member
 
 """Layer helpers for aihwkit tests."""
 
-from aihwkit.nn import AnalogConv1d, AnalogConv2d, AnalogConv3d, AnalogLinear, AnalogLSTM
+from aihwkit.nn import (
+    AnalogConv1d, AnalogConv2d, AnalogConv3d, AnalogLinear, AnalogLSTM, AnalogLinearMapped
+)
+from aihwkit.simulator.configs.utils import MappingParameter
 
 
 class Linear:
@@ -25,8 +28,26 @@ class Linear:
     def get_layer(self, in_features=3, out_features=4, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('digital_bias', self.digital_bias)
 
         return AnalogLinear(in_features, out_features, **kwargs)
+
+
+class LinearMapped:
+    """AnalogLinearMapped."""
+
+    use_cuda = False
+
+    def get_rpu_config(self, **kwargs):
+        kwargs.setdefault('mapping', MappingParameter(max_input_size=4, max_output_size=3))
+        return super().get_rpu_config(**kwargs)
+
+    def get_layer(self, in_features=10, out_features=6, **kwargs):
+
+        kwargs.setdefault('rpu_config', self.get_rpu_config())
+        kwargs.setdefault('bias', self.bias)
+
+        return AnalogLinearMapped(in_features, out_features, **kwargs)
 
 
 class Conv1d:
@@ -37,6 +58,7 @@ class Conv1d:
     def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('digital_bias', self.digital_bias)
 
         return AnalogConv1d(in_channels, out_channels, kernel_size,
                             padding=padding,
@@ -51,6 +73,7 @@ class Conv2d:
     def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('digital_bias', self.digital_bias)
 
         return AnalogConv2d(in_channels, out_channels, kernel_size,
                             padding=padding,
@@ -65,6 +88,7 @@ class Conv3d:
     def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('digital_bias', self.digital_bias)
 
         return AnalogConv3d(in_channels, out_channels, kernel_size,
                             padding=padding,
@@ -91,8 +115,25 @@ class LinearCuda:
     def get_layer(self, in_features=3, out_features=4, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('digital_bias', self.digital_bias)
 
         return AnalogLinear(in_features, out_features, **kwargs).cuda()
+
+
+class LinearMappedCuda:
+    """AnalogLinearMapped."""
+
+    use_cuda = True
+
+    def get_rpu_config(self, **kwargs):
+        kwargs.setdefault('mapping', MappingParameter(max_input_size=4, max_output_size=3))
+        return super().get_rpu_config(**kwargs)
+
+    def get_layer(self, in_features=10, out_features=6, **kwargs):
+        kwargs.setdefault('rpu_config', self.get_rpu_config())
+        kwargs.setdefault('bias', self.bias)
+
+        return AnalogLinearMapped(in_features, out_features, **kwargs).cuda()
 
 
 class Conv1dCuda:
@@ -103,6 +144,7 @@ class Conv1dCuda:
     def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('digital_bias', self.digital_bias)
 
         return AnalogConv1d(in_channels, out_channels, kernel_size,
                             padding=padding,
@@ -117,6 +159,7 @@ class Conv2dCuda:
     def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('digital_bias', self.digital_bias)
 
         return AnalogConv2d(in_channels, out_channels, kernel_size,
                             padding=padding,
@@ -131,6 +174,7 @@ class Conv3dCuda:
     def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('digital_bias', self.digital_bias)
 
         return AnalogConv3d(in_channels, out_channels, kernel_size,
                             padding=padding,

--- a/tests/helpers/testcases.py
+++ b/tests/helpers/testcases.py
@@ -33,7 +33,8 @@ class AihwkitTestCase(TestCase):
     def assertNotAlmostEqualTensor(self, tensor_a, tensor_b, decimal=6):
         """Assert that two tensors are not equal."""
         # pylint: disable=invalid-name
-        assert_raises(AssertionError, self.assertTensorAlmostEqual, tensor_a, tensor_b, decimal)
+        assert_raises(AssertionError, self.assertTensorAlmostEqual, tensor_a, tensor_b,
+                      decimal=decimal)
 
 
 class ParametrizedTestCase(AihwkitTestCase):

--- a/tests/helpers/tiles.py
+++ b/tests/helpers/tiles.py
@@ -65,7 +65,10 @@ class Ideal:
     use_cuda = False
 
     def get_rpu_config(self):
-        return SingleRPUConfig(device=IdealDevice())
+        rpu_config = SingleRPUConfig(device=IdealDevice())
+        rpu_config.forward.is_perfect = True
+        rpu_config.backward.is_perfect = True
+        return rpu_config
 
     def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
         rpu_config = rpu_config or self.get_rpu_config()
@@ -347,7 +350,10 @@ class IdealCuda:
     use_cuda = True
 
     def get_rpu_config(self):
-        return SingleRPUConfig(device=IdealDevice())
+        rpu_config = SingleRPUConfig(device=IdealDevice())
+        rpu_config.forward.is_perfect = True
+        rpu_config.backward.is_perfect = True
+        return rpu_config
 
     def get_tile(self, out_size, in_size, rpu_config=None, **kwargs):
         rpu_config = rpu_config or self.get_rpu_config()

--- a/tests/test_inference_tiles.py
+++ b/tests/test_inference_tiles.py
@@ -70,6 +70,8 @@ class InferenceTileTest(ParametrizedTestCase):
         opt.regroup_param_groups(model)
 
         for _ in range(100):
+            opt.zero_grad()
+
             # Add the training Tensor to the model (input).
             pred = model(x)
             # Add the expected output Tensor.

--- a/tests/test_layers_linear.py
+++ b/tests/test_layers_linear.py
@@ -221,6 +221,7 @@ class LinearLayerTest(ParametrizedTestCase):
             model = model.cuda()
         opt = AnalogSGD(model.parameters(), lr=0.5)
         opt.regroup_param_groups(model)
+        opt.zero_grad()
 
         new_lr = 0.07
         for param_group in opt.param_groups:
@@ -244,6 +245,7 @@ class LinearLayerTest(ParametrizedTestCase):
             model = model.cuda()
         opt = AnalogSGD(model.parameters(), lr=0.5)
         opt.regroup_param_groups(model)
+        opt.zero_grad()
 
         new_lr = 0.07
 

--- a/tests/test_layers_mapped.py
+++ b/tests/test_layers_mapped.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""aihwkit example 1: simple network with one layer.
+Simple network that consist of one analog layer. The network aims to learn
+to sum all the elements from one array.
+"""
+# pylint: disable=invalid-name, too-many-locals
+
+from tempfile import TemporaryFile
+
+# Imports from PyTorch.
+from torch import randn, load, save, manual_seed
+from torch.nn.functional import mse_loss
+
+# Imports from aihwkit.
+from aihwkit.nn import AnalogLinearMapped
+from aihwkit.optim import AnalogSGD
+
+from .helpers.decorators import parametrize_over_layers
+from .helpers.testcases import ParametrizedTestCase
+from .helpers.tiles import FloatingPoint, Inference, Ideal
+from .helpers.layers import Linear, LinearCuda
+
+DECIMAL = 5
+
+
+@parametrize_over_layers(
+    layers=[Linear, LinearCuda],
+    tiles=[FloatingPoint, Inference, Ideal],
+    biases=[True, False],
+    digital_biases=[True])
+class MappedLayerLinearTest(ParametrizedTestCase):
+    """Tests for the AnalogMappedLayer functionality """
+
+    def train_model(self, model, in_vectors, out_vectors):
+        """Trains a model """
+
+        opt = AnalogSGD(model.parameters(), lr=0.1)
+
+        for _ in range(10):
+            opt.zero_grad()
+
+            # Add the training Tensor to the model (input).
+            pred_value = model(in_vectors)
+            # Add the expected output Tensor.
+            loss_value = mse_loss(pred_value, out_vectors)
+            # Run training (backward propagation).
+            loss_value.backward()
+            opt.step()
+
+        return loss_value
+
+    def test_construction(self):
+        """ Test construction of a mapped layer"""
+        manual_seed(123)
+        in_features = 12
+        out_features = 56
+
+        rpu_config = self.get_rpu_config()
+        rpu_config.mapping.max_input_size = 6
+        rpu_config.mapping.max_output_size = 12
+
+        al_model = self.get_layer(in_features, out_features, rpu_config=rpu_config)
+
+        weight = randn(out_features, in_features)
+        bias = randn(out_features) if self.bias else None
+        al_model.set_weights(weight, bias)
+        al_weights, al_bias = al_model.get_weights()
+
+        asl_model = AnalogLinearMapped(in_features, out_features,
+                                       bias=self.bias,
+                                       rpu_config=rpu_config)
+        asl_model.set_weights(weight, bias)
+
+        if self.use_cuda:
+            asl_model = asl_model.cuda()
+
+        asl_weights, asl_bias = asl_model.get_weights()
+
+        self.assertTensorAlmostEqual(al_weights, asl_weights, decimal=DECIMAL)
+        if self.bias:
+            self.assertTensorAlmostEqual(al_bias, asl_bias, decimal=DECIMAL)
+
+    def test_training(self):
+        """ Test of training of a mapped linear layer"""
+        manual_seed(123)
+
+        in_features = 16
+        out_features = 15
+        batch_size = 10
+
+        rpu_config = self.get_rpu_config()
+        rpu_config.mapping.max_input_size = 4
+        rpu_config.mapping.max_output_size = 3
+
+        in_vectors = randn(batch_size, in_features)
+        out_vectors = randn(batch_size, out_features)
+
+        al_model = self.get_layer(in_features, out_features, rpu_config=rpu_config)
+
+        weight = randn(out_features, in_features)
+        bias = randn(out_features) if self.bias else None
+
+        al_model.set_weights(weight, bias)
+
+        asl_model = AnalogLinearMapped(in_features, out_features,
+                                       bias=self.bias,
+                                       rpu_config=rpu_config)
+        asl_model.set_weights(weight, bias)
+
+        if self.use_cuda:
+            in_vectors = in_vectors.cuda()
+            out_vectors = out_vectors.cuda()
+            asl_model = asl_model.cuda()
+
+        # compare predictions for analog linear and analog spit linear layers
+        self.assertTensorAlmostEqual(al_model(in_vectors), asl_model(in_vectors), decimal=DECIMAL)
+
+        # Define an analog-aware optimizer, preparing it for using the layers.
+        al_loss = self.train_model(al_model, in_vectors, out_vectors)
+        asl_loss = self.train_model(asl_model, in_vectors, out_vectors)
+
+        self.assertTensorAlmostEqual(al_loss, asl_loss, decimal=DECIMAL)
+
+        # Make sure that the train model produces the same forward pass
+        self.assertTensorAlmostEqual(al_model(in_vectors), asl_model(in_vectors), decimal=DECIMAL)
+
+    def test_training_after_save(self):
+        """ Test training after it was saved """
+        manual_seed(123)
+
+        in_features = 7
+        out_features = 8
+        batch_size = 10
+
+        rpu_config = self.get_rpu_config()
+        rpu_config.mapping.max_input_size = 3
+        rpu_config.mapping.max_output_size = 4
+
+        in_vectors = randn(batch_size, in_features)
+        out_vectors = randn(batch_size, out_features)
+
+        al_model = self.get_layer(in_features, out_features, rpu_config=rpu_config)
+
+        weight = randn(out_features, in_features)
+        bias = randn(out_features) if self.bias else None
+
+        al_model.set_weights(weight, bias)
+
+        asl_model = AnalogLinearMapped(in_features, out_features,
+                                       bias=self.bias,
+                                       rpu_config=rpu_config)
+        asl_model.set_weights(weight, bias)
+
+        if self.use_cuda:
+            in_vectors = in_vectors.cuda()
+            out_vectors = out_vectors.cuda()
+            asl_model = asl_model.cuda()
+            al_model = al_model.cuda()
+
+        # Save the model to a file.
+        with TemporaryFile() as file:
+            save(asl_model.state_dict(), file)
+            # Create a new model and load its state dict.
+            file.seek(0)
+            new_model = AnalogLinearMapped(in_features, out_features,
+                                           bias=self.bias,
+                                           rpu_config=rpu_config)
+            if self.use_cuda:
+                new_model = new_model.cuda()
+            new_model.load_state_dict(load(file))
+
+        new_weight, new_bias = new_model.get_weights()
+
+        self.assertTensorAlmostEqual(new_weight, weight, decimal=DECIMAL)
+        if self.bias:
+            self.assertTensorAlmostEqual(new_bias, bias, decimal=DECIMAL)
+            self.assertTensorAlmostEqual(al_model.bias, bias, decimal=DECIMAL)
+            self.assertTensorAlmostEqual(asl_model.bias, bias, decimal=DECIMAL)
+
+        for new_tile, tile in zip(list(new_model.analog_tiles()), list(asl_model.analog_tiles())):
+            new_tile_weight, _ = new_tile.get_weights()
+            tile_weight, _ = tile.get_weights()
+            self.assertTensorAlmostEqual(tile_weight, new_tile_weight, decimal=DECIMAL)
+
+        # compare predictions for analog linear and analog spit linear layers
+        self.assertTensorAlmostEqual(al_model(in_vectors), new_model(in_vectors), decimal=DECIMAL)
+
+        # Define an analog-aware optimizer, preparing it for using the layers.
+        al_loss = self.train_model(al_model, in_vectors, out_vectors)
+        new_loss = self.train_model(new_model, in_vectors, out_vectors)
+
+        # compare predictions for analog linear and analog spit linear layers
+        self.assertTensorAlmostEqual(al_model(in_vectors), new_model(in_vectors), decimal=DECIMAL)
+
+        self.assertTensorAlmostEqual(al_loss, new_loss, decimal=DECIMAL)
+
+        # Make sure that the train model produces the same forward pass
+        self.assertTensorAlmostEqual(al_model(in_vectors), new_model(in_vectors), decimal=DECIMAL)

--- a/tests/test_specific_tiles.py
+++ b/tests/test_specific_tiles.py
@@ -134,6 +134,11 @@ class TransferCompoundTest(ParametrizedTestCase):
         x_b = Tensor([[0.1, 0.2], [0.2, 0.4]])
         y_b = Tensor([[0.3], [0.6]])
 
+        if self.use_cuda:
+            model = model.cuda()
+            x_b = x_b.cuda()
+            y_b = y_b.cuda()
+
         epochs = 2
         for _ in range(epochs):
             opt.zero_grad()
@@ -152,8 +157,8 @@ class TransferCompoundTest(ParametrizedTestCase):
         d = (d - reset_bias) * pow(d_dcy, epochs) + reset_bias
 
         if self.digital_bias:
-            self.assertEqual(bias[0], 0.0)
+            self.assertAlmostEqual(bias[0].item(), 0.0)
         if self.bias and not self.digital_bias:
-            self.assertEqual(bias[0], gamma*(a - b) + c - d)
+            self.assertAlmostEqual(bias[0].item(), gamma*(a - b) + c - d, 5)
 
-        self.assertEqual(weight[0][0], gamma*(a - b) + c - d)
+        self.assertAlmostEqual(weight[0][0].item(), gamma*(a - b) + c - d, 5)


### PR DESCRIPTION
## Related issues

related to #314 

## Description
This introduced a new layer module, `AnalogLinearMapped`, implements again an `Linear` like `AnalogLinear`. However, instead of `AnalogLinear` it will use multiple analog tiles of a given max physical size to implement linear layers where the weight matrix exceeds the physical size of a tile.   

## Details

* `rpu_config.mapping` with `MappingParameter()` let's the user set the physical tile size (`max_input_size`, `max_output_size`). Weight matrices will be split in a way that tiles are almost equally used. No additional noise comes from not programmed/used  columns/rows.      
  

