### PR TITLE
New layers that automatically map large convolutions onto multiple analog tiles 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Decay with arbitrary decay point (to reset bias). (\#319)
 * Linear layer ``AnalogLinearMapped`` which maps a large weight
   matrix onto multiple analog tiles. (\#320)
-* Convolution layers ``AnalogConv?dMapped`` which maps large weight matrix
+* Convolution layers ``AnalogConvNdMapped`` which maps large weight matrix
   onto multiple tiles if necessary. (\#331)
 * In the new ``mapping`` field of ``RPUConfig`` the max tile input and
   output sizes can be configured for the ``*Mapped`` layers. (\#331)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 * ``BufferedTranferCompound`` and TTv2 presets. (\#318)
 * Stochastic rounding for ``MixedPrecisionCompound``. (\#318)
 * Decay with arbitrary decay point (to reset bias). (\#319)
-* Linear layer ``AnalogLinerMapped`` which mapped a large weight
+* Linear layer ``AnalogLinearMapped`` which maps a large weight
   matrix onto multiple analog tiles. (\#320)
+* Convolution layers ``AnalogConv?dMapped`` which maps large weight matrix
+  onto multiple tiles if necessary. (\#331)
+* In the new ``mapping`` field of ``RPUConfig`` the max tile input and
+  output sizes can be configured for the ``*Mapped`` layers. (\#331)
 
 ### Fixed
 
@@ -37,7 +41,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Fixed issue in transfer counter for mixed precision in case of GPU. (\#283)
 * Map location keyword for load / save observed. (\#293)
 * Fixed issue with CUDA buffer allocation when batch size changed. (\#294)
-* Fixed missing load statedict for AnalogSequential. (\#295)
+* Fixed missing load statedict for ``AnalogSequential``. (\#295)
 * Fixed issue with hierarchical hidden parameter settings. (\#313)
 * Fixed serious issue that loaded model would not update analog gradients. (\#320)
 * Fixed cuda import in examples. (\#320)
@@ -52,7 +56,8 @@ The format is based on [Keep a Changelog], and this project adheres to
   rate then is applied on the slow matrix (\#312).
 * The ``fixed_value`` of ``WeightClipParameter`` is now  applied for all clipping
   types if set larger than zero. (\#318)
-* Gererator for analog tiles of an AnalogModule. (\#320)
+* The use of generators for analog tiles of an ``AnalogModuleBase``. (\#320)
+* Digital bias is now accessable through ``MappingParameter``. (\#331)
 
 ### Deprecated
 

--- a/examples/03_mnist_training.py
+++ b/examples/03_mnist_training.py
@@ -34,12 +34,13 @@ from aihwkit.nn import AnalogLinear, AnalogSequential
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
+from aihwkit.simulator.rpu_base import cuda
 
 # Check device
 USE_CUDA = 0
-DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-if torch.cuda.is_available():
+if cuda.is_compiled():
     USE_CUDA = 1
+DEVICE = torch.device('cuda' if USE_CUDA else 'cpu')
 
 # Path where the datasets will be stored.
 PATH_DATASET = os.path.join('data', 'DATASET')

--- a/examples/17_resnet34_imagenet_conversion_to_analog.py
+++ b/examples/17_resnet34_imagenet_conversion_to_analog.py
@@ -36,7 +36,7 @@ print(model)
 mapping = MappingParameter(max_input_size=512,  # analog tile size
                            max_output_size=512,
                            digital_bias=True)  # whether to use analog or digital bias
-# choose any preset or RPU configuration or preset, here with custom mapping
+# Choose any preset or RPU configuration here
 rpu_config = TikiTakaReRamSBPreset(mapping=mapping)
 
 # Convert the model to its analog version.

--- a/examples/17_resnet34_imagenet_conversion_to_analog.py
+++ b/examples/17_resnet34_imagenet_conversion_to_analog.py
@@ -21,25 +21,30 @@ https://arxiv.org/abs/1512.03385
 from torchvision.models import resnet34
 
 # Imports from aihwkit.
-from aihwkit.nn.conversion import convert_to_analog
+from aihwkit.nn.conversion import convert_to_analog_mapped
 from aihwkit.simulator.presets import TikiTakaReRamSBPreset
+from aihwkit.simulator.configs.utils import MappingParameter
 
-# Device used in the RPU tile
-RPU_CONFIG = TikiTakaReRamSBPreset()
+# Example: Load a predefined model from pytorch library and convert to
+#          its analog version.
+
+# Load a pytorch model.
+model = resnet34()
+print(model)
+
+# Define device and chip configuration used in the RPU tile
+mapping = MappingParameter(max_input_size=512,  # analog tile size
+                           max_output_size=512,
+                           digital_bias=True)  # whether to use analog or digital bias
+# choose any preset or RPU configuration or preset, here with custom mapping
+rpu_config = TikiTakaReRamSBPreset(mapping=mapping)
+
+# Convert the model to its analog version.
+# this will replace ``Linear`` layers with ``AnalogLinearMapped``
+model = convert_to_analog_mapped(model, rpu_config, weight_scaling_omega=0.6)
+
+# Note: One can also use ``convert_to_analog`` instead to convert
+# ``Linear`` to ``AnalogLinear`` (without mapping to multiple tiles)
 
 
-def main():
-    """Load a predefined model from pytorch library and convert to its analog version."""
-    # Load the pytorch model.
-    model = resnet34()
-    print(model)
-
-    # Convert the model to its analog version.
-    model = convert_to_analog(model, RPU_CONFIG, weight_scaling_omega=0.6, digital_bias=True)
-
-    print(model)
-
-
-if __name__ == '__main__':
-    # Execute only if run as the entry point into the program
-    main()
+print(model)

--- a/src/aihwkit/nn/__init__.py
+++ b/src/aihwkit/nn/__init__.py
@@ -19,3 +19,6 @@ from aihwkit.nn.modules.conv import AnalogConv1d, AnalogConv2d, AnalogConv3d
 from aihwkit.nn.modules.linear import AnalogLinear
 from aihwkit.nn.modules.lstm import AnalogLSTM
 from aihwkit.nn.modules.linear_mapped import AnalogLinearMapped
+from aihwkit.nn.modules.conv_mapped import (
+    AnalogConv1dMapped, AnalogConv2dMapped, AnalogConv3dMapped
+)

--- a/src/aihwkit/nn/conversion.py
+++ b/src/aihwkit/nn/conversion.py
@@ -22,7 +22,8 @@ import copy
 from torch.nn import Module, Linear, Conv1d, Conv2d, Conv3d, Sequential
 
 from aihwkit.nn import (
-    AnalogLinear, AnalogConv1d, AnalogConv2d, AnalogConv3d, AnalogSequential
+    AnalogLinear, AnalogConv1d, AnalogConv2d, AnalogConv3d,
+    AnalogLinearMapped, AnalogConv1dMapped, AnalogConv2dMapped, AnalogConv3dMapped, AnalogSequential
 )
 
 RPUConfigGeneric = TypeVar('RPUConfigGeneric')
@@ -33,13 +34,18 @@ _DEFAULT_CONVERSION_MAP = {Linear: AnalogLinear,
                            Conv3d: AnalogConv3d,
                            Sequential: AnalogSequential}
 
+_DEFAULT_MAPPED_CONVERSION_MAP = {Linear: AnalogLinearMapped,
+                                  Conv1d: AnalogConv1dMapped,
+                                  Conv2d: AnalogConv2dMapped,
+                                  Conv3d: AnalogConv3dMapped,
+                                  Sequential: AnalogSequential}
+
 
 def convert_to_analog(
         module: Module,
         rpu_config: RPUConfigGeneric,
         realistic_read_write: bool = False,
         weight_scaling_omega: float = 0.0,
-        digital_bias: bool = False,
         conversion_map: Optional[Dict] = None
 ) -> Module:
     """Convert a given digital model to analog counter parts.
@@ -60,12 +66,11 @@ def convert_to_analog(
         weight_scaling_omega: If non-zero, applied weights of analog
             layers will be scaled by ``weight_scaling_omega`` divided by
             the absolute maximum value of the original weight matrix.
-        digital_bias: decide whether the bias term is handled by the analog tile
-                or kept in digital.
 
             Note:
                 Make sure that the weight max and min setting of the
                 device support the desired analog weight range.
+
         conversion_map: Dictionary of module classes to be replaced in
             case of custom replacement rules. By default all ``Conv`` and ``Linear``
             layers are replaced with their analog counterparts.
@@ -86,7 +91,7 @@ def convert_to_analog(
     # Convert parent.
     if module.__class__ in conversion_map:
         module = conversion_map[module.__class__].from_digital(  # type: ignore
-            module, rpu_config, realistic_read_write, weight_scaling_omega, digital_bias)
+            module, rpu_config, realistic_read_write, weight_scaling_omega)
 
     # Convert children.
     convert_dic = {}
@@ -95,11 +100,11 @@ def convert_to_analog(
         n_grand_children = len(list(mod.named_children()))
         if n_grand_children > 0:
             new_mod = convert_to_analog(mod, rpu_config, realistic_read_write,
-                                        weight_scaling_omega, digital_bias, conversion_map)
+                                        weight_scaling_omega, conversion_map)
 
         elif mod.__class__ in conversion_map:
             new_mod = conversion_map[mod.__class__].from_digital(   # type: ignore
-                mod, rpu_config, realistic_read_write, weight_scaling_omega, digital_bias)
+                mod, rpu_config, realistic_read_write, weight_scaling_omega)
         else:
             continue
 
@@ -113,3 +118,46 @@ def convert_to_analog(
         module._modules[name] = new_mod  # pylint: disable=protected-access
 
     return module
+
+
+def convert_to_analog_mapped(
+        module: Module,
+        rpu_config: RPUConfigGeneric,
+        realistic_read_write: bool = False,
+        weight_scaling_omega: float = 0.0,
+) -> Module:
+    """Convert a given digital model to analog counter parts with tile
+    mapping.
+
+    Note:
+        The torch device (cuda/cpu) is inferred from the original
+        models parameters, however, if multiple torch
+        devices are used in a given module, the corresponding analog
+        module is not moved to any device.
+
+    Args:
+        module: The torch module to convert. All layers that are
+            defined in the ``conversion_map``.
+        rpu_config: RPU config to apply to all converted tiles.
+            Applied to all converted tiles.
+        realistic_read_write: Whether to use closed-loop programming
+            when setting the weights. Applied to all converted tiles.
+        weight_scaling_omega: If non-zero, applied weights of analog
+            layers will be scaled by ``weight_scaling_omega`` divided by
+            the absolute maximum value of the original weight matrix.
+
+            Note:
+                Make sure that the weight max and min setting of the
+                device support the desired analog weight range.
+
+    Returns:
+        module with replaced digital layers with analog mapped layers.
+
+    """
+    return convert_to_analog(
+        module,
+        rpu_config,
+        realistic_read_write,
+        weight_scaling_omega,
+        _DEFAULT_MAPPED_CONVERSION_MAP
+    )

--- a/src/aihwkit/nn/conversion.py
+++ b/src/aihwkit/nn/conversion.py
@@ -63,12 +63,12 @@ def convert_to_analog(
             Applied to all converted tiles.
         realistic_read_write: Whether to use closed-loop programming
             when setting the weights. Applied to all converted tiles.
-        weight_scaling_omega: If non-zero, applied weights of analog
-            layers will be scaled by ``weight_scaling_omega`` divided by
-            the absolute maximum value of the original weight matrix.
+        weight_scaling_omega: If non-zero, the analog weights will be
+            scaled by ``weight_scaling_omega`` divided by the absolute
+            maximum value of the original weight matrix.
 
             Note:
-                Make sure that the weight max and min setting of the
+                Make sure that the weight max and min settings of the
                 device support the desired analog weight range.
 
         conversion_map: Dictionary of module classes to be replaced in
@@ -81,7 +81,8 @@ def convert_to_analog(
                 conversion.
 
     Returns:
-        module with replaced digital layers with analog layers.
+        Module where all the digital layers are replaced with analog
+        mapped layers.
     """
     module = copy.deepcopy(module)
 
@@ -126,8 +127,8 @@ def convert_to_analog_mapped(
         realistic_read_write: bool = False,
         weight_scaling_omega: float = 0.0,
 ) -> Module:
-    """Convert a given digital model to analog counter parts with tile
-    mapping.
+    """Convert a given digital model to its analog counterpart with tile
+    mapping support.
 
     Note:
         The torch device (cuda/cpu) is inferred from the original
@@ -139,19 +140,19 @@ def convert_to_analog_mapped(
         module: The torch module to convert. All layers that are
             defined in the ``conversion_map``.
         rpu_config: RPU config to apply to all converted tiles.
-            Applied to all converted tiles.
         realistic_read_write: Whether to use closed-loop programming
             when setting the weights. Applied to all converted tiles.
-        weight_scaling_omega: If non-zero, applied weights of analog
-            layers will be scaled by ``weight_scaling_omega`` divided by
-            the absolute maximum value of the original weight matrix.
+        weight_scaling_omega: If non-zero, the analog weights will be
+            scaled by ``weight_scaling_omega`` divided by the absolute
+            maximum value of the original weight matrix.
 
             Note:
-                Make sure that the weight max and min setting of the
+                Make sure that the weight max and min settings of the
                 device support the desired analog weight range.
 
     Returns:
-        module with replaced digital layers with analog mapped layers.
+        Module where all the digital layers are replaced with analog
+        mapped layers.
 
     """
     return convert_to_analog(

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -62,11 +62,11 @@ class AnalogModuleBase(Module):
         out_features: output vector size (number of rows).
         bias: whether to use a bias row on the analog tile or not.
         realistic_read_write: whether to enable realistic read/write
-            for setting initial weights and read out of weights.
-        weight_scaling_omega: the weight value where the max
-            weight will be scaled to. If zero, no weight scaling will
-            be performed
-        mapping: Configuration of the HW architecture (e.g. tile size).
+            for setting initial weights and during reading of the weights.
+        weight_scaling_omega: the weight value that the current max
+            weight value will be scaled to. If zero, no weight scaling will
+            be performed.
+        mapping: Configuration of the hardware architecture (e.g. tile size).
     """
     # pylint: disable=abstract-method, too-many-instance-attributes
     ANALOG_CTX_PREFIX: str = 'analog_ctx_'
@@ -170,7 +170,7 @@ class AnalogModuleBase(Module):
             self,
             rpu_config: RPUConfigAlias,
     ) -> 'BaseTile':
-        """Create a single analog tile and with the setup of this layer it.
+        """Create a single analog tile with the given RPU configuration.
 
         Create an analog tile to be used for the basis of this layer
         operations, while using the attributes ``(in_features,
@@ -198,7 +198,7 @@ class AnalogModuleBase(Module):
             bias: Optional[Tensor] = None,
             force_exact: bool = False
     ) -> None:
-        """Set the weight (and bias) with given Tensors.
+        """Set the weight (and bias) values with given tensors.
 
         This uses an realistic write if the property ``realistic_read_write``
         of the layer is set, unless it is overwritten by ``force_exact``.

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -13,7 +13,7 @@
 """Base class for analog Modules."""
 
 from typing import (
-    Any, Dict, List, Optional, Tuple, Union, NamedTuple,
+    Any, Dict, List, Optional, Tuple, NamedTuple, Union,
     Generator, TYPE_CHECKING
 )
 
@@ -21,10 +21,11 @@ from torch import Tensor, no_grad
 from torch.nn import Module, Parameter
 
 from aihwkit.exceptions import ModuleError
-from aihwkit.simulator.configs import (
+from aihwkit.simulator.configs.configs import (
     FloatingPointRPUConfig, InferenceRPUConfig, SingleRPUConfig,
-    UnitCellRPUConfig
+    UnitCellRPUConfig, DigitalRankUpdateRPUConfig
 )
+from aihwkit.simulator.configs.utils import MappingParameter
 from aihwkit.simulator.tiles import InferenceTile
 from aihwkit.optim.context import AnalogContext
 
@@ -33,7 +34,8 @@ if TYPE_CHECKING:
     from collections import OrderedDict
 
 RPUConfigAlias = Union[FloatingPointRPUConfig, SingleRPUConfig,
-                       UnitCellRPUConfig, InferenceRPUConfig]
+                       UnitCellRPUConfig, InferenceRPUConfig,
+                       DigitalRankUpdateRPUConfig]
 
 
 class AnalogModuleBase(Module):
@@ -42,27 +44,60 @@ class AnalogModuleBase(Module):
     Base ``Module`` for analog layers that use analog tiles. When subclassing,
     please note:
 
-    * the ``_setup_tile()`` method is expected to be called by the subclass
-      constructor, and it does not only create a tile, but also sets some
-      instance attributes that are needed by the analog features (optimizer
-      and others).
+    * the :meth:`_setup_tile()` method is expected to be called by the subclass
+      constructor, and it does not only create a tile.
+    * :meth:`register_analog_tile` needs to be called for each created analog tile
+    * this module does *not* call torch's ``Module`` init as the child is
+      likely again derived from Module
     * the ``weight`` and ``bias`` Parameters are not guaranteed to be in
       sync with the tile weights and biases during the lifetime of the instance,
       for performance reasons. The canonical way of reading and writing
-      weights is via the ``set_weights()`` and ``get_weights()`` as opposed
+      weights is via the :meth:`set_weights()` and :meth:`get_weights()` as opposed
       to using the attributes directly.
     * the ``BaseTile`` subclass that is created is retrieved from the
       ``rpu_config.tile_class`` attribute.
+
+    Args:
+        in_features: input vector size (number of columns).
+        out_features: output vector size (number of rows).
+        bias: whether to use a bias row on the analog tile or not.
+        realistic_read_write: whether to enable realistic read/write
+            for setting initial weights and read out of weights.
+        weight_scaling_omega: the weight value where the max
+            weight will be scaled to. If zero, no weight scaling will
+            be performed
+        mapping: Configuration of the HW architecture (e.g. tile size).
     """
     # pylint: disable=abstract-method, too-many-instance-attributes
     ANALOG_CTX_PREFIX: str = 'analog_ctx_'
     ANALOG_SHARED_WEIGHT_PREFIX: str = 'analog_shared_weights_'
     ANALOG_STATE_PREFIX: str = 'analog_tile_state_'
 
-    def __init__(self) -> None:  # pylint: disable=super-init-not-called
+    def __init__(
+            self,
+            in_features: int,
+            out_features: int,
+            bias: bool,
+            realistic_read_write: bool = False,
+            weight_scaling_omega: float = 0.0,
+            mapping: Optional[MappingParameter] = None,
+    ) -> None:
+        # pylint: disable=super-init-not-called
         self._analog_tile_counter = 0
         self._registered_helper_parameter = []  # type: list
         self._load_rpu_config = True
+
+        if mapping is None:
+            mapping = MappingParameter()
+
+        self.use_bias = bias
+        self.digital_bias = bias and mapping.digital_bias
+        self.analog_bias = bias and not mapping.digital_bias
+
+        self.realistic_read_write = realistic_read_write
+        self.weight_scaling_omega = weight_scaling_omega
+        self.in_features = in_features
+        self.out_features = out_features
 
     def register_analog_tile(self, tile: 'BaseTile', name: Optional[str] = None) -> None:
         """Register the analog context of the tile.
@@ -133,68 +168,28 @@ class AnalogModuleBase(Module):
 
     def _setup_tile(
             self,
-            in_features: int,
-            out_features: int,
-            bias: bool,
-            rpu_config: Optional[RPUConfigAlias] = None,
-            realistic_read_write: bool = False,
-            weight_scaling_omega: float = 0.0,
-            digital_bias: bool = False
+            rpu_config: RPUConfigAlias,
     ) -> 'BaseTile':
-        """Create an analog tile and setup this layer for using it.
+        """Create a single analog tile and with the setup of this layer it.
 
-        Create an analog tile to be used for the basis of this layer operations,
-        and setup additional attributes of this instance that are needed for
-        using the analog tile.
+        Create an analog tile to be used for the basis of this layer
+        operations, while using the attributes ``(in_features,
+        out_features, bias)`` given to this instance during init.
 
-        If ``weight_scaling_omega`` is larger than 0, the weights are set in a
-        scaled manner (assuming a digital output scale). See
-        :meth:`~aihwkit.simulator.tiles.base.BaseTile.set_weights_scaled`
-        for details.
-
-        Note:
-            This method also sets the following attributes, which are assumed
-            to be set by the rest of the methods:
-            * ``self.use_bias``
-            * ``self.analog_bias``
-            * ``self.digital_bias``
-            * ``self.realistic_read_write``
-            * ``self.weight_scaling_omega``
-            * ``self.in_features``
-            * ``self.out_features``
+        After tile creation, the tile needs to be registered using
+        :meth:`register_analog_tile`.
 
         Args:
-            in_features: input vector size (number of columns).
-            out_features: output vector size (number of rows).
             rpu_config: resistive processing unit configuration.
-            bias: whether to use a bias row on the analog tile or not.
-            realistic_read_write: whether to enable realistic read/write
-                for setting initial weights and read out of weights.
-            weight_scaling_omega: the weight value where the max
-                weight will be scaled to. If zero, no weight scaling will
-                be performed
-            digital_bias: whether to use bias in digital
 
         Returns:
             An analog tile with the requested parameters.
+
         """
-        # pylint: disable=attribute-defined-outside-init, protected-access
-        # Default to constant step device if not provided.
-        if not rpu_config:
-            rpu_config = SingleRPUConfig()
-
-        # Setup the analog-related attributes of this instance.
-        self.use_bias = bias
-        self.digital_bias = bias and digital_bias
-        self.analog_bias = bias and not digital_bias
-
-        self.realistic_read_write = realistic_read_write
-        self.weight_scaling_omega = weight_scaling_omega
-        self.in_features = in_features
-        self.out_features = out_features
+        # pylint: disable=protected-access
 
         # Create the tile.
-        return rpu_config.tile_class(out_features, in_features, rpu_config,
+        return rpu_config.tile_class(self.out_features, self.in_features, rpu_config,
                                      bias=self.analog_bias)
 
     def set_weights(
@@ -206,9 +201,12 @@ class AnalogModuleBase(Module):
         """Set the weight (and bias) with given Tensors.
 
         This uses an realistic write if the property ``realistic_read_write``
-        of the layer is set, unless it is overwritten by ``force_exact``. It
-        uses a scaled write if ``weight_scaling_omega`` is positive (see
-        :meth:`~aihwkit.simulator.tiles.base.BaseTile.set_weights_scaled`).
+        of the layer is set, unless it is overwritten by ``force_exact``.
+
+        If ``weight_scaling_omega`` is larger than 0, the weights are set in a
+        scaled manner (assuming a digital output scale). See
+        :meth:`~aihwkit.simulator.tiles.base.BaseTile.set_weights_scaled`
+        for details.
 
         Note:
             This is the recommended way for setting the weight/bias matrix of
@@ -468,8 +466,8 @@ class AnalogModuleBase(Module):
         if self.weight_scaling_omega > 0:
             output += ', weight_scaling_omega={:.3f}'.format(self.weight_scaling_omega)
         if self.analog_bias:
-            output += ', analog bias)'
+            output += ', analog bias'
         if self.digital_bias:
-            output += ', digital bias)'
+            output += ', digital bias'
 
         return output

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -199,10 +199,11 @@ class AnalogConv1d(_AnalogConvNd):
         bias: whether to use a bias row on the analog tile or not.
         padding_mode: padding strategy. Only ``'zeros'`` is supported.
         rpu_config: resistive processing unit configuration.
-        realistic_read_write: whether to enable realistic read/write for
-            setting initial weights and read out of weights.
-        weight_scaling_omega: the weight value where the max weight will be
-            scaled to. If zero, no weight scaling will be performed.
+        realistic_read_write: whether to enable realistic read/write
+            for setting initial weights and during reading of the weights.
+        weight_scaling_omega: the weight value that the current max
+            weight value will be scaled to. If zero, no weight scaling will
+            be performed.
     """
     # pylint: disable=abstract-method
 
@@ -253,12 +254,12 @@ class AnalogConv1d(_AnalogConvNd):
                 Applied to all converted tiles.
             realistic_read_write: Whether to use closed-loop programming
                 when setting the weights. Applied to all converted tiles.
-            weight_scaling_omega: If non-zero, applied weights of analog
-                layers will be scaled by ``weight_scaling_omega`` divided by
-                the absolute maximum value of the original weight matrix.
+            weight_scaling_omega: If non-zero, the analog weights will be
+                scaled by ``weight_scaling_omega`` divided by the absolute
+                maximum value of the original weight matrix.
 
                 Note:
-                    Make sure that the weight max and min setting of the
+                    Make sure that the weight max and min settings of the
                     device support the desired analog weight range.
 
         Returns:
@@ -423,12 +424,12 @@ class AnalogConv2d(_AnalogConvNd):
                 Applied to all converted tiles.
             realistic_read_write: Whether to use closed-loop programming
                 when setting the weights. Applied to all converted tiles.
-            weight_scaling_omega: If non-zero, applied weights of analog
-                layers will be scaled by ``weight_scaling_omega`` divided by
-                the absolute maximum value of the original weight matrix.
+            weight_scaling_omega: If non-zero, the analog weights will be
+                scaled by ``weight_scaling_omega`` divided by the absolute
+                maximum value of the original weight matrix.
 
                 Note:
-                    Make sure that the weight max and min setting of the
+                    Make sure that the weight max and min settings of the
                     device support the desired analog weight range.
 
         Returns:
@@ -585,12 +586,12 @@ class AnalogConv3d(_AnalogConvNd):
                 Applied to all converted tiles.
             realistic_read_write: Whether to use closed-loop programming
                 when setting the weights. Applied to all converted tiles.
-            weight_scaling_omega: If non-zero, applied weights of analog
-                layers will be scaled by ``weight_scaling_omega`` divided by
-                the absolute maximum value of the original weight matrix.
+            weight_scaling_omega: If non-zero, the analog weights will be
+                scaled by ``weight_scaling_omega`` divided by the absolute
+                maximum value of the original weight matrix.
 
                 Note:
-                    Make sure that the weight max and min setting of the
+                    Make sure that the weight max and min settings of the
                     device support the desired analog weight range.
 
         Returns:

--- a/src/aihwkit/nn/modules/conv_mapped.py
+++ b/src/aihwkit/nn/modules/conv_mapped.py
@@ -469,12 +469,12 @@ class AnalogConv1dMapped(_AnalogConvNdMapped):
                 Applied to all converted tiles.
             realistic_read_write: Whether to use closed-loop programming
                 when setting the weights. Applied to all converted tiles.
-            weight_scaling_omega: If non-zero, applied weights of analog
-                layers will be scaled by ``weight_scaling_omega`` divided by
-                the absolute maximum value of the original weight matrix.
+            weight_scaling_omega: If non-zero, the analog weights will be
+                scaled by ``weight_scaling_omega`` divided by the absolute
+                maximum value of the original weight matrix.
 
                 Note:
-                    Make sure that the weight max and min setting of the
+                    Make sure that the weight max and min settings of the
                     device support the desired analog weight range.
 
         Returns:
@@ -645,12 +645,12 @@ class AnalogConv2dMapped(_AnalogConvNdMapped):
                 Applied to all converted tiles.
             realistic_read_write: Whether to use closed-loop programming
                 when setting the weights. Applied to all converted tiles.
-            weight_scaling_omega: If non-zero, applied weights of analog
-                layers will be scaled by ``weight_scaling_omega`` divided by
-                the absolute maximum value of the original weight matrix.
+            weight_scaling_omega: If non-zero, the analog weights will be
+                scaled by ``weight_scaling_omega`` divided by the absolute
+                maximum value of the original weight matrix.
 
                 Note:
-                    Make sure that the weight max and min setting of the
+                    Make sure that the weight max and min settings of the
                     device support the desired analog weight range.
 
         Returns:
@@ -819,12 +819,12 @@ class AnalogConv3dMapped(_AnalogConvNdMapped):
                 Applied to all converted tiles.
             realistic_read_write: Whether to use closed-loop programming
                 when setting the weights. Applied to all converted tiles.
-            weight_scaling_omega: If non-zero, applied weights of analog
-                layers will be scaled by ``weight_scaling_omega`` divided by
-                the absolute maximum value of the original weight matrix.
+            weight_scaling_omega: If non-zero, the analog weights will be
+                scaled by ``weight_scaling_omega`` divided by the absolute
+                maximum value of the original weight matrix.
 
                 Note:
-                    Make sure that the weight max and min setting of the
+                    Make sure that the weight max and min settings of the
                     device support the desired analog weight range.
 
         Returns:

--- a/src/aihwkit/nn/modules/conv_mapped.py
+++ b/src/aihwkit/nn/modules/conv_mapped.py
@@ -14,7 +14,7 @@
 
 from typing import Optional, Tuple, Union, List
 
-from torch import Tensor, arange, cat, float64, int32, ones
+from torch import Tensor, arange, cat, float64, int32, ones, split, no_grad
 from torch.nn import Unfold
 from torch.nn.functional import pad
 from torch.nn.modules.conv import _ConvNd, Conv1d, Conv2d, Conv3d
@@ -22,11 +22,14 @@ from torch.nn.modules.utils import _single, _pair, _triple
 
 from aihwkit.nn.functions import AnalogIndexedFunction
 from aihwkit.nn.modules.base import AnalogModuleBase, RPUConfigAlias
+from aihwkit.exceptions import ModuleError
 from aihwkit.simulator.configs import SingleRPUConfig
 
 
-class _AnalogConvNd(AnalogModuleBase, _ConvNd):
-    """Base class for convolution layers."""
+class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
+    """Base class for convolution layers with tile mapping.
+
+    """
 
     __constants__ = ['stride', 'padding', 'dilation', 'groups',
                      'padding_mode', 'output_padding', 'in_channels',
@@ -55,6 +58,7 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
 
     def __init__(
             self,
+
             in_channels: int,
             out_channels: int,
             kernel_size: Tuple[int, ...],
@@ -81,7 +85,7 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
                          padding, dilation, transposed, output_padding, groups, bias,
                          padding_mode)
 
-        # Create the tile and set the analog.
+        # Create tiles
         if rpu_config is None:
             rpu_config = SingleRPUConfig()
 
@@ -94,22 +98,75 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
             weight_scaling_omega,
             rpu_config.mapping
         )
-        self.analog_tile = self._setup_tile(rpu_config)
 
-        # Register analog tile
-        self.register_analog_tile(self.analog_tile)
+        if self.analog_bias:
+            raise ModuleError("AnalogConvNdMapped only supports digital bias.")
 
-        # Set weights from the reset_parameters
+        if not rpu_config:
+            rpu_config = SingleRPUConfig()
+
+        max_input_size = rpu_config.mapping.max_input_size
+        max_output_size = rpu_config.mapping.max_output_size
+
+        kernel_elem = self.in_features // self.in_channels
+        self.in_sizes = self.get_split_sizes(self.in_features, max_input_size, kernel_elem)
+        self.out_sizes = self.get_split_sizes(self.out_features, max_output_size)
+
+        self.analog_tile_array = []
+        for i, in_tile_size in enumerate(self.in_sizes):
+            in_tiles = []
+            for j, out_tile_size in enumerate(self.out_sizes):
+                tile = rpu_config.tile_class(out_tile_size,
+                                             in_tile_size * kernel_elem,
+                                             rpu_config,
+                                             bias=self.analog_bias)
+                self.register_analog_tile(tile, name=f"{i}_{j}")
+                in_tiles.append(tile)
+            self.analog_tile_array.append(in_tiles)
+
+        # Set weights from the reset_parameters (since now the
+        # analog_tiles are registered)
         self.set_weights(self.weight, self.bias)
 
         # Set the index matrices.
-        self.fold_indices = Tensor().detach()
         self.input_size = 0
+        self.fold_indices_lst = []  # type: List[Tensor]
 
-        # Unregister weight/bias as a parameter but keep it for syncs
+        # Unregister weight/bias as a parameter but keep it as a
+        # field (needed for syncing still)
         self.unregister_parameter('weight')
         if self.analog_bias:
             self.unregister_parameter('bias')
+
+    def get_split_sizes(self, size: int, split_max_size: int, group_size: int = 1) -> List[int]:
+        """ Computed the split sizes across channels.
+
+        Args:
+            size: number of elements of the layer in one dimension
+            split_max_size: max size of the split
+            group_size: minimal size of features that needs to stay on one tile
+
+        Returns:
+            List of split sizes (in split groups)
+
+        Raises:
+            ModuleError: Tiling weight matrices is always done across channels
+                only. If the group_size is larger than the
+                maximal tile size, mapping cannot be done
+        """
+        if split_max_size <= 0:
+            return [size // group_size]
+
+        if group_size > split_max_size:
+            raise ModuleError("Tile size too small to fit a single group (kernel): " +
+                              f"{group_size} > {split_max_size}")
+
+        size_per_group = size // group_size
+        split_max_per_group = split_max_size // group_size
+
+        n_splits = (size_per_group + split_max_per_group - 1) // split_max_per_group
+        base, extra = divmod(size_per_group, n_splits)
+        return [(base + (i < extra)) for i in range(n_splits)]
 
     def get_tile_size(
             self,
@@ -131,13 +188,6 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
         if self.analog_tile_count():
             self.set_weights(self.weight, self.bias)
 
-    def recalculate_indexes(self, x_input: Tensor) -> None:
-        """Calculate and set the indexes of the analog tile."""
-
-        self.fold_indices, image_sizes, self.input_size = \
-            self._calculate_indexes(x_input, self.in_channels)
-        self.analog_tile.set_indexed(self.fold_indices, image_sizes)
-
     def _calculate_indexes(self, x_input: Tensor,
                            in_channels: int) -> Tuple[Tensor, List[int], int]:
         """Calculate and return the fold indexes and sizes.
@@ -153,6 +203,30 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
         """
         raise NotImplementedError
 
+    def recalculate_indexes(self, x_input: Tensor) -> None:
+        """Calculate and set the indexes of the analog tile.
+
+        Args:
+            x_input: the input tensor.
+
+        Raises:
+            ModuleError: in case the input is not at least 3
+            dimensional
+
+        """
+        self.input_size = x_input.numel() / x_input.size(0)
+        if x_input.ndim < 3:
+            raise ModuleError("Expect >2-dim inputs to convolutions")
+        channel_dim = 1
+        self.fold_indices_lst = []
+        splits = split(x_input, self.in_sizes, dim=channel_dim)
+        for x, in_channels, in_tiles in zip(splits, self.in_sizes, self.analog_tile_array):
+            fold_indices, image_sizes, _ = self._calculate_indexes(x, in_channels)
+            self.fold_indices_lst.append(fold_indices)
+
+            for analog_tile in in_tiles:
+                analog_tile.set_indexed(fold_indices, image_sizes)
+
     def digital_bias_view(self) -> Tensor:
         """Return the correct view to the digital bias """
 
@@ -160,24 +234,166 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
 
     def forward(self, x_input: Tensor) -> Tensor:
         """Compute the forward pass."""
+        # pylint: disable=arguments-differ,arguments-renamed
+
         input_size = x_input.numel() / x_input.size(0)
-        if not self.fold_indices.numel() or self.input_size != input_size:
+        if self.input_size != input_size:
             self.recalculate_indexes(x_input)
 
-        out = AnalogIndexedFunction.apply(
-            self.analog_tile.get_analog_ctx(), x_input,
-            self.analog_tile.shared_weights, not self.training)
+        if self.analog_tile_count() == 1:
+            analog_tile = self.analog_tile_array[0][0]
+            output = AnalogIndexedFunction.apply(
+                analog_tile.get_analog_ctx(), x_input,
+                analog_tile.shared_weights, not self.training)
+
+            if self.digital_bias:
+                return output + self.digital_bias_view()
+            return output
+
+        # mapped version
+        channel_dim = 1
+        splits = split(x_input, self.in_sizes, dim=channel_dim)
+        result = None  # type: Tensor
+        for idx, (x, in_tiles) in enumerate(zip(splits, self.analog_tile_array)):
+            out_result = []
+            input_size = x.numel() / x.size(0)
+
+            for analog_tile in in_tiles:
+                output = AnalogIndexedFunction.apply(
+                    analog_tile.get_analog_ctx(), x,
+                    analog_tile.shared_weights, not self.training)
+                out_result.append(output)
+
+            if idx == 0:
+                result = cat(out_result, channel_dim)
+            else:
+                result.add_(cat(out_result, channel_dim))
+
+        # add bias to final result
+        if self.digital_bias:
+            return result + self.digital_bias_view()
+        return result
+
+    def set_weights(
+            self,
+            weight: Tensor,
+            bias: Optional[Tensor] = None,
+            force_exact: bool = False
+    ) -> None:
+        """Set the weight (and bias) with given Tensors.
+
+        This uses an realistic write if the property ``realistic_read_write``
+        of the layer is set, unless it is overwritten by ``force_exact``. It
+        uses a scaled write if ``weight_scaling_omega`` is positive (see
+        :meth:`~aihwkit.simulator.tiles.base.BaseTile.set_weights_scaled`).
+
+        Note:
+            This is the recommended way for setting the weight/bias matrix of
+            the analog tile, as it will correctly store the weights into the
+            internal memory. Directly writing to ``self.weight`` and
+            ``self.bias`` might yield wrong results as they are not always in
+            sync with the analog tile Parameters, for performance reasons.
+
+        Args:
+            weight: weight matrix
+            bias: bias vector
+            force_exact: forces an exact write to the analog tiles
+        """
+        realistic = self.realistic_read_write and not force_exact
+
+        shape = [self.out_features, self.in_channels, self.in_features // self.in_channels]
+        weight = weight.clone().reshape(shape)
+
+        weight_splits = split(weight, self.in_sizes, dim=1)
+
+        for in_tiles, in_weight in zip(self.analog_tile_array, weight_splits):
+            out_start = out_end = 0
+            in_weight = in_weight.reshape([self.out_features, -1])
+            for out_size, analog_tile in zip(self.out_sizes, in_tiles):
+                out_end += out_size
+                tile_weight = in_weight[out_start:out_end, :]
+                out_start = out_end
+
+                if self.weight_scaling_omega > 0.0:
+                    analog_tile.set_weights_scaled(tile_weight, None,
+                                                   realistic=realistic,
+                                                   omega=self.weight_scaling_omega)
+                else:
+                    analog_tile.set_weights(tile_weight, None, realistic=realistic)
+
+        self._sync_weights_from_tile()
+
+        if self.digital_bias and bias is not None:
+            with no_grad():
+                self.bias.data[:] = bias[:]
+
+    def get_weights(self, force_exact: bool = False) -> Tuple[Tensor, Optional[Tensor]]:
+        """Get the weight (and bias) tensors.
+
+        This uses an realistic read if the property ``realistic_read_write`` of
+        the layer is set, unless it is overwritten by ``force_exact``. It
+        scales the analog weights by the digital alpha scale if
+        ``weight_scaling_omega`` is positive (see
+        :meth:`~aihwkit.simulator.tiles.base.BaseTile.get_weights_scaled`).
+
+        Note:
+            This is the recommended way for setting the weight/bias matrix from
+            the analog tile, as it will correctly fetch the weights from the
+            internal memory. Accessing ``self.weight`` and ``self.bias`` might
+            yield wrong results as they are not always in sync with the
+            analog tile library, for performance reasons.
+
+        Args:
+            force_exact: forces an exact read to the analog tiles
+
+        Returns:
+            tuple: weight matrix, bias vector
+
+        """
+
+        realistic = self.realistic_read_write and not force_exact
+
+        weight_lst = []
+        for in_tiles in self.analog_tile_array:
+            in_tile_weight = []
+            for analog_tile in in_tiles:
+                if self.weight_scaling_omega > 0.0:
+                    tile_weight, _ = analog_tile.get_weights_scaled(realistic=realistic)
+                else:
+                    tile_weight, _ = analog_tile.get_weights(realistic=realistic)
+                in_tile_weight.append(tile_weight)
+            weight_lst.append(cat(in_tile_weight, 0))
+
+        weight = cat(weight_lst, 1)
 
         if self.digital_bias:
-            return out + self.digital_bias_view()
-        return out
+            with no_grad():
+                return weight, self.bias.data.detach().cpu()
+        return weight, None
+
+    def extra_repr(self) -> str:
+        """Set the extra representation of the module.
+
+        Returns:
+            A string with the extra representation.
+        """
+        output = AnalogModuleBase.extra_repr(self)[:-1]
+        output += ', mapping={}'.format((len(self.in_sizes), len(self.out_sizes)))
+
+        return output
 
 
-class AnalogConv1d(_AnalogConvNd):
-    """1D convolution layer that uses an analog tile.
+class AnalogConv1dMapped(_AnalogConvNdMapped):
+    """1D convolution layer that maps to analog tiles.
 
     Applies a 1D convolution over an input signal composed of several input
     planes, using an analog tile for its forward, backward and update passes.
+
+    The module will split the weight matrix onto multiple tiles if
+    necessary. Physical max tile sizes are specified with
+    :class:`~aihwkit.simulator.configs.utils.MappingParameter` in the
+    RPU configuration, see
+    :class:`~aihwkit.simulator.configs.configs.RPUConfigAlias`.
 
     Note:
         The tensor parameters of this layer (``.weight`` and ``.bias``) are not
@@ -219,7 +435,7 @@ class AnalogConv1d(_AnalogConvNd):
             padding_mode: str = 'zeros',
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
-            weight_scaling_omega: float = 0.0
+            weight_scaling_omega: float = 0.0,
     ):
         # pylint: disable=too-many-arguments
         kernel_size = _single(kernel_size)
@@ -243,8 +459,8 @@ class AnalogConv1d(_AnalogConvNd):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
-    ) -> 'AnalogConv1d':
-        """Return an AnalogConv1d layer from a torch Conv1d layer.
+    ) -> 'AnalogConv1dMapped':
+        """Return an AnalogConv1dMapped layer from a torch Conv1d layer.
 
         Args:
             module: The torch module to convert. All layers that are
@@ -305,7 +521,7 @@ class AnalogConv1d(_AnalogConvNd):
         """
         input_size = x_input.numel() / x_input.size(0)
 
-        # pytorch just always uses NCHW order
+        # pytorch just always uses NCHW order?
         fold_indices = arange(2, x_input.size(2) + 2, dtype=float64).detach()
         shape = [1] + [1] + list(x_input.shape[2:])
         fold_indices = fold_indices.reshape(*shape)
@@ -346,11 +562,17 @@ class AnalogConv1d(_AnalogConvNd):
         return self.bias.view(self.out_channels, 1)
 
 
-class AnalogConv2d(_AnalogConvNd):
-    """2D convolution layer that uses an analog tile.
+class AnalogConv2dMapped(_AnalogConvNdMapped):
+    """2D convolution layer that maps to analog tiles.
 
     Applies a 2D convolution over an input signal composed of several input
     planes, using an analog tile for its forward, backward and update passes.
+
+    The module will split the weight matrix onto multiple tiles if
+    necessary. Physical max tile sizes are specified with
+    :class:`~aihwkit.simulator.configs.utils.MappingParameter` in the
+    RPU configuration, see
+    :class:`~aihwkit.simulator.configs.configs.RPUConfigAlias`.
 
     Note:
         The tensor parameters of this layer (``.weight`` and ``.bias``) are not
@@ -392,7 +614,7 @@ class AnalogConv2d(_AnalogConvNd):
             padding_mode: str = 'zeros',
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
-            weight_scaling_omega: float = 0.0,
+            weight_scaling_omega: float = 0.0
     ):
         # pylint: disable=too-many-arguments
         kernel_size = _pair(kernel_size)
@@ -413,8 +635,8 @@ class AnalogConv2d(_AnalogConvNd):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
-    ) -> 'AnalogConv2d':
-        """Return an AnalogConv2d layer from a torch Conv2d layer.
+    ) -> 'AnalogConv2dMapped':
+        """Return an AnalogConv2dMapped layer from a torch Conv2d layer.
 
         Args:
             module: The torch module to convert. All layers that are
@@ -432,7 +654,7 @@ class AnalogConv2d(_AnalogConvNd):
                     device support the desired analog weight range.
 
         Returns:
-            an AnalogConv2d layer based on the digital Conv2d ``module``.
+            an AnalogConv2dMapped layer based on the digital Conv2d ``module``.
         """
         analog_module = cls(module.in_channels,
                             module.out_channels,
@@ -505,11 +727,17 @@ class AnalogConv2d(_AnalogConvNd):
         return self.bias.view(self.out_channels, 1, 1)
 
 
-class AnalogConv3d(_AnalogConvNd):
-    """3D convolution layer that uses an analog tile.
+class AnalogConv3dMapped(_AnalogConvNdMapped):
+    """3D convolution layer that maps to analog tiles.
 
     Applies a 3D convolution over an input signal composed of several input
     planes, using an analog tile for its forward, backward and update passes.
+
+    The module will split the weight matrix onto multiple tiles if
+    necessary. Physical max tile sizes are specified with
+    :class:`~aihwkit.simulator.configs.utils.MappingParameter` in the
+    RPU configuration, see
+    :class:`~aihwkit.simulator.configs.configs.RPUConfigAlias`.
 
     Note:
         The tensor parameters of this layer (``.weight`` and ``.bias``) are not
@@ -535,6 +763,12 @@ class AnalogConv3d(_AnalogConvNd):
             for setting initial weights and read out of weights.
         weight_scaling_omega: the weight value where the max weight will be
             scaled to. If zero, no weight scaling will be performed.
+
+    Raises:
+        ModuleError: Tiling weight matrices is always done across channels
+            only. If the kernel number of elements is larger than the
+            maximal tile size, mapping cannot be done
+
     """
     # pylint: disable=abstract-method
 
@@ -565,7 +799,7 @@ class AnalogConv3d(_AnalogConvNd):
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,  # type: ignore
             False, _triple(0), groups, bias, padding_mode,
-            rpu_config, realistic_read_write, weight_scaling_omega
+            rpu_config, realistic_read_write, weight_scaling_omega,
         )
 
     @classmethod
@@ -575,8 +809,8 @@ class AnalogConv3d(_AnalogConvNd):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
-    ) -> 'AnalogConv3d':
-        """Return an AnalogConv3d layer from a torch Conv3d layer.
+    ) -> 'AnalogConv3dMapped':
+        """Return an AnalogConv3dMapped layer from a torch Conv3d layer.
 
         Args:
             module: The torch module to convert. All layers that are
@@ -607,7 +841,8 @@ class AnalogConv3d(_AnalogConvNd):
                             module.padding_mode,
                             rpu_config,
                             realistic_read_write,
-                            weight_scaling_omega)
+                            weight_scaling_omega,
+                            )
 
         analog_module.set_weights(module.weight, module.bias)
         return analog_module
@@ -628,7 +863,7 @@ class AnalogConv3d(_AnalogConvNd):
 
         Args:
             x_input: input matrix
-            in_channels: then number of in channels
+            in_channels: number of input channel
 
         Returns:
             fold_indices: indices for the analog tile

--- a/src/aihwkit/nn/modules/linear.py
+++ b/src/aihwkit/nn/modules/linear.py
@@ -19,6 +19,7 @@ from torch.nn import Linear
 
 from aihwkit.nn.functions import AnalogFunction
 from aihwkit.nn.modules.base import AnalogModuleBase, RPUConfigAlias
+from aihwkit.simulator.configs import SingleRPUConfig
 
 
 class AnalogLinear(AnalogModuleBase, Linear):
@@ -45,8 +46,6 @@ class AnalogLinear(AnalogModuleBase, Linear):
         weight_scaling_omega: the weight value where the max
             weight will be scaled to. If zero, no weight scaling will
             be performed.
-        digital_bias: decide whether the bias term is handled by the analog tile
-            or kept in digital.
     """
     # pylint: disable=abstract-method
 
@@ -68,25 +67,29 @@ class AnalogLinear(AnalogModuleBase, Linear):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
-            digital_bias: bool = False
-    ):
-
+              ):
         # Call super() after tile creation, including ``reset_parameters``.
         Linear.__init__(self, in_features, out_features, bias=bias)
 
-        # Create the tile.
-        AnalogModuleBase.__init__(self)
-        self.analog_tile = self._setup_tile(in_features,
-                                            out_features,
-                                            bias,
-                                            rpu_config,
-                                            realistic_read_write,
-                                            weight_scaling_omega,
-                                            digital_bias)
+        # Create tile
+        if rpu_config is None:
+            rpu_config = SingleRPUConfig()
+
+        AnalogModuleBase.__init__(
+            self,
+            in_features,
+            out_features,
+            bias,
+            realistic_read_write,
+            weight_scaling_omega,
+            rpu_config.mapping
+        )
+        self.analog_tile = self._setup_tile(rpu_config)
+
         # Register tile
         self.register_analog_tile(self.analog_tile)
-        # Set weights from the reset_parameters call (since only now the
-        # analog_tiles are registered)
+
+        # Set weights from the reset_parameters call
         self.set_weights(self.weight, self.bias)
 
         # Unregister weight/bias as a parameter but keep it as a
@@ -102,7 +105,6 @@ class AnalogLinear(AnalogModuleBase, Linear):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
-            digital_bias: bool = False,
     ) -> 'AnalogLinear':
         """Return an AnalogLinear layer from a torch Linear layer.
 
@@ -116,8 +118,6 @@ class AnalogLinear(AnalogModuleBase, Linear):
             weight_scaling_omega: If non-zero, applied weights of analog
                 layers will be scaled by ``weight_scaling_omega`` divided by
                 the absolute maximum value of the original weight matrix.
-            digital_bias: decide whether the bias term is handled by the analog tile
-                or kept in digital.
 
                 Note:
                     Make sure that the weight max and min setting of the
@@ -131,8 +131,7 @@ class AnalogLinear(AnalogModuleBase, Linear):
                             module.bias is not None,
                             rpu_config,
                             realistic_read_write,
-                            weight_scaling_omega,
-                            digital_bias)
+                            weight_scaling_omega)
 
         analog_module.set_weights(module.weight, module.bias)
         return analog_module

--- a/src/aihwkit/nn/modules/linear.py
+++ b/src/aihwkit/nn/modules/linear.py
@@ -42,9 +42,9 @@ class AnalogLinear(AnalogModuleBase, Linear):
         rpu_config: resistive processing unit configuration.
         bias: whether to use a bias row on the analog tile or not.
         realistic_read_write: whether to enable realistic read/write
-            for setting initial weights and read out of weights.
-        weight_scaling_omega: the weight value where the max
-            weight will be scaled to. If zero, no weight scaling will
+            for setting initial weights and during reading of the weights.
+        weight_scaling_omega: the weight value that the current max
+            weight value will be scaled to. If zero, no weight scaling will
             be performed.
     """
     # pylint: disable=abstract-method
@@ -115,12 +115,12 @@ class AnalogLinear(AnalogModuleBase, Linear):
                 Applied to all converted tiles.
             realistic_read_write: Whether to use closed-loop programming
                 when setting the weights. Applied to all converted tiles.
-            weight_scaling_omega: If non-zero, applied weights of analog
-                layers will be scaled by ``weight_scaling_omega`` divided by
-                the absolute maximum value of the original weight matrix.
+            weight_scaling_omega: If non-zero, the analog weights will be
+                scaled by ``weight_scaling_omega`` divided by the absolute
+                maximum value of the original weight matrix.
 
                 Note:
-                    Make sure that the weight max and min setting of the
+                    Make sure that the weight max and min settings of the
                     device support the desired analog weight range.
 
         Returns:

--- a/src/aihwkit/nn/modules/linear_mapped.py
+++ b/src/aihwkit/nn/modules/linear_mapped.py
@@ -319,12 +319,12 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
                 Applied to all converted tiles.
             realistic_read_write: Whether to use closed-loop programming
                 when setting the weights. Applied to all converted tiles.
-            weight_scaling_omega: If non-zero, applied weights of analog
-                layers will be scaled by ``weight_scaling_omega`` divided by
-                the absolute maximum value of the original weight matrix.
+            weight_scaling_omega: If non-zero, the analog weights will be
+                scaled by ``weight_scaling_omega`` divided by the absolute
+                maximum value of the original weight matrix.
 
                 Note:
-                    Make sure that the weight max and min setting of the
+                    Make sure that the weight max and min settings of the
                     device support the desired analog weight range.
 
         Returns:

--- a/src/aihwkit/nn/modules/linear_mapped.py
+++ b/src/aihwkit/nn/modules/linear_mapped.py
@@ -17,9 +17,8 @@ from typing import Optional, Tuple, List
 from torch import Tensor, cat, split, no_grad
 from torch.nn import Linear
 
-from aihwkit.nn.modules.base import RPUConfigAlias
 from aihwkit.nn.functions import AnalogFunction
-from aihwkit.nn.modules.base import AnalogModuleBase
+from aihwkit.nn.modules.base import AnalogModuleBase, RPUConfigAlias
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.exceptions import ModuleError
 
@@ -59,7 +58,6 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
         weight_scaling_omega: the weight value where the max
             weight will be scaled to. If zero, no weight scaling will
             be performed
-
     """
     # pylint: disable=abstract-method, too-many-locals, too-many-instance-attributes
 
@@ -83,35 +81,33 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
-            digital_bias: bool = True,
     ):
-
-        AnalogModuleBase.__init__(self)
-
-        if bias and not digital_bias:
-            raise ModuleError("AnalogMappedLayer only supports digital bias.")
-
-        self.in_features = in_features
-        self.out_features = out_features
-        self.use_bias = bias
-        self.analog_bias = False
-        self.digital_bias = bias
-
-        self.realistic_read_write = realistic_read_write
-        self.weight_scaling_omega = weight_scaling_omega
-
-        if not rpu_config:
-            rpu_config = SingleRPUConfig()
 
         # Call super() after tile creation, including ``reset_parameters``.
         Linear.__init__(self, in_features, out_features, bias=bias)
 
-        # Create the tile(s)
+        # Create tiles
+        if rpu_config is None:
+            rpu_config = SingleRPUConfig()
+
+        AnalogModuleBase.__init__(
+            self,
+            in_features,
+            out_features,
+            bias,
+            realistic_read_write,
+            weight_scaling_omega,
+            rpu_config.mapping
+        )
+        if self.analog_bias:
+            raise ModuleError("AnalogLinearMapped only supports digital bias.")
+
         # More than one tile may need to be created. If so, divide
         # weight matrix into equal pieces along input dimension with
         # as many tiles as needed
         max_input_size = rpu_config.mapping.max_input_size
         max_output_size = rpu_config.mapping.max_output_size
+
         self.in_sizes = self.get_split_sizes(in_features, max_input_size)
         self.out_sizes = self.get_split_sizes(out_features, max_output_size)
 
@@ -127,12 +123,10 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
                 in_tiles.append(tile)
             self.analog_tile_array.append(in_tiles)
 
-        # Set weights from the reset_parameters call (since only now the
-        # analog_tiles are registered)
+        # Set weights from the reset_parameters
         self.set_weights(self.weight, self.bias)
 
-        # Unregister weight/bias as a parameter but keep it as a
-        # field (needed for syncing still)
+        # Unregister weight/bias as a parameter but keep for sync
         self.unregister_parameter('weight')
 
         if self.analog_bias:
@@ -148,6 +142,9 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
         Returns:
             List of split sizes
         """
+        if split_max_size <= 0:
+            return [size]
+
         n_splits = (size + split_max_size - 1) // split_max_size
         base, extra = divmod(size, n_splits)
         return [base + (i < extra) for i in range(n_splits)]
@@ -202,7 +199,7 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
                 out_start = out_end
             in_start = in_end
 
-        if self.use_bias and bias is not None:
+        if self.digital_bias and bias is not None:
             with no_grad():
                 self.bias.data[:] = bias[:]
 
@@ -300,7 +297,7 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
         Returns:
             A string with the extra representation.
         """
-        output = AnalogModuleBase.extra_repr(self)[:-1]
+        output = AnalogModuleBase.extra_repr(self)
         output += ', mapping={}'.format((len(self.in_sizes), len(self.out_sizes)))
 
         return output
@@ -312,7 +309,6 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: float = 0.0,
-            digital_bias: bool = False,
     ) -> 'AnalogLinearMapped':
         """Return an AnalogLinearMapped layer from a torch Linear layer.
 
@@ -326,8 +322,6 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
             weight_scaling_omega: If non-zero, applied weights of analog
                 layers will be scaled by ``weight_scaling_omega`` divided by
                 the absolute maximum value of the original weight matrix.
-            digital_bias: decide whether the bias term is handled by the analog tile
-                or kept in digital.
 
                 Note:
                     Make sure that the weight max and min setting of the
@@ -342,7 +336,7 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
                             rpu_config,
                             realistic_read_write,
                             weight_scaling_omega,
-                            digital_bias)
+                            )
 
         analog_module.set_weights(module.weight, module.bias)
         return analog_module

--- a/src/aihwkit/nn/modules/lstm.py
+++ b/src/aihwkit/nn/modules/lstm.py
@@ -100,11 +100,9 @@ from torch import Tensor, sigmoid, stack, tanh, jit, zeros
 from torch.nn import Dropout, ModuleList, init
 
 from aihwkit.nn import AnalogLinear, AnalogSequential
-from aihwkit.nn.modules.base import RPUConfigAlias
 from aihwkit.simulator.configs import SingleRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice
-from aihwkit.nn.modules.base import AnalogModuleBase
-
+from aihwkit.nn.modules.base import AnalogModuleBase, RPUConfigAlias
 
 LSTMState = namedtuple('LSTMState', ['hx', 'cx'])
 

--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -31,20 +31,11 @@ from aihwkit.inference import (
     PCMLikeNoiseModel
 )
 from aihwkit.simulator.rpu_base import devices
-
 from aihwkit.simulator.tiles import AnalogTile, FloatingPointTile, InferenceTile
 
 
 @dataclass
-class BaseRPUConfig(_PrintableMixin):
-    """ Base class  for RPUConfigs """
-
-    mapping: MappingParameter = field(default_factory=MappingParameter)
-    """Parameter related to mapping weights to tiles for supporting modules."""
-
-
-@dataclass
-class FloatingPointRPUConfig(BaseRPUConfig):
+class FloatingPointRPUConfig(_PrintableMixin):
     """Configuration for a floating point resistive processing unit."""
 
     tile_class: ClassVar[Type] = FloatingPointTile
@@ -53,9 +44,12 @@ class FloatingPointRPUConfig(BaseRPUConfig):
     device: FloatingPointDevice = field(default_factory=FloatingPointDevice)
     """Parameter that modify the behavior of the pulsed device."""
 
+    mapping: MappingParameter = field(default_factory=MappingParameter)
+    """Parameter related to mapping weights to tiles for supporting modules."""
+
 
 @dataclass
-class SingleRPUConfig(BaseRPUConfig):
+class SingleRPUConfig(_PrintableMixin):
     """Configuration for an analog (pulsed device) resistive processing unit."""
 
     tile_class: ClassVar[Type] = AnalogTile
@@ -75,13 +69,16 @@ class SingleRPUConfig(BaseRPUConfig):
     update: UpdateParameters = field(default_factory=UpdateParameters)
     """Parameter for the update behavior."""
 
+    mapping: MappingParameter = field(default_factory=MappingParameter)
+    """Parameter related to mapping weights to tiles for supporting modules."""
+
     def as_bindings(self) -> devices.AnalogTileParameter:
         """Return a representation of this instance as a simulator bindings object."""
         return tile_parameters_to_bindings(self)
 
 
 @dataclass
-class UnitCellRPUConfig(BaseRPUConfig):
+class UnitCellRPUConfig(_PrintableMixin):
     """Configuration for an analog (unit cell) resistive processing unit."""
 
     tile_class: ClassVar[Type] = AnalogTile
@@ -101,13 +98,16 @@ class UnitCellRPUConfig(BaseRPUConfig):
     update: UpdateParameters = field(default_factory=UpdateParameters)
     """Parameter for the parallel analog update behavior."""
 
+    mapping: MappingParameter = field(default_factory=MappingParameter)
+    """Parameter related to mapping weights to tiles for supporting modules."""
+
     def as_bindings(self) -> devices.AnalogTileParameter:
         """Return a representation of this instance as a simulator bindings object."""
         return tile_parameters_to_bindings(self)
 
 
 @dataclass
-class InferenceRPUConfig(BaseRPUConfig):
+class InferenceRPUConfig(_PrintableMixin):
     """Configuration for an analog tile that is used only for inference.
 
     Training is done in *hardware-aware* manner, thus using only the
@@ -158,13 +158,16 @@ class InferenceRPUConfig(BaseRPUConfig):
     )
     """Parameter for the update behavior: ``NONE`` pulse type."""
 
+    mapping: MappingParameter = field(default_factory=MappingParameter)
+    """Parameter related to mapping weights to tiles for supporting modules."""
+
     def as_bindings(self) -> devices.AnalogTileParameter:
         """Return a representation of this instance as a simulator bindings object."""
         return tile_parameters_to_bindings(self)
 
 
 @dataclass
-class DigitalRankUpdateRPUConfig(BaseRPUConfig):
+class DigitalRankUpdateRPUConfig(_PrintableMixin):
     """Configuration for an analog (unit cell) resistive processing unit
     where the rank update is done in digital.
 
@@ -190,6 +193,9 @@ class DigitalRankUpdateRPUConfig(BaseRPUConfig):
     update: UpdateParameters = field(default_factory=UpdateParameters)
     """Parameter for the analog part of the update, that is the transfer
     from the digital buffer to the devices."""
+
+    mapping: MappingParameter = field(default_factory=MappingParameter)
+    """Parameter related to mapping weights to tiles for supporting modules."""
 
     def as_bindings(self) -> devices.AnalogTileParameter:
         """Return a representation of this instance as a simulator bindings object."""

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -703,12 +703,14 @@ class DriftParameter(SimpleDriftParameter):
 
 @dataclass
 class MappingParameter(_PrintableMixin):
-    """Parameter related to the mapping of logical weights to physical tiles.
+    """Parameter related to hardware design and the mapping of logical
+    weight matrices to physical tiles.
 
     Caution:
 
         Some of these parameters have only an affect for modules that
-        support mappings.
+        support tile mappings.
+
     """
 
     digital_bias: bool = True
@@ -722,12 +724,16 @@ class MappingParameter(_PrintableMixin):
         is instead situated on the the crossbar itself (as an extra
         column)
 
-    Caution:
+    Note:
         ``digital_bias`` is supported by *all* analog modules.
     """
 
     max_input_size: int = 512
-    """Maximal size of the physical in the input dimension.
+    """Maximal input size (number of columns) of the weight matrix
+    that is handled on a single analog tile.
+
+    If the logical weight matrix size exceeds this size it will be
+    split and mapped onto multiple analog tiles.
 
     Caution:
         Only relevant for ``Mapped`` modules such as
@@ -735,7 +741,11 @@ class MappingParameter(_PrintableMixin):
     """
 
     max_output_size: int = 512
-    """Maximal size of the physical in the output dimension.
+    """Maximal output size (number of rows) of the weight matrix
+    that is handled on a single analog tile.
+
+    If the logical weight matrix size exceeds this size it will be
+    split and mapped onto multiple analog tiles.
 
     Caution:
         Only relevant for ``Mapped`` modules such as

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -687,10 +687,10 @@ class DriftParameter(SimpleDriftParameter):
     """``w(g_min)``, i.e. to what value ``g_min`` is mapped to in w-space."""
 
     nu_k: float = 0.0
-    r"""Variation of "math:`nu` with :math:`W`.
+    r"""Variation of math:`nu` with :math:`W`.
 
-    ie. :math:`\nu(R) = nu_0 - k \log(G/G_0)`.
-    See Oh et al.
+    That is :math:`\nu(R) = nu_0 - k \log(G/G_0)`.  See Oh et al. for
+    details.
     """
 
     log_g0: float = 0.0
@@ -705,16 +705,39 @@ class DriftParameter(SimpleDriftParameter):
 class MappingParameter(_PrintableMixin):
     """Parameter related to the mapping of logical weights to physical tiles.
 
-    Note:
+    Caution:
 
-        These parameters have only an affect for modules that
+        Some of these parameters have only an affect for modules that
         support mappings.
+    """
+
+    digital_bias: bool = True
+    """Whether the bias term is handled by the analog tile or kept in
+    digital.
+
+    Note:
+        Default is having a *digital* bias so that bias values are
+        *not* stored onto the analog crossbar. This needs to be
+        supported by the chip design. Set to False if the analog bias
+        is instead situated on the the crossbar itself (as an extra
+        column)
+
+    Caution:
+        ``digital_bias`` is supported by *all* analog modules.
     """
 
     max_input_size: int = 512
     """Maximal size of the physical in the input dimension.
+
+    Caution:
+        Only relevant for ``Mapped`` modules such as
+        :class:`aihwkit.nn.modules.linear_mapped.AnalogLinearMapped`.
     """
 
     max_output_size: int = 512
     """Maximal size of the physical in the output dimension.
+
+    Caution:
+        Only relevant for ``Mapped`` modules such as
+        :class:`aihwkit.nn.modules.linear_mapped.AnalogLinearMapped`.
     """

--- a/tests/helpers/layers.py
+++ b/tests/helpers/layers.py
@@ -14,8 +14,11 @@
 
 """Layer helpers for aihwkit tests."""
 
+from unittest import SkipTest
+
 from aihwkit.nn import (
-    AnalogConv1d, AnalogConv2d, AnalogConv3d, AnalogLinear, AnalogLSTM, AnalogLinearMapped
+    AnalogConv1d, AnalogConv2d, AnalogConv3d, AnalogLinear, AnalogLSTM, AnalogLinearMapped,
+    AnalogConv1dMapped, AnalogConv2dMapped, AnalogConv3dMapped
 )
 from aihwkit.simulator.configs.utils import MappingParameter
 
@@ -28,8 +31,7 @@ class Linear:
     def get_layer(self, in_features=3, out_features=4, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
-        kwargs.setdefault('digital_bias', self.digital_bias)
-
+        kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
         return AnalogLinear(in_features, out_features, **kwargs)
 
 
@@ -43,10 +45,11 @@ class LinearMapped:
         return super().get_rpu_config(**kwargs)
 
     def get_layer(self, in_features=10, out_features=6, **kwargs):
-
+        if not self.digital_bias and self.bias:
+            raise SkipTest('Analog Bias is not supported.')
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
-
+        kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
         return AnalogLinearMapped(in_features, out_features, **kwargs)
 
 
@@ -55,14 +58,13 @@ class Conv1d:
 
     use_cuda = False
 
-    def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
+    def get_layer(self, in_channels=2, out_channels=3, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
-        kwargs.setdefault('digital_bias', self.digital_bias)
-
-        return AnalogConv1d(in_channels, out_channels, kernel_size,
-                            padding=padding,
-                            **kwargs)
+        kwargs.setdefault('kernel_size', [4])
+        kwargs.setdefault('padding', 2)
+        kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
+        return AnalogConv1d(in_channels, out_channels, **kwargs)
 
 
 class Conv2d:
@@ -70,14 +72,13 @@ class Conv2d:
 
     use_cuda = False
 
-    def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
+    def get_layer(self, in_channels=2, out_channels=3, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
-        kwargs.setdefault('digital_bias', self.digital_bias)
-
-        return AnalogConv2d(in_channels, out_channels, kernel_size,
-                            padding=padding,
-                            **kwargs)
+        kwargs.setdefault('kernel_size', [3, 3])
+        kwargs.setdefault('padding', 2)
+        kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
+        return AnalogConv2d(in_channels, out_channels, **kwargs)
 
 
 class Conv3d:
@@ -85,14 +86,79 @@ class Conv3d:
 
     use_cuda = False
 
-    def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
+    def get_layer(self, in_channels=2, out_channels=3, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
-        kwargs.setdefault('digital_bias', self.digital_bias)
+        kwargs.setdefault('kernel_size', [2, 2, 2])
+        kwargs.setdefault('padding', 2)
+        kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
+        return AnalogConv3d(in_channels, out_channels, **kwargs)
 
-        return AnalogConv3d(in_channels, out_channels, kernel_size,
-                            padding=padding,
-                            **kwargs)
+
+class Conv1dMapped:
+    """AnalogConv1dMapped."""
+
+    use_cuda = False
+
+    def get_rpu_config(self, **kwargs):
+        kwargs.setdefault('mapping', MappingParameter(max_input_size=4, max_output_size=3))
+        return super().get_rpu_config(**kwargs)
+
+    def get_layer(self, in_channels=2, out_channels=3, **kwargs):
+
+        if not self.digital_bias and self.bias:
+            raise SkipTest('Analog Bias is not supported.')
+
+        kwargs.setdefault('rpu_config', self.get_rpu_config())
+        kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('kernel_size', [4])
+        kwargs.setdefault('padding', 2)
+        kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
+        return AnalogConv1dMapped(in_channels, out_channels, **kwargs)
+
+
+class Conv2dMapped:
+    """AnalogConv2dMapped."""
+
+    use_cuda = False
+
+    def get_rpu_config(self, **kwargs):
+        kwargs.setdefault('mapping', MappingParameter(max_input_size=21, max_output_size=3))
+        return super().get_rpu_config(**kwargs)
+
+    def get_layer(self, in_channels=2, out_channels=3, **kwargs):
+
+        if not self.digital_bias and self.bias:
+            raise SkipTest('Analog Bias is not supported.')
+
+        kwargs.setdefault('rpu_config', self.get_rpu_config())
+        kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('kernel_size', [3, 3])
+        kwargs.setdefault('padding', 2)
+        kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
+        return AnalogConv2dMapped(in_channels, out_channels, **kwargs)
+
+
+class Conv3dMapped:
+    """AnalogConv3dMapped."""
+
+    use_cuda = False
+
+    def get_rpu_config(self, **kwargs):
+        kwargs.setdefault('mapping', MappingParameter(max_input_size=21, max_output_size=3))
+        return super().get_rpu_config(**kwargs)
+
+    def get_layer(self, in_channels=2, out_channels=3, **kwargs):
+
+        if not self.digital_bias and self.bias:
+            raise SkipTest('Analog Bias is not supported.')
+
+        kwargs.setdefault('rpu_config', self.get_rpu_config())
+        kwargs.setdefault('bias', self.bias)
+        kwargs.setdefault('kernel_size', [2, 2, 2])
+        kwargs.setdefault('padding', 2)
+        kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
+        return AnalogConv3dMapped(in_channels, out_channels, **kwargs)
 
 
 class LSTM:
@@ -103,91 +169,86 @@ class LSTM:
     def get_layer(self, input_size=2, hidden_size=3, **kwargs):
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
-
+        kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
         return AnalogLSTM(input_size, hidden_size, **kwargs)
 
 
-class LinearCuda:
+class LinearCuda(Linear):
     """AnalogLinear."""
 
     use_cuda = True
 
-    def get_layer(self, in_features=3, out_features=4, **kwargs):
-        kwargs.setdefault('rpu_config', self.get_rpu_config())
-        kwargs.setdefault('bias', self.bias)
-        kwargs.setdefault('digital_bias', self.digital_bias)
-
-        return AnalogLinear(in_features, out_features, **kwargs).cuda()
+    def get_layer(self, *args, **kwargs):
+        return Linear.get_layer(self, *args, **kwargs).cuda()
 
 
-class LinearMappedCuda:
+class LinearMappedCuda(LinearMapped):
     """AnalogLinearMapped."""
 
     use_cuda = True
 
-    def get_rpu_config(self, **kwargs):
-        kwargs.setdefault('mapping', MappingParameter(max_input_size=4, max_output_size=3))
-        return super().get_rpu_config(**kwargs)
-
-    def get_layer(self, in_features=10, out_features=6, **kwargs):
-        kwargs.setdefault('rpu_config', self.get_rpu_config())
-        kwargs.setdefault('bias', self.bias)
-
-        return AnalogLinearMapped(in_features, out_features, **kwargs).cuda()
+    def get_layer(self, *args, **kwargs):
+        return LinearMapped.get_layer(self, *args, **kwargs).cuda()
 
 
-class Conv1dCuda:
-    """AnalogConv1d."""
+class Conv1dCuda(Conv1d):
+    """AnalogConv1dCuda."""
 
     use_cuda = True
 
-    def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
-        kwargs.setdefault('rpu_config', self.get_rpu_config())
-        kwargs.setdefault('bias', self.bias)
-        kwargs.setdefault('digital_bias', self.digital_bias)
-
-        return AnalogConv1d(in_channels, out_channels, kernel_size,
-                            padding=padding,
-                            **kwargs).cuda()
+    def get_layer(self, *args, **kwargs):
+        return Conv1d.get_layer(self, *args, **kwargs).cuda()
 
 
-class Conv2dCuda:
-    """AnalogConv2d."""
+class Conv2dCuda(Conv2d):
+    """AnalogConv2dCuda."""
 
     use_cuda = True
 
-    def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
-        kwargs.setdefault('rpu_config', self.get_rpu_config())
-        kwargs.setdefault('bias', self.bias)
-        kwargs.setdefault('digital_bias', self.digital_bias)
-
-        return AnalogConv2d(in_channels, out_channels, kernel_size,
-                            padding=padding,
-                            **kwargs).cuda()
+    def get_layer(self, *args, **kwargs):
+        return Conv2d.get_layer(self, *args, **kwargs).cuda()
 
 
-class Conv3dCuda:
-    """AnalogConv3d."""
+class Conv3dCuda(Conv2d):
+    """AnalogConv3dCuda."""
 
     use_cuda = True
 
-    def get_layer(self, in_channels=2, out_channels=3, kernel_size=4, padding=2, **kwargs):
-        kwargs.setdefault('rpu_config', self.get_rpu_config())
-        kwargs.setdefault('bias', self.bias)
-        kwargs.setdefault('digital_bias', self.digital_bias)
-
-        return AnalogConv3d(in_channels, out_channels, kernel_size,
-                            padding=padding,
-                            **kwargs).cuda()
+    def get_layer(self, *args, **kwargs):
+        return Conv3d.get_layer(self, *args, **kwargs).cuda()
 
 
-class LSTMCuda:
-    """AnalogLSTM."""
+class Conv1dMappedCuda(Conv1dMapped):
+    """AnalogConv1dMappedCuda."""
 
     use_cuda = True
 
-    def get_layer(self, input_size=2, hidden_size=3, **kwargs):
-        kwargs.setdefault('rpu_config', self.get_rpu_config())
-        kwargs.setdefault('bias', self.bias)
+    def get_layer(self, *args, **kwargs):
+        return Conv1dMapped.get_layer(self, *args, **kwargs).cuda()
 
-        return AnalogLSTM(input_size, hidden_size, **kwargs).cuda()
+
+class Conv2dMappedCuda(Conv2dMapped):
+    """AnalogConv2dMappedCuda."""
+
+    use_cuda = True
+
+    def get_layer(self, *args, **kwargs):
+        return Conv2dMapped.get_layer(self, *args, **kwargs).cuda()
+
+
+class Conv3dMappedCuda(Conv3dMapped):
+    """AnalogConv3dMappedCuda."""
+
+    use_cuda = True
+
+    def get_layer(self, *args, **kwargs):
+        return Conv3dMapped.get_layer(self, *args, **kwargs).cuda()
+
+
+class LSTMCuda(LSTM):
+    """AnalogLSTMCuda."""
+
+    use_cuda = True
+
+    def get_layer(self, *args, **kwargs):
+        return LSTM.get_layer(self, *args, **kwargs).cuda()

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -37,11 +37,11 @@ from .helpers.tiles import ConstantStep, Inference
     layers=[Linear, Conv1d, Conv2d, Conv3d,
             LinearCuda, Conv1dCuda, Conv2dCuda, Conv3dCuda],
     tiles=[ConstantStep],
-    biases=[True, False],
-    digital_biases=[True, False]
+    biases=['analog', None]
 )
 class AnalogLayerTest(ParametrizedTestCase):
     """Analog layers abstraction tests."""
+    # pylint: disable=no-member
 
     def test_realistic_weights(self):
         """Test using realistic weights."""
@@ -52,7 +52,7 @@ class AnalogLayerTest(ParametrizedTestCase):
         # the weights are synced after being set.
         tile_weights, tile_biases = layer.analog_tile.get_weights()
         self.assertTensorAlmostEqual(layer.weight, tile_weights.reshape(shape))
-        if self.bias:
+        if self.analog_bias:
             self.assertTensorAlmostEqual(layer.bias, tile_biases)
 
         # 1. Set the layer weights and biases.
@@ -64,13 +64,13 @@ class AnalogLayerTest(ParametrizedTestCase):
         # the weights are synced after being set.
         tile_weights, tile_biases = layer.analog_tile.get_weights()
         self.assertTensorAlmostEqual(layer.weight, tile_weights.reshape(shape))
-        if self.bias:
+        if self.analog_bias:
             self.assertTensorAlmostEqual(layer.bias, tile_biases)
 
         # Check that the tile weights are different than the user-specified
         # weights, as it is realistic.
         self.assertNotAlmostEqualTensor(user_weights, tile_weights.reshape(shape))
-        if self.bias:
+        if self.analog_bias:
             self.assertNotAlmostEqualTensor(user_biases, tile_biases)
 
         # 2. Get the layer weights and biases.
@@ -79,7 +79,7 @@ class AnalogLayerTest(ParametrizedTestCase):
         # Check that the tile weights are different than the gotten
         # weights, as it is realistic.
         self.assertNotAlmostEqualTensor(gotten_weights, tile_weights.reshape(shape))
-        if self.bias:
+        if self.analog_bias:
             self.assertNotAlmostEqualTensor(gotten_biases, tile_biases)
 
     def test_not_realistic_weights(self):
@@ -91,7 +91,7 @@ class AnalogLayerTest(ParametrizedTestCase):
         # the weights are synced after being set.
         tile_weights, tile_biases = layer.analog_tile.get_weights()
         self.assertTensorAlmostEqual(layer.weight, tile_weights.reshape(shape))
-        if self.bias:
+        if self.analog_bias:
             self.assertTensorAlmostEqual(layer.bias, tile_biases)
 
         # 1. Set the layer weights and biases.
@@ -103,13 +103,13 @@ class AnalogLayerTest(ParametrizedTestCase):
         # the weights are synced after being set.
         tile_weights, tile_biases = layer.analog_tile.get_weights()
         self.assertTensorAlmostEqual(layer.weight, tile_weights.reshape(shape))
-        if self.bias:
+        if self.analog_bias:
             self.assertTensorAlmostEqual(layer.bias, tile_biases)
 
         # Check that the tile weights are equal to the user-specified
         # weights, as it is not realistic.
         self.assertTensorAlmostEqual(user_weights, tile_weights)
-        if self.bias:
+        if self.analog_bias:
             self.assertTensorAlmostEqual(user_biases, tile_biases)
 
         # 2. Get the layer weights and biases.
@@ -118,7 +118,7 @@ class AnalogLayerTest(ParametrizedTestCase):
         # Check that the tile weights are equal than the gotten
         # weights, as it is not realistic.
         self.assertTensorAlmostEqual(gotten_weights, tile_weights)
-        if self.bias:
+        if self.analog_bias:
             self.assertTensorAlmostEqual(gotten_biases, tile_biases)
 
 
@@ -126,8 +126,7 @@ class AnalogLayerTest(ParametrizedTestCase):
     layers=[Linear, Conv1d, Conv2d, Conv3d,
             LinearCuda, Conv1dCuda, Conv2dCuda, Conv3dCuda],
     tiles=[ConstantStep, Inference],
-    biases=[True, False],
-    digital_biases=[True, False]
+    biases=['analog', None]
 )
 class AnalogLayerMoveTest(ParametrizedTestCase):
     """Analog layers abstraction tests."""
@@ -319,8 +318,7 @@ class AnalogLayerMoveTest(ParametrizedTestCase):
 @parametrize_over_layers(
     layers=[Linear, Conv1d, Conv2d, Conv3d],
     tiles=[ConstantStep, Inference],
-    biases=[True, False],
-    digital_biases=[True, False]
+    biases=['analog', 'digital', None]
 )
 class CpuAnalogLayerTest(ParametrizedTestCase):
     """Analog layers tests using CPU tiles as the source."""
@@ -391,8 +389,7 @@ class CustomTileTestHelper:
 @parametrize_over_layers(
     layers=[Linear, Conv1d, Conv2d, Conv3d],
     tiles=[CustomTileTestHelper],
-    biases=[True, False],
-    digital_biases=[True, False]
+    biases=['analog', 'digital', None]
 )
 class CustomTileTest(ParametrizedTestCase):
     """Test for analog layers using custom tiles."""

--- a/tests/test_layers_linear.py
+++ b/tests/test_layers_linear.py
@@ -21,6 +21,7 @@ from torch.optim import SGD
 
 from aihwkit.optim import AnalogSGD
 from aihwkit.simulator.configs.configs import InferenceRPUConfig, FloatingPointRPUConfig
+from aihwkit.simulator.configs.utils import MappingParameter
 from aihwkit.nn import AnalogSequential, AnalogLinear
 
 from .helpers.decorators import parametrize_over_layers
@@ -32,8 +33,7 @@ from .helpers.tiles import FloatingPoint, IdealizedConstantStep, Inference
 @parametrize_over_layers(
     layers=[Linear, LinearCuda],
     tiles=[FloatingPoint, IdealizedConstantStep, Inference],
-    biases=[True, False],
-    digital_biases=[True, False]
+    biases=['analog', 'digital', None]
 )
 class LinearLayerTest(ParametrizedTestCase):
     """Linear layer abstractions tests."""
@@ -177,11 +177,12 @@ class LinearLayerTest(ParametrizedTestCase):
             return
 
         manual_seed(4321)
+        rpu_config = FloatingPointRPUConfig(
+            mapping=MappingParameter(digital_bias=self.digital_bias)
+        )
         model2 = AnalogSequential(
-            AnalogLinear(4, 3, rpu_config=FloatingPointRPUConfig(), bias=self.bias,
-                         digital_bias=self.digital_bias),
-            AnalogLinear(3, 1, rpu_config=FloatingPointRPUConfig(), bias=self.bias,
-                         digital_bias=self.digital_bias)
+            AnalogLinear(4, 3, rpu_config=rpu_config, bias=self.bias),
+            AnalogLinear(3, 1, rpu_config=rpu_config, bias=self.bias)
         )
 
         if self.use_cuda:

--- a/tests/test_layers_lstm.py
+++ b/tests/test_layers_lstm.py
@@ -31,8 +31,7 @@ from .helpers.tiles import FloatingPoint, Inference
 @parametrize_over_layers(
     layers=[LSTM, LSTMCuda],
     tiles=[FloatingPoint, Inference],
-    biases=[False, True],
-    digital_biases=[False]
+    biases=['analog', 'digital', None]
 )
 class LSTMLayerTest(ParametrizedTestCase):
     """Tests for AnalogLSTM layer."""
@@ -104,11 +103,9 @@ class LSTMLayerTest(ParametrizedTestCase):
 
     def test_layer_training(self):
         """Test AnalogLSTM layer training."""
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals, too-many-statements
         def get_parameters(model, analog_if) -> dict:
             """Returns the parameter in an dict."""
-            if not analog_if:
-                return dict(model.named_parameters())
 
             dic = {}
             for name, param in model.named_parameters():
@@ -120,6 +117,12 @@ class LSTMLayerTest(ParametrizedTestCase):
                     dic['weight' + add_on] = weight
                     if bias is not None:
                         dic['bias' + add_on] = bias
+                elif analog_if and name.endswith('bias'):  # digital bias
+                    splits = name.split('.')
+                    add_on = '_' + splits[-2].split('_')[-1] + '_l' + splits[2]
+                    dic['bias' + add_on] = param
+                else:
+                    dic[name] = param
 
             return dic
 

--- a/tests/test_layers_mapped.py
+++ b/tests/test_layers_mapped.py
@@ -17,30 +17,63 @@ to sum all the elements from one array.
 # pylint: disable=invalid-name, too-many-locals
 
 from tempfile import TemporaryFile
+from numpy import array
 
 # Imports from PyTorch.
 from torch import randn, load, save, manual_seed
 from torch.nn.functional import mse_loss
 
 # Imports from aihwkit.
-from aihwkit.nn import AnalogLinearMapped
+from aihwkit.nn import (
+    AnalogLinearMapped, AnalogConv1dMapped,
+    AnalogConv2dMapped,  AnalogConv3dMapped
+)
 from aihwkit.optim import AnalogSGD
 
 from .helpers.decorators import parametrize_over_layers
 from .helpers.testcases import ParametrizedTestCase
 from .helpers.tiles import FloatingPoint, Inference, Ideal
-from .helpers.layers import Linear, LinearCuda
+from .helpers.layers import (
+    Linear, LinearCuda, Conv1d, Conv1dCuda, Conv2d,
+    Conv2dCuda, Conv3dCuda
+)
 
-DECIMAL = 5
+DECIMAL = 4
 
 
 @parametrize_over_layers(
-    layers=[Linear, LinearCuda],
+    layers=[Linear, LinearCuda, Conv1d, Conv2d, Conv1dCuda, Conv2dCuda, Conv3dCuda],
     tiles=[FloatingPoint, Inference, Ideal],
-    biases=[True, False],
-    digital_biases=[True])
+    biases=['digital', None])
 class MappedLayerLinearTest(ParametrizedTestCase):
     """Tests for the AnalogMappedLayer functionality """
+
+    def get_mapped_class(self, model):
+        """Returns the mapped class"""
+        name = model.__class__.__name__
+        if name == 'AnalogLinear':
+            return AnalogLinearMapped
+        if name == 'AnalogConv1d':
+            return AnalogConv1dMapped
+        if name == 'AnalogConv2d':
+            return AnalogConv2dMapped
+        if name == 'AnalogConv3d':
+            return AnalogConv3dMapped
+
+        raise RuntimeError("Cannot find mapped module.")
+
+    def get_mapped_model(self, model, rpu_config):
+        """Returns the mapped model"""
+        mapped_model = self.get_mapped_class(model).from_digital(
+            model, rpu_config=rpu_config)
+        mapped_model.reset_parameters()  # should set it explicitly below
+        return mapped_model
+
+    def get_image_size(self, model):
+        """Returns the image size"""
+        if not hasattr(model, 'kernel_size'):
+            return []
+        return (array(model.kernel_size) * 2).tolist()
 
     def train_model(self, model, in_vectors, out_vectors):
         """Trains a model """
@@ -63,119 +96,116 @@ class MappedLayerLinearTest(ParametrizedTestCase):
     def test_construction(self):
         """ Test construction of a mapped layer"""
         manual_seed(123)
-        in_features = 12
-        out_features = 56
+        in_features = 14
+        out_features = 5
 
         rpu_config = self.get_rpu_config()
-        rpu_config.mapping.max_input_size = 6
-        rpu_config.mapping.max_output_size = 12
+        rpu_config.mapping.max_input_size = 10
+        rpu_config.mapping.max_output_size = 4
 
-        al_model = self.get_layer(in_features, out_features, rpu_config=rpu_config)
+        model = self.get_layer(in_features, out_features, rpu_config=rpu_config)
+        weight, bias = model.get_weights()
 
-        weight = randn(out_features, in_features)
-        bias = randn(out_features) if self.bias else None
-        al_model.set_weights(weight, bias)
-        al_weights, al_bias = al_model.get_weights()
+        weight = randn(*weight.shape)
+        if self.bias:
+            bias = randn(*bias.shape)
+        model.set_weights(weight, bias)
 
-        asl_model = AnalogLinearMapped(in_features, out_features,
-                                       bias=self.bias,
-                                       rpu_config=rpu_config)
-        asl_model.set_weights(weight, bias)
+        mapped_model = self.get_mapped_model(model, rpu_config)
+        mapped_model.set_weights(weight, bias)
 
         if self.use_cuda:
-            asl_model = asl_model.cuda()
+            mapped_model = mapped_model.cuda()
 
-        asl_weights, asl_bias = asl_model.get_weights()
+        mapped_weights, mapped_bias = mapped_model.get_weights()
 
-        self.assertTensorAlmostEqual(al_weights, asl_weights, decimal=DECIMAL)
+        self.assertTensorAlmostEqual(weight, mapped_weights, decimal=DECIMAL)
         if self.bias:
-            self.assertTensorAlmostEqual(al_bias, asl_bias, decimal=DECIMAL)
+            self.assertTensorAlmostEqual(bias, mapped_bias, decimal=DECIMAL)
 
     def test_training(self):
         """ Test of training of a mapped linear layer"""
         manual_seed(123)
 
-        in_features = 16
-        out_features = 15
+        in_features = 12
+        out_features = 13
         batch_size = 10
 
         rpu_config = self.get_rpu_config()
-        rpu_config.mapping.max_input_size = 4
-        rpu_config.mapping.max_output_size = 3
+        rpu_config.mapping.max_input_size = 10
+        rpu_config.mapping.max_output_size = 6
 
-        in_vectors = randn(batch_size, in_features)
-        out_vectors = randn(batch_size, out_features)
+        model = self.get_layer(in_features, out_features, rpu_config=rpu_config)
+        weight, bias = model.get_weights()
 
-        al_model = self.get_layer(in_features, out_features, rpu_config=rpu_config)
+        weight = randn(*weight.shape)
+        if self.bias:
+            bias = randn(*bias.shape)
+        model.set_weights(weight, bias)
 
-        weight = randn(out_features, in_features)
-        bias = randn(out_features) if self.bias else None
+        mapped_model = self.get_mapped_model(model, rpu_config)
+        mapped_model.set_weights(weight, bias)
 
-        al_model.set_weights(weight, bias)
-
-        asl_model = AnalogLinearMapped(in_features, out_features,
-                                       bias=self.bias,
-                                       rpu_config=rpu_config)
-        asl_model.set_weights(weight, bias)
+        in_vectors = randn(*([batch_size, in_features] + self.get_image_size(model)))
 
         if self.use_cuda:
             in_vectors = in_vectors.cuda()
+            mapped_model = mapped_model.cuda()
+
+        out_vectors = randn(*model(in_vectors).shape)
+        if self.use_cuda:
             out_vectors = out_vectors.cuda()
-            asl_model = asl_model.cuda()
 
         # compare predictions for analog linear and analog spit linear layers
-        self.assertTensorAlmostEqual(al_model(in_vectors), asl_model(in_vectors), decimal=DECIMAL)
+        self.assertTensorAlmostEqual(model(in_vectors), mapped_model(in_vectors), decimal=DECIMAL)
 
         # Define an analog-aware optimizer, preparing it for using the layers.
-        al_loss = self.train_model(al_model, in_vectors, out_vectors)
-        asl_loss = self.train_model(asl_model, in_vectors, out_vectors)
+        loss = self.train_model(model, in_vectors, out_vectors)
+        mapped_loss = self.train_model(mapped_model, in_vectors, out_vectors)
 
-        self.assertTensorAlmostEqual(al_loss, asl_loss, decimal=DECIMAL)
+        self.assertTensorAlmostEqual(loss, mapped_loss, decimal=DECIMAL)
 
         # Make sure that the train model produces the same forward pass
-        self.assertTensorAlmostEqual(al_model(in_vectors), asl_model(in_vectors), decimal=DECIMAL)
+        self.assertTensorAlmostEqual(model(in_vectors), mapped_model(in_vectors), decimal=DECIMAL)
 
     def test_training_after_save(self):
         """ Test training after it was saved """
         manual_seed(123)
 
-        in_features = 7
-        out_features = 8
+        in_features = 11
+        out_features = 11
         batch_size = 10
 
         rpu_config = self.get_rpu_config()
-        rpu_config.mapping.max_input_size = 3
+        rpu_config.mapping.max_input_size = 10
         rpu_config.mapping.max_output_size = 4
 
-        in_vectors = randn(batch_size, in_features)
-        out_vectors = randn(batch_size, out_features)
+        model = self.get_layer(in_features, out_features, rpu_config=rpu_config)
+        weight, bias = model.get_weights()
 
-        al_model = self.get_layer(in_features, out_features, rpu_config=rpu_config)
+        weight = randn(*weight.shape)
+        if self.bias:
+            bias = randn(*bias.shape)
+        model.set_weights(weight, bias)
 
-        weight = randn(out_features, in_features)
-        bias = randn(out_features) if self.bias else None
+        mapped_model = self.get_mapped_model(model, rpu_config)
+        mapped_model.set_weights(weight, bias)
 
-        al_model.set_weights(weight, bias)
-
-        asl_model = AnalogLinearMapped(in_features, out_features,
-                                       bias=self.bias,
-                                       rpu_config=rpu_config)
-        asl_model.set_weights(weight, bias)
-
+        in_vectors = randn(*([batch_size, in_features] + self.get_image_size(model)))
         if self.use_cuda:
             in_vectors = in_vectors.cuda()
+            mapped_model = mapped_model.cuda()
+
+        out_vectors = randn(*model(in_vectors).shape)
+        if self.use_cuda:
             out_vectors = out_vectors.cuda()
-            asl_model = asl_model.cuda()
-            al_model = al_model.cuda()
 
         # Save the model to a file.
         with TemporaryFile() as file:
-            save(asl_model.state_dict(), file)
+            save(mapped_model.state_dict(), file)
             # Create a new model and load its state dict.
             file.seek(0)
-            new_model = AnalogLinearMapped(in_features, out_features,
-                                           bias=self.bias,
-                                           rpu_config=rpu_config)
+            new_model = self.get_mapped_model(model, rpu_config)
             if self.use_cuda:
                 new_model = new_model.cuda()
             new_model.load_state_dict(load(file))
@@ -185,25 +215,26 @@ class MappedLayerLinearTest(ParametrizedTestCase):
         self.assertTensorAlmostEqual(new_weight, weight, decimal=DECIMAL)
         if self.bias:
             self.assertTensorAlmostEqual(new_bias, bias, decimal=DECIMAL)
-            self.assertTensorAlmostEqual(al_model.bias, bias, decimal=DECIMAL)
-            self.assertTensorAlmostEqual(asl_model.bias, bias, decimal=DECIMAL)
+            self.assertTensorAlmostEqual(model.bias, bias, decimal=DECIMAL)
+            self.assertTensorAlmostEqual(mapped_model.bias, bias, decimal=DECIMAL)
 
-        for new_tile, tile in zip(list(new_model.analog_tiles()), list(asl_model.analog_tiles())):
+        for new_tile, tile in zip(list(new_model.analog_tiles()),
+                                  list(mapped_model.analog_tiles())):
             new_tile_weight, _ = new_tile.get_weights()
             tile_weight, _ = tile.get_weights()
             self.assertTensorAlmostEqual(tile_weight, new_tile_weight, decimal=DECIMAL)
 
         # compare predictions for analog linear and analog spit linear layers
-        self.assertTensorAlmostEqual(al_model(in_vectors), new_model(in_vectors), decimal=DECIMAL)
+        self.assertTensorAlmostEqual(model(in_vectors), new_model(in_vectors), decimal=DECIMAL)
 
         # Define an analog-aware optimizer, preparing it for using the layers.
-        al_loss = self.train_model(al_model, in_vectors, out_vectors)
+        loss = self.train_model(model, in_vectors, out_vectors)
         new_loss = self.train_model(new_model, in_vectors, out_vectors)
 
         # compare predictions for analog linear and analog spit linear layers
-        self.assertTensorAlmostEqual(al_model(in_vectors), new_model(in_vectors), decimal=DECIMAL)
+        self.assertTensorAlmostEqual(model(in_vectors), new_model(in_vectors), decimal=DECIMAL)
 
-        self.assertTensorAlmostEqual(al_loss, new_loss, decimal=DECIMAL)
+        self.assertTensorAlmostEqual(loss, new_loss, decimal=DECIMAL)
 
         # Make sure that the train model produces the same forward pass
-        self.assertTensorAlmostEqual(al_model(in_vectors), new_model(in_vectors), decimal=DECIMAL)
+        self.assertTensorAlmostEqual(model(in_vectors), new_model(in_vectors), decimal=DECIMAL)

--- a/tests/test_specific_tiles.py
+++ b/tests/test_specific_tiles.py
@@ -32,8 +32,7 @@ from .helpers.tiles import FloatingPoint
 @parametrize_over_layers(
     layers=[Linear, LinearCuda],
     tiles=[FloatingPoint],
-    biases=[True, False],
-    digital_biases=[True, False]
+    biases=['analog', 'digital', None]
 )
 class TransferCompoundTest(ParametrizedTestCase):
     """Tests for transfer compound."""


### PR DESCRIPTION
## Related issues

#330,  closes #321 

## Description

This PR introduces mapped conv layers, `AnalogConv1dMapped`, `AnalogConv2dMapped`. and `AnalogConv3dMapped`, which are  similar to `AnalogLinearMapped`: If the weight matrix is too big to fit onto one tile, multiple tiles are used and the outputs are added / concatenated. The splitting is done across the channel axis.    

The tile size can be set using the new `mapping` field in the `rpu_config`, which accepts `MappingParameter`.

Note: 
* MappingParameter are introduced that govern the mapping and *also* the digital bias
* digital bias is set to True by default now.  
* `convert_to_analog_mapped` can be used to convert a model to analog layers using the new `*Mapped` layers that observe the tile size restrictions. 
* The standard layers, e.g. `AnalogLinear` behave unchanged, they thus ignore the tile size information in the `mapping` field.

## Details

Example: 
```python
from aihwkit.simulator.configs.utils import MappingParameter
from aihwkit.simulator.configs import SingleRPUConfig
from aihwkit.nn import AnalogConv2dMapped

rpu_config = SingleRPUConfig(mapping=MappingParameter(max_input_size=256, max_output_size=256))
model =AnalogConv2dMapped(10, 10, rpu_config=rpu_config)
```

