### PR TITLE
Added notebooks directory and readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+* Notebooks directory and readme file which links to the public notebooks repository 
+  that has several notebook examples (https://github.com/IBM-AI-Hardware-Center)
 * Load model state dict into a new model with modified `RPUConfig`. (\#276)
 * Visualization for noise models for analog inference hardware simulation. (\#278)
 * State independent inference noise model. (\# 284)

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,34 @@
+<!---
+Copyright 2021 IBM Analog Hardware Acceleration Kit  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# AIHWKIT Notebooks
+
+You can find here example notebooks provided by the AIHWKIT team.
+
+
+### Pytorch notebooks
+
+You can open any page of the documentation as a notebook in colab (there is a button directly on said pages) but they are also listed here if you need to:
+
+| Notebook     |      Description      |   |
+|:----------|:-------------|------:|
+| [Analog training of LeNet5 on ReRam analog device ](https://github.com/IBM-AI-Hardware-Center/aihwkit-notebooks/blob/main/examples/analog_training_LeNet5.ipynb)  | Training the LeNet5 neural network with MNIST dataset and the Analog SGD optimizer simulated on the analog resistive random-access memory with soft bounds (ReRam) device | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/IBM-AI-Hardware-Center/aihwkit-notebooks/blob/main/examples/analog_training_LeNet5.ipynb) |
+| [Analog Training of LeNet5 with the Tiki Taka optimizer and ReRAM analog device](https://github.com/IBM-AI-Hardware-Center/aihwkit-notebooks/blob/main/examples/analog_training_LeNet5_TT.ipynb)  | Training the LeNet5 neural network with Tiki Taka analog optimizer on MNIST dataset, simulated on the the analog resistive random-access memory with soft bounds (ReRam) device | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/IBM-AI-Hardware-Center/aihwkit-notebooks/blob/main/examples/analog_training_LeNet5_TT.ipynb) |
+| [Analog Training of LeNet5 with hardware aware training for inference on a PCM device](https://github.com/IBM-AI-Hardware-Center/aihwkit-notebooks/blob/main/examples/analog_training_LeNet5_hwa.ipynb)  | Training the LeNet5 neural network with hardware aware training using the Inference RPU Config to optimize inference on a PCM device. | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/IBM-AI-Hardware-Center/aihwkit-notebooks/blob/main/examples/analog_training_LeNet5_hwa.ipynb) |
+
+
+
+


### PR DESCRIPTION
## Related issues
No related issues

## Description

Added a notebooks folder and its corresponding readme file which shows a table of existing documentation notebooks and a link to directly open them in Google co-lab

## Details

The notebooks are stored in another public repository: https://github.com/IBM-AI-Hardware-Center/aihwkit-notebooks
