### PR TITLE
Pin types-requests dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 mypy==0.910
-types-dataclasses==0.6.3
-types-requests
+types-dataclasses
+types-requests==2.26.3
 pycodestyle==2.7.0
 pylint==2.9.0
 pytest==6.2.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 mypy==0.910
-types-dataclasses
+types-dataclasses==0.6.3
 types-requests
 pycodestyle==2.7.0
 pylint==2.9.0


### PR DESCRIPTION
## Related issues

#343 (while checking travis)

## Description

Small tweak to get `make mypy` passing - it seems that a [recently released](https://pypi.org/project/types-requests/2.27.0/) `2.27.0` version of `types-requests` results in a new error:

```
$ make mypy
mypy --show-error-codes src/
src/aihwkit/cloud/client/session.py:84: error: Call to untyped function "disable_warnings" in typed context  [no-untyped-call]
```

This PR pins the version of `types-requests`. Longer term, it would be more desireable to bump the `mypy` version as it is lagging behind a bit (and it seems it has better intercompatibility with typeshed) and keep the `types-requests` version unpinned, although that would likely require some tweaks to the type hints as usual.
