### PR TITLE
Follow-up on out scaling alpha

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ option(USE_CUDA "Build with CUDA support" OFF)
 option(RPU_DEBUG "Enable debug printing" OFF)
 option(RPU_USE_FASTMOD "Use fast mod" ON)
 option(RPU_USE_FASTRAND "Use fastrand" OFF)
+option(USE_ABI_ZERO "Whether to set _GLIBCXX_USE_CXX11_ABI=0" ON)
+
 set(RPU_BLAS "OpenBLAS" CACHE STRING "BLAS backend of choice (OpenBLAS, MKL)")
 set(RPU_CUDA_ARCHITECTURES "60" CACHE STRING "Target CUDA architectures")
 
@@ -49,7 +51,10 @@ else()
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -ftree-vectorize")
 endif()
 
-add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
+if (USE_ABI_ZERO)
+  add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
+endif()
+
 if (APPLE)
   string(APPEND CMAKE_CXX_FLAGS " -fvisibility=hidden")
 endif()

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-.PHONY: build_inplace clean clean-doc clang-format mypy pycodestyle pylint pytest build_inplace_mkl build_inplace_cuda build_cuda
+.PHONY: build_inplace clean clean-doc clang-format mypy pycodestyle pylint pytest build_inplace_mkl build_inplace_cuda build_cuda build_inplace_cuda_abi
 
 build_inplace:
 	python setup.py build_ext -j8 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE --inplace ${flags}
@@ -29,6 +29,9 @@ build_cuda:
 
 build_inplace_cuda:
 	make build_inplace_mkl flags="-DUSE_CUDA=ON ${flags}"
+
+build_inplace_cuda_abi:
+	make build_inplace_mkl flags="-DUSE_CUDA=ON -DUSE_ABI_ZERO=OFF ${flags}"
 
 clean:
 	python setup.py clean

--- a/examples/20_mnist_ddp.py
+++ b/examples/20_mnist_ddp.py
@@ -192,7 +192,7 @@ def train(model, train_set):
         # Decay learning rate if needed.
         scheduler.step()
 
-    dist.all_gather(total_time, torch.tensor(time()-time_init).to(device))
+    dist.all_gather(total_time, torch.Tensor(time()-time_init).to(device))
 
     if rank == 0:
         avg_train_time = torch.mean(torch.cat(total_time, 0))
@@ -231,7 +231,7 @@ def test_evaluation(model, val_set):
         total_images += labels.size(0)
         predicted_ok += (predicted == labels).sum().item()
 
-    dist.all_gather(acc_list, torch.tensor(predicted_ok/total_images).to(device))
+    dist.all_gather(acc_list, torch.Tensor(predicted_ok/total_images).to(device))
 
     if rank == 0:
         acc = torch.mean(torch.cat(acc_list, 0))

--- a/src/aihwkit/cloud/converter/v1/mappings.py
+++ b/src/aihwkit/cloud/converter/v1/mappings.py
@@ -127,6 +127,10 @@ class LayerFunction(Function):
         """Get the value of a field."""
         if field == 'bias':
             return getattr(source, 'bias', None) is not None
+
+        if field == 'weight_scaling_omega':
+            return list(source.analog_tiles())[0].rpu_config.mapping.weight_scaling_omega
+
         if field == 'rpu_config':
             preset_cls = type(source.analog_tile.rpu_config)
             try:

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -11,14 +11,12 @@
 # that they have been altered from the originals.
 
 """Base class for analog Modules."""
-import warnings
-
 from typing import (
     Any, Dict, List, Optional, Tuple, NamedTuple, Union,
     Generator, TYPE_CHECKING
 )
 
-from torch import Tensor, no_grad
+from torch import Tensor, no_grad, ones, float32
 from torch.nn import Module, Parameter
 
 from aihwkit.exceptions import ModuleError
@@ -64,9 +62,6 @@ class AnalogModuleBase(Module):
         bias: whether to use a bias row on the analog tile or not.
         realistic_read_write: whether to enable realistic read/write
             for setting initial weights and during reading of the weights.
-        weight_scaling_omega: the weight value that the current max
-            weight value will be scaled to. If zero, no weight scaling will
-            be performed.
         mapping: Configuration of the hardware architecture (e.g. tile size).
     """
     # pylint: disable=abstract-method, too-many-instance-attributes
@@ -81,7 +76,6 @@ class AnalogModuleBase(Module):
             out_features: int,
             bias: bool,
             realistic_read_write: bool = False,
-            weight_scaling_omega: Optional[float] = None,
             mapping: Optional[MappingParameter] = None,
     ) -> None:
         # pylint: disable=super-init-not-called
@@ -95,20 +89,6 @@ class AnalogModuleBase(Module):
         self.use_bias = bias
         self.digital_bias = bias and mapping.digital_bias
         self.analog_bias = bias and not mapping.digital_bias
-        self.weight_scaling_omega = mapping.weight_scaling_omega if weight_scaling_omega is None \
-            else weight_scaling_omega
-        if weight_scaling_omega is not None:
-            warnings.warn(DeprecationWarning('\nSetting the weight_scaling_omega through the '
-                                             'layers input parameters will be deprecated in the '
-                                             'future. Please set it through the MappingParameter '
-                                             'of the rpu_config.\n'))
-
-        self.weight_scaling_omega_columnwise = mapping.weight_scaling_omega_columnwise
-        self.learn_out_scaling_alpha = mapping.learn_out_scaling_alpha
-
-        if self.learn_out_scaling_alpha and self.weight_scaling_omega == 0:
-            raise ValueError('out_scaling_alpha can only be learned if weight_scaling_omega > 0')
-
         self.realistic_read_write = realistic_read_write
         self.in_features = in_features
         self.out_features = out_features
@@ -143,8 +123,11 @@ class AnalogModuleBase(Module):
             if par_name not in self._registered_helper_parameter:
                 self._registered_helper_parameter.append(par_name)
 
-        if self.learn_out_scaling_alpha:
-            if not isinstance(tile.out_scaling_alpha, Parameter):
+        mapping = tile.rpu_config.mapping
+        if mapping.learn_out_scaling_alpha:
+            if tile.out_scaling_alpha is None:
+                tile.out_scaling_alpha = Parameter(ones([1], device=tile.device, dtype=float32))
+            elif not isinstance(tile.out_scaling_alpha, Parameter):
                 tile.out_scaling_alpha = Parameter(tile.out_scaling_alpha)
             par_name = self.ANALOG_OUT_SCALING_ALPHA_PREFIX + str(self._analog_tile_counter)
             self.register_parameter(par_name, tile.out_scaling_alpha)
@@ -219,7 +202,9 @@ class AnalogModuleBase(Module):
             self,
             weight: Tensor,
             bias: Optional[Tensor] = None,
-            force_exact: bool = False
+            force_exact: bool = False,
+            remap_weights: bool = True,
+            weight_scaling_omega: float = None
     ) -> None:
         """Set the weight (and bias) values with given tensors.
 
@@ -242,6 +227,17 @@ class AnalogModuleBase(Module):
             weight: weight matrix
             bias: bias vector
             force_exact: forces an exact write to the analog tiles
+            remap_weights: Whether to rescale the given weight matrix
+                and populate the digital output scaling factors as
+                specified in the configuration
+                :class:`~aihwkit.configs.utils.MappingParameter`. A
+                new ``weight_scaling_omega`` can be given. Note that
+                this will overwrite the existing digital out scaling
+                factors.
+            weight_scaling_omega: The weight scaling omega factor (see
+                :class:`~aihwkit.configs.utils.MappingParameter`). If
+                given explicitly here, it will overwrite the value in
+                the mapping field.
 
         Raises:
             ModuleError: in case of multiple defined analog tiles in the module
@@ -257,13 +253,15 @@ class AnalogModuleBase(Module):
             raise ModuleError("AnalogModuleBase.set_weights only supports a single tile.")
         analog_tile = analog_tiles[0]
 
-        if self.weight_scaling_omega > 0.0:
+        if remap_weights:
+            omega = weight_scaling_omega
+            if omega is None:
+                omega = analog_tile.rpu_config.mapping.weight_scaling_omega
+
             analog_tile.set_weights_scaled(
                 weight, bias if self.analog_bias else None,
                 realistic=realistic,
-                omega=self.weight_scaling_omega,
-                weight_scaling_omega_columnwise=self.weight_scaling_omega_columnwise,
-                learn_out_scaling_alpha=self.learn_out_scaling_alpha)
+                weight_scaling_omega=omega)
         else:
             analog_tile.set_weights(weight, bias if self.analog_bias else None,
                                     realistic=realistic)
@@ -276,7 +274,8 @@ class AnalogModuleBase(Module):
 
     def get_weights(
             self,
-            force_exact: bool = False
+            force_exact: bool = False,
+            apply_out_scales: bool = True,
     ) -> Tuple[Tensor, Optional[Tensor]]:
         """Get the weight (and bias) tensors.
 
@@ -294,13 +293,23 @@ class AnalogModuleBase(Module):
             analog tile library, for performance reasons.
 
         Args:
-            force_exact: forces an exact read to the analog tiles
+            force_exact: Forces an exact read to the analog tiles
+
+            apply_out_scales: Whether to return the weights with the
+                (digital) output scaling factors applied. Note the
+                "logical" weights of the layer which the DNN is
+                effectively using are those with the output scales
+                applied. If ``apply_out_scales`` is set to False, then
+                only the weight values that is programmed onto the
+                crossbar array are returned, without applying the
+                digital scales.
 
         Returns:
             tuple: weight matrix, bias vector
 
         Raises:
             ModuleError: in case of multiple defined analog tiles in the module
+
         """
         analog_tiles = list(self.analog_tiles())
         if len(analog_tiles) != 1:
@@ -308,16 +317,22 @@ class AnalogModuleBase(Module):
         analog_tile = analog_tiles[0]
 
         realistic = self.realistic_read_write and not force_exact
-        if self.weight_scaling_omega > 0.0:
-            weight, bias = analog_tile.get_weights_scaled(
-                realistic=realistic,
-                weight_scaling_omega_columnwise=self.weight_scaling_omega_columnwise)
+        if apply_out_scales:
+            weight, analog_bias = analog_tile.get_weights_scaled(realistic=realistic)
         else:
-            weight, bias = analog_tile.get_weights(realistic=realistic)
+            weight, analog_bias = analog_tile.get_weights(realistic=realistic)
 
+        digital_bias = None
         if self.digital_bias:
             with no_grad():
-                bias = self.bias.data.detach().cpu()
+                digital_bias = self.bias.data.clone().detach().cpu()
+
+        if (digital_bias is not None) and (analog_bias is not None):
+            bias = digital_bias + analog_bias
+        elif digital_bias is not None:
+            bias = digital_bias
+        else:
+            bias = analog_bias
         return weight, bias
 
     def _sync_weights_from_tile(self) -> None:
@@ -491,8 +506,6 @@ class AnalogModuleBase(Module):
         output = super().extra_repr()
         if self.realistic_read_write:
             output += ', realistic_read_write={}'.format(self.realistic_read_write)
-        if self.weight_scaling_omega > 0:
-            output += ', weight_scaling_omega={:.3f}'.format(self.weight_scaling_omega)
         if self.analog_bias:
             output += ', analog bias'
         if self.digital_bias:

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -91,7 +91,6 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
             out_channels,
             bias,
             realistic_read_write,
-            weight_scaling_omega,
             rpu_config.mapping
         )
         self.analog_tile = self._setup_tile(rpu_config)
@@ -100,11 +99,13 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
         self.register_analog_tile(self.analog_tile)
 
         # Set weights from the reset_parameters
-        self.set_weights(self.weight, self.bias)
+        self.set_weights(self.weight, self.bias, remap_weights=True,
+                         weight_scaling_omega=weight_scaling_omega)
 
         # Set the index matrices.
         self.fold_indices = Tensor().detach()
         self.input_size = 0
+        self.tensor_view = (-1,)  # type: Tuple[int, ...]
 
         # Unregister weight/bias as a parameter but keep it for syncs
         self.unregister_parameter('weight')
@@ -153,18 +154,6 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
         """
         raise NotImplementedError
 
-    def get_tensor_view(self, tensor_to_view: Tensor) -> Tensor:
-        """Return the correct view to the input tensor.
-
-        Args:
-            tensor_to_view: tensor to modify view of
-
-        Returns:
-            tensor: tensor_to_view with correct view
-        """
-
-        raise NotImplementedError
-
     def forward(self, x_input: Tensor) -> Tensor:
         """Compute the forward pass."""
         input_size = x_input.numel() / x_input.size(0)
@@ -175,15 +164,10 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
             self.analog_tile.get_analog_ctx(), x_input,
             self.analog_tile.shared_weights, not self.training)
 
-        if self.weight_scaling_omega:
-            alpha = self.analog_tile.out_scaling_alpha
-            if self.weight_scaling_omega_columnwise:
-                alpha = self.get_tensor_view(alpha)
-            out = out * alpha
+        out = self.analog_tile.apply_out_scaling(out, self.tensor_view)
 
         if self.digital_bias:
-            digital_bias = self.get_tensor_view(self.bias)
-            return out + digital_bias
+            return out + self.bias.view(*self.tensor_view)
         return out
 
 
@@ -250,6 +234,8 @@ class AnalogConv1d(_AnalogConvNd):
             False, _single(0), groups, bias, padding_mode,
             rpu_config, realistic_read_write, weight_scaling_omega
         )
+
+        self.tensor_view = (-1, 1)
 
     @classmethod
     def from_digital(
@@ -350,18 +336,6 @@ class AnalogConv1d(_AnalogConvNd):
         image_sizes = [in_channels, x_height, d_height]
         return (fold_indices, image_sizes, input_size)
 
-    def get_tensor_view(self, tensor_to_view: Tensor) -> Tensor:
-        """Return the correct view to the input tensor.
-
-        Args:
-            tensor_to_view: tensor to modify view of
-
-        Returns:
-            tensor: tensor_to_view with correct view
-        """
-
-        return tensor_to_view.view(self.out_channels, 1)
-
 
 class AnalogConv2d(_AnalogConvNd):
     """2D convolution layer that uses an analog tile.
@@ -423,6 +397,8 @@ class AnalogConv2d(_AnalogConvNd):
             False, _pair(0), groups, bias, padding_mode,
             rpu_config, realistic_read_write, weight_scaling_omega
         )
+
+        self.tensor_view = (-1, 1, 1)
 
     @classmethod
     def from_digital(
@@ -513,17 +489,6 @@ class AnalogConv2d(_AnalogConvNd):
         image_sizes = [in_channels, x_height, x_width, d_height, d_width]
         return (fold_indices, image_sizes, input_size)
 
-    def get_tensor_view(self, tensor_to_view: Tensor) -> Tensor:
-        """Return the correct view to the input tensor.
-
-        Args:
-            tensor_to_view: tensor to modify view of
-
-        Returns:
-            tensor: tensor_to_view with correct view
-        """
-        return tensor_to_view.view(self.out_channels, 1, 1)
-
 
 class AnalogConv3d(_AnalogConvNd):
     """3D convolution layer that uses an analog tile.
@@ -588,6 +553,8 @@ class AnalogConv3d(_AnalogConvNd):
             False, _triple(0), groups, bias, padding_mode,
             rpu_config, realistic_read_write, weight_scaling_omega
         )
+
+        self.tensor_view = (-1, 1, 1, 1)
 
     @classmethod
     def from_digital(
@@ -702,14 +669,3 @@ class AnalogConv3d(_AnalogConvNd):
 
         image_sizes = [in_channels, x_depth, x_height, x_width, d_depth, d_height, d_width]
         return (fold_indices, image_sizes, input_size)
-
-    def get_tensor_view(self, tensor_to_view: Tensor) -> Tensor:
-        """Return the correct view to the input tensor.
-
-        Args:
-            tensor_to_view: tensor to modify view of
-
-        Returns:
-            tensor: tensor_to_view with correct view
-        """
-        return tensor_to_view.view(self.out_channels, 1, 1, 1)

--- a/src/aihwkit/nn/modules/conv_mapped.py
+++ b/src/aihwkit/nn/modules/conv_mapped.py
@@ -58,7 +58,6 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
 
     def __init__(
             self,
-
             in_channels: int,
             out_channels: int,
             kernel_size: Tuple[int, ...],
@@ -95,7 +94,6 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
             out_channels,
             bias,
             realistic_read_write,
-            weight_scaling_omega,
             rpu_config.mapping
         )
 
@@ -125,11 +123,13 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
 
         # Set weights from the reset_parameters (since now the
         # analog_tiles are registered)
-        self.set_weights(self.weight, self.bias)
+        self.set_weights(self.weight, self.bias, remap_weights=True,
+                         weight_scaling_omega=weight_scaling_omega)
 
         # Set the index matrices.
         self.input_size = 0
         self.fold_indices_lst = []  # type: List[Tensor]
+        self.tensor_view = (-1,)  # type: Tuple[int, ...]
 
         # Unregister weight/bias as a parameter but keep it as a
         # field (needed for syncing still)
@@ -226,19 +226,6 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
             for analog_tile in in_tiles:
                 analog_tile.set_indexed(fold_indices, image_sizes)
 
-    def get_tensor_view(self, dim: int, tensor_to_view: Tensor) -> Tensor:
-        """Return the correct view to the input tensor.
-
-        Args:
-            dim: dimension to use to modify tensor view
-            tensor_to_view: tensor to modify view of
-
-        Returns:
-            tensor: tensor_to_view with correct view
-        """
-
-        raise NotImplementedError
-
     def forward(self, x_input: Tensor) -> Tensor:
         """Compute the forward pass."""
         # pylint: disable=arguments-differ,arguments-renamed
@@ -253,15 +240,10 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
                 analog_tile.get_analog_ctx(), x_input,
                 analog_tile.shared_weights, not self.training)
 
-            if self.weight_scaling_omega:
-                alpha = analog_tile.out_scaling_alpha
-                if self.weight_scaling_omega_columnwise:
-                    alpha = self.get_tensor_view(self.out_channels, alpha)
-                output = output * alpha
+            output = analog_tile.apply_out_scaling(output, self.tensor_view)
 
             if self.digital_bias:
-                digital_bias = self.get_tensor_view(self.out_channels, self.bias)
-                return output + digital_bias
+                return output + self.bias.view(*self.tensor_view)
             return output
 
         # mapped version
@@ -277,12 +259,7 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
                     analog_tile.get_analog_ctx(), x,
                     analog_tile.shared_weights, not self.training)
 
-                if self.weight_scaling_omega:
-                    alpha = analog_tile.out_scaling_alpha
-                    if self.weight_scaling_omega_columnwise:
-                        alpha = self.get_tensor_view(output.size(1), alpha)
-                    output = output * alpha
-
+                output = analog_tile.apply_out_scaling(output, self.tensor_view)
                 out_result.append(output)
 
             if idx == 0:
@@ -292,15 +269,16 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
 
         # add bias to final result
         if self.digital_bias:
-            digital_bias = self.get_tensor_view(self.out_channels, self.bias)
-            return result + digital_bias
+            return result + self.bias.view(*self.tensor_view)
         return result
 
     def set_weights(
             self,
             weight: Tensor,
             bias: Optional[Tensor] = None,
-            force_exact: bool = False
+            force_exact: bool = False,
+            remap_weights: bool = True,
+            weight_scaling_omega: float = None
     ) -> None:
         """Set the weight (and bias) with given Tensors.
 
@@ -320,7 +298,23 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
             weight: weight matrix
             bias: bias vector
             force_exact: forces an exact write to the analog tiles
+            remap_weights: Whether to rescale the given weight matrix
+                and populate the digital output scaling factors as
+                specified in the configuration
+                :class:`~aihwkit.configs.utils.MappingParameter`. A
+                new ``weight_scaling_omega`` can be given. Note that
+                this will overwrite the existing digital out scaling
+                factors.
+
+                Note that each tile (in case of multiple mapped tiles)
+                has it separate out scaling factors.
+
+            weight_scaling_omega: The weight scaling omega factor (see
+                :class:`~aihwkit.configs.utils.MappingParameter`). If
+                given explicitly here, it will overwrite the value in
+                the mapping field.
         """
+        # pylint: disable=too-many-locals
         realistic = self.realistic_read_write and not force_exact
 
         shape = [self.out_features, self.in_channels, self.in_features // self.in_channels]
@@ -336,13 +330,15 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
                 tile_weight = in_weight[out_start:out_end, :]
                 out_start = out_end
 
-                if self.weight_scaling_omega > 0.0:
+                if remap_weights:
+                    omega = weight_scaling_omega
+                    if omega is None:
+                        omega = analog_tile.rpu_config.mapping.weight_scaling_omega
+
                     analog_tile.set_weights_scaled(
                         tile_weight, None,
                         realistic=realistic,
-                        omega=self.weight_scaling_omega,
-                        weight_scaling_omega_columnwise=self.weight_scaling_omega_columnwise,
-                        learn_out_scaling_alpha=self.learn_out_scaling_alpha
+                        weight_scaling_omega=omega
                     )
                 else:
                     analog_tile.set_weights(tile_weight, None, realistic=realistic)
@@ -353,7 +349,8 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
             with no_grad():
                 self.bias.data[:] = bias[:]
 
-    def get_weights(self, force_exact: bool = False) -> Tuple[Tensor, Optional[Tensor]]:
+    def get_weights(self, force_exact: bool = False,
+                    apply_out_scales: bool = True) -> Tuple[Tensor, Optional[Tensor]]:
         """Get the weight (and bias) tensors.
 
         This uses an realistic read if the property ``realistic_read_write`` of
@@ -371,6 +368,14 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
 
         Args:
             force_exact: forces an exact read to the analog tiles
+            apply_out_scales: Whether to return the weights with the
+                (digital) output scaling factors applied. Note the
+                "logical" weights of the layer which the DNN is
+                effectively using are those with the output scales
+                applied. If ``apply_out_scales`` is set to False, then
+                only the weight values that is programmed onto the
+                crossbar array are returned, without applying the
+                digital scales.
 
         Returns:
             tuple: weight matrix, bias vector
@@ -383,10 +388,8 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
         for in_tiles in self.analog_tile_array:
             in_tile_weight = []
             for analog_tile in in_tiles:
-                if self.weight_scaling_omega > 0.0:
-                    tile_weight, _ = analog_tile.get_weights_scaled(
-                        realistic=realistic,
-                        weight_scaling_omega_columnwise=self.weight_scaling_omega_columnwise)
+                if apply_out_scales:
+                    tile_weight, _ = analog_tile.get_weights_scaled(realistic=realistic)
                 else:
                     tile_weight, _ = analog_tile.get_weights(realistic=realistic)
                 in_tile_weight.append(tile_weight)
@@ -396,7 +399,7 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
 
         if self.digital_bias:
             with no_grad():
-                return weight, self.bias.data.detach().cpu()
+                return weight, self.bias.data.clone().detach().cpu()
         return weight, None
 
     def extra_repr(self) -> str:
@@ -479,6 +482,8 @@ class AnalogConv1dMapped(_AnalogConvNdMapped):
             False, _single(0), groups, bias, padding_mode,
             rpu_config, realistic_read_write, weight_scaling_omega
         )
+
+        self.tensor_view = (-1, 1)
 
     @classmethod
     def from_digital(
@@ -579,19 +584,6 @@ class AnalogConv1dMapped(_AnalogConvNdMapped):
         image_sizes = [in_channels, x_height, d_height]
         return (fold_indices, image_sizes, input_size)
 
-    def get_tensor_view(self, dim: int, tensor_to_view: Tensor) -> Tensor:
-        """Return the correct view to the input tensor.
-
-        Args:
-            dim: dimension to use to modify tensor view
-            tensor_to_view: tensor to modify view of
-
-        Returns:
-            tensor: tensor_to_view with correct view
-        """
-
-        return tensor_to_view.view(dim, 1)
-
 
 class AnalogConv2dMapped(_AnalogConvNdMapped):
     """2D convolution layer that maps to analog tiles.
@@ -658,6 +650,8 @@ class AnalogConv2dMapped(_AnalogConvNdMapped):
             False, _pair(0), groups, bias, padding_mode,
             rpu_config, realistic_read_write, weight_scaling_omega
         )
+
+        self.tensor_view = (-1, 1, 1)
 
     @classmethod
     def from_digital(
@@ -747,18 +741,6 @@ class AnalogConv2dMapped(_AnalogConvNdMapped):
         image_sizes = [in_channels, x_height, x_width, d_height, d_width]
         return (fold_indices, image_sizes, input_size)
 
-    def get_tensor_view(self, dim: int, tensor_to_view: Tensor) -> Tensor:
-        """Return the correct view to the input tensor.
-
-        Args:
-            dim: dimension to use to modify tensor view
-            tensor_to_view: tensor to modify view of
-
-        Returns:
-            tensor: tensor_to_view with correct view
-        """
-        return tensor_to_view.view(dim, 1, 1)
-
 
 class AnalogConv3dMapped(_AnalogConvNdMapped):
     """3D convolution layer that maps to analog tiles.
@@ -834,6 +816,8 @@ class AnalogConv3dMapped(_AnalogConvNdMapped):
             False, _triple(0), groups, bias, padding_mode,
             rpu_config, realistic_read_write, weight_scaling_omega
         )
+
+        self.tensor_view = (-1, 1, 1, 1)
 
     @classmethod
     def from_digital(
@@ -947,15 +931,3 @@ class AnalogConv3dMapped(_AnalogConvNdMapped):
 
         image_sizes = [in_channels, x_depth, x_height, x_width, d_depth, d_height, d_width]
         return (fold_indices, image_sizes, input_size)
-
-    def get_tensor_view(self, dim: int, tensor_to_view: Tensor) -> Tensor:
-        """Return the correct view to the input tensor.
-
-        Args:
-            dim: dimension to use to modify tensor view
-            tensor_to_view: tensor to modify view of
-
-        Returns:
-            tensor: tensor_to_view with correct view
-        """
-        return tensor_to_view.view(dim, 1, 1, 1)

--- a/src/aihwkit/nn/modules/linear.py
+++ b/src/aihwkit/nn/modules/linear.py
@@ -81,7 +81,6 @@ class AnalogLinear(AnalogModuleBase, Linear):
             out_features,
             bias,
             realistic_read_write,
-            weight_scaling_omega,
             rpu_config.mapping
         )
         self.analog_tile = self._setup_tile(rpu_config)
@@ -90,7 +89,8 @@ class AnalogLinear(AnalogModuleBase, Linear):
         self.register_analog_tile(self.analog_tile)
 
         # Set weights from the reset_parameters call
-        self.set_weights(self.weight, self.bias)
+        self.set_weights(self.weight, self.bias, remap_weights=True,
+                         weight_scaling_omega=weight_scaling_omega)
 
         # Unregister weight/bias as a parameter but keep it as a
         # field (needed for syncing still)
@@ -145,8 +145,7 @@ class AnalogLinear(AnalogModuleBase, Linear):
                 self.analog_tile.get_analog_ctx(), x_input,
                 self.analog_tile.shared_weights, not self.training)
 
-        if self.weight_scaling_omega:
-            out = out * self.analog_tile.out_scaling_alpha
+        out = self.analog_tile.apply_out_scaling(out, (-1, ))
 
         if self.digital_bias:
             return out + self.bias

--- a/src/aihwkit/nn/modules/linear_mapped.py
+++ b/src/aihwkit/nn/modules/linear_mapped.py
@@ -96,7 +96,6 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
             out_features,
             bias,
             realistic_read_write,
-            weight_scaling_omega,
             rpu_config.mapping
         )
         if self.analog_bias:
@@ -124,7 +123,8 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
             self.analog_tile_array.append(in_tiles)
 
         # Set weights from the reset_parameters
-        self.set_weights(self.weight, self.bias)
+        self.set_weights(self.weight, self.bias, remap_weights=True,
+                         weight_scaling_omega=weight_scaling_omega)
 
         # Unregister weight/bias as a parameter but keep for sync
         self.unregister_parameter('weight')
@@ -153,7 +153,9 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
             self,
             weight: Tensor,
             bias: Optional[Tensor] = None,
-            force_exact: bool = False
+            force_exact: bool = False,
+            remap_weights: bool = True,
+            weight_scaling_omega: float = None
     ) -> None:
         """Set the weight (and bias) with given Tensors.
 
@@ -173,6 +175,21 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
             weight: weight matrix
             bias: bias vector
             force_exact: forces an exact write to the analog tiles
+            remap_weights: Whether to rescale the given weight matrix
+                and populate the digital output scaling factors as
+                specified in the configuration
+                :class:`~aihwkit.configs.utils.MappingParameter`. A
+                new ``weight_scaling_omega`` can be given. Note that
+                this will overwrite the existing digital out scaling
+                factors.
+
+                Note that each tile (in case of multiple mapped tiles)
+                has it separate out scaling factors.
+
+            weight_scaling_omega: The weight scaling omega factor (see
+                :class:`~aihwkit.configs.utils.MappingParameter`). If
+                given explicitly here, it will overwrite the value in
+                the mapping field.
 
         """
         shape = [self.out_features, self.in_features]
@@ -188,13 +205,16 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
 
                 tile_weight = weight[out_start:out_end, in_start:in_end]
 
-                if self.weight_scaling_omega > 0.0:
+                if remap_weights:
+
+                    omega = weight_scaling_omega
+                    if omega is None:
+                        omega = analog_tile.rpu_config.mapping.weight_scaling_omega
+
                     analog_tile.set_weights_scaled(
                         tile_weight, None,
                         realistic=realistic,
-                        omega=self.weight_scaling_omega,
-                        weight_scaling_omega_columnwise=self.weight_scaling_omega_columnwise,
-                        learn_out_scaling_alpha=self.learn_out_scaling_alpha
+                        weight_scaling_omega=omega
                     )
                 else:
                     analog_tile.set_weights(tile_weight, None, realistic=realistic)
@@ -208,7 +228,8 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
 
         self._sync_weights_from_tile()
 
-    def get_weights(self, force_exact: bool = False) -> Tuple[Tensor, Optional[Tensor]]:
+    def get_weights(self, force_exact: bool = False,
+                    apply_out_scales: bool = True) -> Tuple[Tensor, Optional[Tensor]]:
         """Get the weight (and bias) tensors.
 
         This uses an realistic read if the property ``realistic_read_write`` of
@@ -226,6 +247,14 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
 
         Args:
             force_exact: forces an exact read to the analog tiles
+            apply_out_scales: Whether to return the weights with the
+                (digital) output scaling factors applied. Note the
+                "logical" weights of the layer which the DNN is
+                effectively using are those with the output scales
+                applied. If ``apply_out_scales`` is set to False, then
+                only the weight values that is programmed onto the
+                crossbar array are returned, without applying the
+                digital scales.
 
         Returns:
             tuple: weight matrix, bias vector
@@ -238,11 +267,8 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
         for in_tiles in self.analog_tile_array:
             in_tile_weight = []
             for analog_tile in in_tiles:
-                if self.weight_scaling_omega > 0.0:
-                    tile_weight, _ = analog_tile.get_weights_scaled(
-                        realistic=realistic,
-                        weight_scaling_omega_columnwise=self.weight_scaling_omega_columnwise
-                    )
+                if apply_out_scales:
+                    tile_weight, _ = analog_tile.get_weights_scaled(realistic=realistic)
                 else:
                     tile_weight, _ = analog_tile.get_weights(realistic=realistic)
                 in_tile_weight.append(tile_weight)
@@ -252,7 +278,7 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
 
         if self.digital_bias:
             with no_grad():
-                return weight, self.bias.data.detach().cpu()
+                return weight, self.bias.data.clone().detach().cpu()
         return weight, None
 
     def reset_parameters(self) -> None:
@@ -266,12 +292,12 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
         # pylint: disable=arguments-differ,arguments-renamed
 
         if self.analog_tile_count() == 1:
+            analog_tile = self.analog_tile_array[0][0]
             out = AnalogFunction.apply(
-                self.analog_tile_array[0][0].get_analog_ctx(), x_input,
-                self.analog_tile_array[0][0].shared_weights, not self.training)
+                analog_tile.get_analog_ctx(), x_input,
+                analog_tile.shared_weights, not self.training)
 
-            if self.weight_scaling_omega:
-                out = out * self.analog_tile_array[0][0].out_scaling_alpha
+            out = analog_tile.apply_out_scaling(out, (-1, ))
 
             if self.digital_bias:
                 return out + self.bias
@@ -289,9 +315,7 @@ class AnalogLinearMapped(AnalogModuleBase, Linear):
                     analog_tile.get_analog_ctx(), x,
                     analog_tile.shared_weights, not self.training)
 
-                if self.weight_scaling_omega:
-                    output = output * analog_tile.out_scaling_alpha
-
+                output = analog_tile.apply_out_scaling(output, (-1, ))
                 out_result.append(output)
 
             if idx == 0:

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_tiles.cpp
@@ -806,23 +806,6 @@ void declare_rpu_tiles(py::module &m) {
 
            Args:
                idx: index of the (unit cell) devices, returns 0 in all other cases.
-           )pbdoc")
-      .def(
-          "set_alpha_scale", &Class::setAlphaScale,
-          R"pbdoc( Set a global scale on the forward and backward computation,
-           which is applied in digital at the output.
-
-           Args:
-               scale: the scalar scale value (default is 1.0)
-           )pbdoc")
-      .def(
-          "get_alpha_scale", &Class::getFwdAlpha, // only allow the setting of forward/backward
-          R"pbdoc( Get the global scale for forward computation. Backward computation will use
-          the same if set by without noise.
-           )pbdoc")
-      .def(
-          "get_backward_alpha_scale", &Class::getBwdAlpha,
-          R"pbdoc( Get the global scale for backward computation.
            )pbdoc");
 
   py::class_<ClassPulsed, Class>(

--- a/src/aihwkit/simulator/tiles/analog.py
+++ b/src/aihwkit/simulator/tiles/analog.py
@@ -250,7 +250,6 @@ class AnalogTile(BaseTile):
                 self.analog_ctx.cuda(device)
                 if self.out_scaling_alpha is not None:
                     self.out_scaling_alpha.data = self.out_scaling_alpha.data.cuda(device)
-
         return self
 
     def _create_simulator_tile(

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -14,8 +14,11 @@
 
 from collections import OrderedDict
 from typing import Dict, Generic, List, Optional, Tuple, TypeVar, Union
+from copy import deepcopy
 
-from torch import Tensor, stack, zeros, as_tensor, cat, unsqueeze, squeeze
+from torch import (
+    Tensor, stack, zeros, as_tensor, cat, unsqueeze, squeeze, ones_like
+)
 from torch import device as torch_device
 from torch import max as torch_max
 from torch.nn import Parameter
@@ -52,7 +55,7 @@ class BaseTile(Generic[RPUConfigGeneric]):
     ):
         self.out_size = out_size
         self.in_size = in_size
-        self.rpu_config = rpu_config
+        self.rpu_config = deepcopy(rpu_config)
         self.bias = bias
         self.in_trans = in_trans
         self.out_trans = out_trans
@@ -135,7 +138,6 @@ class BaseTile(Generic[RPUConfigGeneric]):
         current_dict['analog_tile_hidden_parameter_names'] \
             = self.tile.get_hidden_parameter_names()
         current_dict['analog_tile_class'] = self.__class__.__name__
-        current_dict['analog_alpha_scale'] = self.tile.get_alpha_scale()
         current_dict['analog_lr'] = self.tile.get_learning_rate()
         current_dict['shared_weights'] = self.shared_weights
         current_dict.pop('tile', None)
@@ -168,7 +170,7 @@ class BaseTile(Generic[RPUConfigGeneric]):
         weights = current_dict.pop('analog_tile_weights')
         hidden_parameters = current_dict.pop('analog_tile_hidden_parameters')
         hidden_parameters_names = current_dict.pop('analog_tile_hidden_parameter_names', [])
-        alpha_scale = current_dict.pop('analog_alpha_scale')
+        alpha_scale = current_dict.pop('analog_alpha_scale', None)
         tile_class = current_dict.pop('analog_tile_class', self.__class__.__name__)
         analog_lr = current_dict.pop('analog_lr', 0.01)
         analog_ctx = current_dict.pop('analog_ctx')
@@ -202,8 +204,6 @@ class BaseTile(Generic[RPUConfigGeneric]):
                             'Hidden parameter structure is unexpected.')
         self.tile.set_hidden_parameters(Tensor(hidden_parameters))
         self.tile.set_weights(weights)
-        if alpha_scale is not None:
-            self.tile.set_alpha_scale(alpha_scale)
 
         self.tile.set_learning_rate(analog_lr)
 
@@ -228,6 +228,16 @@ class BaseTile(Generic[RPUConfigGeneric]):
 
         if to_device.type.startswith('cuda'):
             self.cuda(to_device)
+
+        if alpha_scale is not None:
+            # legacy. We apply the alpha scale instaed of the
+            # out_scaling_alpha when loading. The alpha_scale
+            # mechansim is now replaced with the out scaling factors
+            #
+            # Caution: will overwrite the loaded out_scaling_alphas
+            # if they would exist also (should not be for old checkpoints)
+
+            self.set_out_scaling_alpha(alpha_scale)
 
     def _create_simulator_tile(
             self,
@@ -303,10 +313,7 @@ class BaseTile(Generic[RPUConfigGeneric]):
 
         return self.tile.set_weights(combined_weights.numpy())
 
-    def get_weights(
-            self,
-            realistic: bool = False
-    ) -> Tuple[Tensor, Optional[Tensor]]:
+    def get_weights(self, realistic: bool = False) -> Tuple[Tensor, Optional[Tensor]]:
         """Get the tile weights (and biases).
 
         Gets the tile weights and extracts the mathematical weight
@@ -350,9 +357,7 @@ class BaseTile(Generic[RPUConfigGeneric]):
             biases: Optional[Tensor] = None,
             realistic: bool = False,
             n_loops: int = 10,
-            omega: float = 1.0,
-            weight_scaling_omega_columnwise: bool = False,
-            learn_out_scaling_alpha: bool = False,
+            weight_scaling_omega: Optional[float] = None
     ) -> None:
         r"""Set the tile weights (and biases) in a scaled fashion.
 
@@ -384,12 +389,14 @@ class BaseTile(Generic[RPUConfigGeneric]):
                 closed-loop manner.
                 A value of ``1`` means that all columns in principle receive
                 enough pulses to change from ``w_min`` to ``w_max``.
-            omega: where the weight max should be mapped in terms of the weight
-                range. Note that for ``omega`` larger than the maximal weight of
-                the device, weights will get clipped for most devices.
-            weight_scaling_omega_columnwise: whether the weight matrix will be
-                remapped column-wise over the maximum device value allowed.
-            learn_out_scaling_alpha: whether the alpha scaling are learnable.
+            weight_scaling_omega: where the weight max should be mapped in terms of
+                the weight range. Note that for ``omega`` larger than
+                the maximal weight of the device, weights will get
+                clipped for most devices. If this parameter is not
+                given, it will default to the ``weight_scaling_omega``
+                value set in the
+                :class:`~aihwkit.configs.utils.MappingParameter` of the
+                ``rpu_config``
 
         Returns:
             None.
@@ -399,6 +406,7 @@ class BaseTile(Generic[RPUConfigGeneric]):
                 specified.
 
         .. _`Rasch, Gokmen & Haensch (2019)`: https://arxiv.org/abs/1906.02698
+
         """
         # Prepare the array expected by the pybind function, appending the
         # biases row if needed.
@@ -414,29 +422,38 @@ class BaseTile(Generic[RPUConfigGeneric]):
         else:
             # Use only the ``[out_size, in_size]`` matrix.
             combined_weights = weights_torch
-        # Scale the weights.
-        if weight_scaling_omega_columnwise:
+
+        mapping = self.rpu_config.mapping  # type: ignore
+        omega = weight_scaling_omega
+        if omega is None:
+            omega = mapping.weight_scaling_omega
+
+        # Apply the scaling
+        if mapping.weight_scaling_omega_columnwise:
             weight_max, _ = torch_max(abs(combined_weights), 1, keepdim=True)
         else:
             weight_max = torch_max(abs(combined_weights)).view(1)
 
-        combined_weights = combined_weights / weight_max * omega
-        alpha = weight_max / omega
-
-        if learn_out_scaling_alpha:
-            self.out_scaling_alpha.data = squeeze(as_tensor(alpha))
+        if omega > 0:
+            alpha = weight_max / omega
+        elif mapping.learn_out_scaling_alpha:
+            alpha = ones_like(weight_max)
         else:
-            self.out_scaling_alpha = squeeze(as_tensor(alpha))
+            alpha = None
+
+        if alpha is not None:
+            combined_weights = combined_weights / alpha
+
+        self.set_out_scaling_alpha(alpha)
+
+        # update the mapping field
+        self.rpu_config.mapping.weight_scaling_omega = omega  # type: ignore
 
         if realistic:
             return self.tile.set_weights_realistic(combined_weights.numpy(), n_loops)
         return self.tile.set_weights(combined_weights.numpy())
 
-    def get_weights_scaled(
-            self,
-            realistic: bool = False,
-            weight_scaling_omega_columnwise: bool = False,
-    ) -> Tuple[Tensor, Optional[Tensor]]:
+    def get_weights_scaled(self, realistic: bool = False) -> Tuple[Tensor, Optional[Tensor]]:
         """Get the tile weights (and biases) and applies the current alpha
         scale to it.
 
@@ -451,8 +468,6 @@ class BaseTile(Generic[RPUConfigGeneric]):
         Args:
             realistic: Whether to use the forward pass to read out the tile
                 weights iteratively, using :meth:`get_weights_realistic`.
-            weight_scaling_omega_columnwise: whether the weight matrix will be
-                remapped column-wise over the maximum device value allowed.
 
         Returns:
             tuple: where the first item is the ``[out_size, in_size]`` weight
@@ -461,16 +476,12 @@ class BaseTile(Generic[RPUConfigGeneric]):
                 scale applied.
         """
         weights, biases = self.get_weights(realistic=realistic)
+
+        if self.out_scaling_alpha is None:
+            return weights, biases
+
         alpha = self.out_scaling_alpha.clone().detach().cpu()
-
-        if self.bias:
-            if weight_scaling_omega_columnwise:
-                return weights*alpha.view(weights.size(0), 1), biases*alpha
-            return weights*alpha, biases*alpha
-
-        if weight_scaling_omega_columnwise:
-            return weights*alpha.view(weights.size(0), 1), None
-        return weights*alpha, None
+        return weights * alpha.view(-1, 1), biases * alpha if self.bias else None
 
     def get_out_scaling_alpha(self) -> Tensor:
         """Get the out_scaling_alpha used to scale the weights
@@ -479,6 +490,40 @@ class BaseTile(Generic[RPUConfigGeneric]):
             tensor: out_scaling_alpha
             """
         return self.out_scaling_alpha
+
+    def set_out_scaling_alpha(self, alpha: Union[Tensor, float]) -> None:
+        """Helper function to set the out scaling alpha used to scale the
+        weights in digital.
+
+        Args:
+            alpha: out scaling alpha scale as a tensor or float
+                value (depending on the property set by in the
+                :class:`~aihwkit.configs.utils.MappingParameter`
+                configurations
+
+        Caution:
+            Will not check the correct size of the given alpha.
+        """
+        if alpha is None:
+            self.out_scaling_alpha = None
+        elif isinstance(self.out_scaling_alpha, Parameter):
+            self.out_scaling_alpha.data = squeeze(as_tensor(alpha)).to(self.device)
+        else:
+            self.out_scaling_alpha = squeeze(as_tensor(alpha)).to(self.device)
+
+    def apply_out_scaling(self, values: Tensor, tensor_view: Tuple[int, ...] = (-1, )) -> Tensor:
+        """Apply the out scaling to the given tensor.
+
+        Args:
+            values: tensor to apply the out scaling alphas to.
+            tensor_view: view to cast the out scaling alphas before multiplication
+
+        Returns:
+            output tensor with applied out scaling factors
+        """
+        if self.out_scaling_alpha is not None:
+            return values * self.out_scaling_alpha.view(*tensor_view)
+        return values
 
     def set_learning_rate(self, learning_rate: float) -> None:
         """Set the tile learning rate.

--- a/tests/test_bindings_tiles.py
+++ b/tests/test_bindings_tiles.py
@@ -15,7 +15,6 @@
 from unittest import SkipTest
 
 from numpy import array, std, dot, reshape
-from numpy import abs as numpy_abs
 from numpy.random import uniform
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
@@ -189,86 +188,6 @@ class BindingsTilesTest(ParametrizedTestCase):
         cuda_python_tile = python_tile.cuda()
         init_weights_cuda = cuda_python_tile.tile.get_weights()
         assert_array_almost_equal(init_weights, init_weights_cuda)
-
-    def test_alpha_scale(self):
-        """Test the alpha scaling."""
-        n_rows = 6  # out_size aka d_size.
-        n_cols = 5  # in_size aka x_size.
-        alpha = 4.0
-        m_batch = 4
-        lr = 0.1
-
-        python_tile = self.get_noisefree_tile(n_rows, n_cols)
-        cpp_tile = python_tile.tile
-
-        init_weights = cpp_tile.get_weights().copy()
-        cpp_tile.set_learning_rate(lr)
-
-        cpp_tile.set_alpha_scale(alpha)
-        self.assertEqual(alpha, cpp_tile.get_alpha_scale())
-
-        x_t = from_numpy(uniform(-1.2, 1.2, size=(m_batch, n_cols)).astype('float32'))
-        d_t = from_numpy(uniform(-0.1, 0.1, size=(m_batch, n_rows)).astype('float32'))
-
-        if python_tile.is_cuda:
-            x_t = x_t.cuda()
-            d_t = d_t.cuda()
-
-        # Perform forward.
-        y = cpp_tile.forward(x_t).cpu()
-        self.assertIsInstance(y, Tensor)
-        assert_array_almost_equal(y.numpy(), dot(x_t.cpu(), alpha*init_weights.T))
-
-        # Perform backward.
-        z = cpp_tile.backward(d_t).cpu()
-        self.assertIsInstance(y, Tensor)
-        assert_array_almost_equal(z.numpy(), dot(d_t.cpu(), alpha*init_weights))
-
-        # Perform update.
-        cpp_tile.update(x_t, d_t, bias=False)
-        post_rank_weights = cpp_tile.get_weights().copy()
-        ref_weights = init_weights - lr/alpha*dot(d_t.cpu().T, x_t.cpu())
-
-        assert_array_almost_equal(post_rank_weights, ref_weights)
-
-    def test_alpha_get_set_weights(self):
-        """Tests that ``alpha`` does not affect ``get_weights()``."""
-        alpha = 2.0
-
-        python_tile = self.get_noisefree_tile(5, 4)
-        cpp_tile = python_tile.tile
-        init_weights = cpp_tile.get_weights().copy()
-        cpp_tile.set_alpha_scale(alpha)
-        self.assertEqual(alpha, cpp_tile.get_alpha_scale())
-
-        # Get weights with alpha.
-        init_weights2 = cpp_tile.get_weights().copy()
-        assert_array_almost_equal(init_weights, init_weights2)
-
-        # Set the weights (with alpha).
-        cpp_tile.set_weights(init_weights)
-        init_weights2 = cpp_tile.get_weights().copy()
-        assert_array_almost_equal(init_weights, init_weights2)
-
-    def test_get_set_weights_scaled(self):
-        """Test that ``alpha`` affects the ``get_weights()`` scaled."""
-        omega = 0.5
-        python_tile = self.get_noisefree_tile(5, 4)
-        cpp_tile = python_tile.tile
-        init_weights = cpp_tile.get_weights().copy()
-
-        # Get weights with alpha.
-        python_tile.set_weights_scaled(from_numpy(init_weights), omega=omega)
-
-        alpha = python_tile.out_scaling_alpha.numpy()
-        self.assertEqual(alpha, numpy_abs(init_weights).max()/omega)
-
-        init_weights_scaled = cpp_tile.get_weights()
-
-        assert_array_almost_equal(init_weights, init_weights_scaled*alpha)
-
-        init_weights2 = python_tile.get_weights_scaled()[0].cpu().numpy()
-        assert_array_almost_equal(init_weights, init_weights2)
 
 
 @parametrize_over_tiles([

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -371,26 +371,6 @@ class SerializationTest(ParametrizedTestCase):
         new_hidden_parameters = new_analog_tile.tile.get_hidden_parameters()
         assert_array_almost_equal(hidden_parameters, new_hidden_parameters)
 
-    def test_save_load_alpha_scale(self):
-        """Test saving and loading a device with alpha_scale."""
-        # Create the device and the array.
-        model = self.get_layer()
-        alpha = 2.0
-        analog_tile = self.get_analog_tile(model)
-        analog_tile.tile.set_alpha_scale(alpha)
-
-        # Save the model to a file.
-        with TemporaryFile() as file:
-            save(model, file)
-            # Load the model.
-            file.seek(0)
-            new_model = load(file)
-
-        # Assert over the new model tile parameters.
-        new_analog_tile = self.get_analog_tile(new_model)
-        alpha_new = new_analog_tile.tile.get_alpha_scale()
-        assert_array_almost_equal(array(alpha), array(alpha_new))
-
     def test_save_load_out_scaling_alpha(self):
         """Test saving and loading a device with out_scaling_alpha."""
         # Create the device and the array.


### PR DESCRIPTION
## Related issues

* Legacy checkpoints would not load the correct alpha scale
* Out scaling alpha was re-applied always 

## Description

Now the out scaling alphas are correctly loaded from the checkpoints. Additionally the user can re-apply them when setting the weights by using the new input options. 

## Details

* removing of the C++ alpha scale to avoid confusion with the new mechanism
* legacy loading of the old alpha scale
* set_weights on module level can now either set the weight scaled are not, such as the user requests
* set_weights supports the change of the weight_scaling_omega after instantiation
* out scaling factors can be learned even if initially the weight_scaling_omega was 0
* fixes and issues that the out scaling where re-computed after loading (instead the saved ones are now just loaded).


