### PR TITLE
Add reverse up / down device option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 * Set weights can be used to re-apply the weight scaling omega. (\#360)
 * Out scaling factors can be learnt even if weight scaling omega was set to 0. (\#360)
+* Reverse up / down option for ``LinearStepDevice``. (\#361)
 
 ### Fixed
 

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -504,6 +504,28 @@ class LinearStepDevice(PulsedDevice):
     :math:`w_\text{apparent}`.
     """
 
+    reverse_up: bool = False
+    """Whether to increase the step size in up direction with increasing
+    weights (default decreases).
+
+    Note:
+        If set, ``mult_noise`` needs to be also set.
+    """
+
+    reverse_down: bool = False
+    """Whether to increase the step size in down direction with decreasing
+    weights (default decreases).
+
+    Note:
+        If set, ``mult_noise`` needs to be also set.
+
+    """
+
+    reverse_offset: float = 0.01
+    """Offset to add to the step size for reverse up or down to avoid
+    zero step size at weight min or max.
+    """
+
 
 @dataclass
 class SoftBoundsDevice(PulsedDevice):
@@ -522,6 +544,44 @@ class SoftBoundsDevice(PulsedDevice):
     mult_noise: bool = True
     """Whether to use multiplicative noise instead of additive cycle-to-cycle
     noise."""
+
+    write_noise_std: float = 0.0
+    r"""Whether to use update write noise.
+
+    Whether to use update write noise that is added to the updated
+    devices weight, while the update is done on a hidden persistent weight. The
+    update write noise is then sampled anew when the device is touched
+    again.
+
+    Thus it is:
+
+    .. math::
+        w_\text{apparent}{ij} = w_{ij} + \sigma_\text{write_noise} \Delta w_\text{min}\xi
+
+    and the update is done on :math:`w_{ij}` but the forward sees the
+    :math:`w_\text{apparent}`.
+    """
+
+    reverse_up: bool = False
+    """Whether to increase the step size in up direction with increasing
+    weights (default decreases).
+
+    Note:
+        If set, ``mult_noise`` needs to be also set.
+    """
+
+    reverse_down: bool = False
+    """Whether to increase the step size in down direction with decreasing
+    weights (default decreases).
+
+    Note:
+        If set, ``mult_noise`` needs to be also set.
+    """
+
+    reverse_offset: float = 0.01
+    """Offset to add to the step size for reverse up or down to avoid
+    zero step size at weight min or max.
+    """
 
 
 @dataclass

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -465,6 +465,9 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("mean_bound_reference", &LinearStepParam::ls_mean_bound_reference)
       .def_readwrite("write_noise_std", &LinearStepParam::write_noise_std)
       .def_readwrite("mult_noise", &LinearStepParam::ls_mult_noise)
+      .def_readwrite("reverse_up", &LinearStepParam::ls_reverse_up)
+      .def_readwrite("reverse_down", &LinearStepParam::ls_reverse_down)
+      .def_readwrite("reverse_offset", &LinearStepParam::ls_reverse_offset)
       .def(
           "__str__",
           [](LinearStepParam &self) {
@@ -481,10 +484,13 @@ void declare_rpu_devices(py::module &m) {
            float: weight granularity
         )pbdoc");
 
-  py::class_<SoftBoundsParam, PySoftBoundsParam, PulsedParam>(
+  py::class_<SoftBoundsParam, PySoftBoundsParam, LinearStepParam>(
       m, "SoftBoundsResistiveDeviceParameter")
       .def_readwrite("mult_noise", &SoftBoundsParam::ls_mult_noise)
       .def_readwrite("write_noise_std", &SoftBoundsParam::write_noise_std)
+      .def_readwrite("reverse_up", &SoftBoundsParam::ls_reverse_up)
+      .def_readwrite("reverse_down", &SoftBoundsParam::ls_reverse_down)
+      .def_readwrite("reverse_offset", &SoftBoundsParam::ls_reverse_offset)
       .def(py::init<>())
       .def(
           "__str__",

--- a/src/rpucuda/rpu_linearstep_device.cpp
+++ b/src/rpucuda/rpu_linearstep_device.cpp
@@ -30,6 +30,10 @@ void LinearStepRPUDevice<T>::populate(
   PulsedRPUDevice<T>::populate(p, rng); // will clone par
   auto &par = getPar();
 
+  if ((par.ls_reverse_up || par.ls_reverse_down) && !par.ls_mult_noise) {
+    RPU_FATAL("Only mulitplicative noise supported with reverse up/down!");
+  }
+
   for (int i = 0; i < this->d_size_; ++i) {
 
     for (int j = 0; j < this->x_size_; ++j) {
@@ -43,21 +47,33 @@ void LinearStepRPUDevice<T>::populate(
         diff_slope_at_bound_up = fabs(diff_slope_at_bound_up);
         diff_slope_at_bound_down = fabs(diff_slope_at_bound_down);
       }
+      T w_ref_up, w_ref_down;
 
       if (par.ls_mean_bound_reference) {
-
         /* divide by mean bound, otherwise slope depends on device
            bound, which does not make sense both slopes are negative
            (sign of scale_up/scale_down here both positive and later
            corrected in update rule) */
-        w_slope_up_[i][j] = -diff_slope_at_bound_up * this->w_scale_up_[i][j] / par.w_max;
-        w_slope_down_[i][j] = -diff_slope_at_bound_down * this->w_scale_down_[i][j] / par.w_min;
+
+        w_ref_up = par.ls_reverse_up ? par.w_min - par.ls_reverse_offset : par.w_max;
+        w_ref_down = par.ls_reverse_down ? par.w_max + par.ls_reverse_offset : par.w_min;
       } else {
-        /* In this case slope depends on the bound*/
-        w_slope_up_[i][j] =
-            -diff_slope_at_bound_up * this->w_scale_up_[i][j] / this->w_max_bound_[i][j];
-        w_slope_down_[i][j] =
-            -diff_slope_at_bound_down * this->w_scale_down_[i][j] / this->w_min_bound_[i][j];
+        w_ref_up = par.ls_reverse_up ? this->w_min_bound_[i][j] - par.ls_reverse_offset
+                                     : this->w_max_bound_[i][j];
+        w_ref_down = par.ls_reverse_down ? this->w_max_bound_[i][j] + par.ls_reverse_offset
+                                         : this->w_min_bound_[i][j];
+      }
+
+      // slope should be correct because of sign of reference
+      if (w_ref_up != 0.0) {
+        w_slope_up_[i][j] = -diff_slope_at_bound_up * this->w_scale_up_[i][j] / w_ref_up;
+      } else {
+        w_slope_up_[i][j] = 0.0;
+      }
+      if (w_ref_down != 0.0) {
+        w_slope_down_[i][j] = -diff_slope_at_bound_down * this->w_scale_down_[i][j] / w_ref_down;
+      } else {
+        w_slope_down_[i][j] = 0.0;
       }
     }
   }

--- a/src/rpucuda/rpu_linearstep_device.h
+++ b/src/rpucuda/rpu_linearstep_device.h
@@ -33,6 +33,9 @@ BUILD_PULSED_DEVICE_META_PARAMETER(
     bool ls_allow_increasing_slope = false;
     bool ls_mean_bound_reference = true;
     bool ls_mult_noise = true;
+    bool ls_reverse_up = false;
+    bool ls_reverse_down = false;
+    T ls_reverse_offset = 0.01;
     ,
     /*print body*/
 
@@ -44,9 +47,21 @@ BUILD_PULSED_DEVICE_META_PARAMETER(
        << " (dtod=" << ls_decrease_down_dtod << ")" << std::endl;
 
     ss << "\t ls_decrease_down_dtod:\t\t" << ls_decrease_down_dtod << std::endl;
+    if (ls_allow_increasing_slope) {
+      ss << "\t ls_allow_increasing_slope:\t" << std::boolalpha << ls_allow_increasing_slope
+         << std::endl;
+      ;
+    } if (ls_reverse_up) {
+      ss << "\t ls_reverse_up:\t" << std::boolalpha << ls_reverse_up << std::endl;
+      ;
+    } if (ls_reverse_down) {
+      ss << "\t ls_reverse_down:\t" << std::boolalpha << ls_reverse_down << std::endl;
+      ;
+    } if (ls_reverse_up || ls_reverse_down) {
+      ss << "\t ls_reverse_offset:\t" << ls_reverse_offset << std::endl;
+      ;
+    }
 
-    ss << "\t ls_allow_increasing_slope:\t" << std::boolalpha << ls_allow_increasing_slope
-       << std::endl;
     ,
     /* calc weight granularity body */
     return this->dw_min;
@@ -93,6 +108,18 @@ struct SoftBoundsRPUDeviceMetaParameter : LinearStepRPUDeviceMetaParameter<T> {
     // ss << "   ";
     // ss << getName() << " parameter:" << std::endl;
     ss << "\t ls_mult_noise:\t\t" << std::boolalpha << this->ls_mult_noise << std::endl;
+    if (this->ls_reverse_up) {
+      ss << "\t ls_reverse_up:\t" << std::boolalpha << this->ls_reverse_up << std::endl;
+      ;
+    }
+    if (this->ls_reverse_down) {
+      ss << "\t ls_reverse_down:\t" << std::boolalpha << this->ls_reverse_down << std::endl;
+      ;
+    }
+    if (this->ls_reverse_up || this->ls_reverse_down) {
+      ss << "\t ls_reverse_offset:\t" << this->ls_reverse_offset << std::endl;
+      ;
+    }
   };
 };
 


### PR DESCRIPTION
## Description

Add a new option to `LinearStepDevice` / `SoftBoundsDevice` to reverse the up / down asymmetry.  

## Details

For example: 
```python

from aihwkit.simulator.configs.devices import SoftBoundsDevice
from aihwkit.utils.visualization import plot_device_compact

plot_device_compact(SoftBoundsDevice(reverse_up=False, reverse_down=True, w_min_dtod=0.0,                                w_max_dtod=0.0), n_steps=1000)

```
![image](https://media.github.ibm.com/user/63124/files/c47f4100-a073-11ec-90e6-c70b3457926b)

or 

```python
plot_device_compact(SoftBoundsDevice(reverse_up=True, reverse_down=False, reverse_offset=0.1, w_min_dtod=0.0,
                                     w_max_dtod=0.0), n_steps=1000)
```
![image](https://media.github.ibm.com/user/63124/files/fe047c00-a074-11ec-921e-322efc72c047)
