### PR TITLE
Drop Python 3.6, introduce Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ jobs:
     env:
       - TORCH_VERSION_SPECIFIER="==1.7.1"
 
-  - name: "Build wheel for Python 3.6, 3.7, 3.8, 3.9 on Linux x86_64"
+  - name: "Build wheel for Python 3.7, 3.8, 3.9, 3.10 on Linux x86_64"
     os: linux
     dist: bionic
     language: python
@@ -114,7 +114,7 @@ jobs:
       - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.8.1'"
       - CIBW_BEFORE_BUILD="pip install torch==1.8.1 torchvision==0.9.1 && pip install -r requirements.txt"
       - CIBW_MANYLINUX_X86_64_IMAGE="aihwkit/manylinux2014_x86_64_aihwkit"
-      - CIBW_BUILD="cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64"
+      - CIBW_BUILD="cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64"
     before_install:
       - docker pull aihwkit/manylinux2014_x86_64_aihwkit
     install:
@@ -124,7 +124,7 @@ jobs:
       - python3 -m cibuildwheel --output-dir wheelhouse
     <<: *build_deploy_common
 
-  - name: "Build wheel for Python 3.6, 3.7, 3.8, 3.9 on OS X"
+  - name: "Build wheel for Python 3.7, 3.8, 3.9, 3.10 on OS X"
     os: osx
     osx_image: xcode12.2
     stage: Build wheels
@@ -138,7 +138,7 @@ jobs:
       # Use a specific torch version.
       - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.8.1'"
       - CIBW_BEFORE_BUILD="pip install torch==1.8.1 torchvision==0.9.1 && pip install ./delocate && pip install -r requirements.txt"
-      - CIBW_BUILD="cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64 cp39-macosx_x86_64"
+      - CIBW_BUILD="cp37-macosx_x86_64 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64"
     before_install:
       - git clone -b aihwkit https://github.com/aihwkit-bot/delocate.git
     install:
@@ -148,7 +148,7 @@ jobs:
       - python3 -m cibuildwheel --output-dir wheelhouse --platform macos
     <<: *build_deploy_common
 
-  - name: "Build wheel for Python 3.6, 3.7, 3.8, 3.9 on win64"
+  - name: "Build wheel for Python 3.7, 3.8, 3.9, 3.10 on win64"
     os: windows
     language: shell
     stage: Build wheels
@@ -157,7 +157,7 @@ jobs:
       # Use a specific torch version.
       - CIBW_ENVIRONMENT="TORCH_VERSION_SPECIFIER='==1.8.1'"
       - CIBW_BEFORE_BUILD="pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html && pip install -r requirements.txt"
-      - CIBW_BUILD="cp36-win_amd64 cp37-win_amd64 cp38-win_amd64 cp39-win_amd64"
+      - CIBW_BUILD="cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64"
       # Use unzipped OpenBLAS.
       - OPENBLAS_ROOT=C:\\BLAS
       - OPENBLAS_ROOT_DIR=C:\\BLAS

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,27 +56,22 @@ build_deploy_common: &build_deploy_common
 
 jobs:
   include:
-  - name: "Compile and test. Python 3.6"
+  - name: "Compile and test. Python 3.7"
     <<: *job_compile_common
     stage: Test and lint
-    python: "3.6"
+    python: "3.7"
     env:
       - TEST_DATASET=true
 
-  - name: "Compile and lint. Python 3.6"
+  - name: "Compile and lint. Python 3.7"
     <<: *job_compile_common
     stage: Test and lint
-    python: "3.6"
+    python: "3.7"
     script:
       - pip install -r requirements-dev.txt
       - make pycodestyle
       - make pylint
       - make mypy
-
-  - name: "Compile and test. Python 3.7"
-    <<: *job_compile_common
-    stage: Test multiple python versions
-    python: "3.7"
 
   - name: "Compile and test. Python 3.8"
     <<: *job_compile_common
@@ -88,10 +83,15 @@ jobs:
     stage: Test multiple python versions
     python: "3.9"
 
-  - name: "Compile and test. Python 3.6, Torch 1.7.1"
+  - name: "Compile and test. Python 3.10"
     <<: *job_compile_common
     stage: Test multiple python versions
-    python: "3.6"
+    python: "3.19"
+
+  - name: "Compile and test. Python 3.7, Torch 1.7.1"
+    <<: *job_compile_common
+    stage: Test multiple python versions
+    python: "3.7"
     install:
       # Set the python executable, to force cmake picking the right one.
       - PYTHON_EXECUTABLE=~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python$TRAVIS_PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
   - name: "Compile and test. Python 3.10"
     <<: *job_compile_common
     stage: Test multiple python versions
-    python: "3.19"
+    python: "3.10"
 
   - name: "Compile and test. Python 3.7, Torch 1.7.1"
     <<: *job_compile_common

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Changed
 
 * The ``set_alpha_scale`` and ``get_alpha_scale`` methods of the C++ tiles are removed. (\#360)
-
+* The lowest supported Python version is now `3.7`, as `3.6` has reached
+  end-of-life. Additionally, the library now officially supports Python
+  `3.10`. (\#368)
 
 ## [0.5.1] - 2022/01/27
 

--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -33,7 +33,7 @@ C++11 compatible compiler
 `cmake`_                         3.18+
 `pybind11`_                      2.6.2+    Versions 2.6.0+ can be installed using ``pip`` (recommended)
 `scikit-build`_                  0.11.0+
-`Python 3 development headers`_  3.6+
+`Python 3 development headers`_  3.7+
 BLAS implementation                        `OpenBLAS`_ or `Intel MKL`_
 `PyTorch`_                       1.7+      The libtorch library and headers are needed [#f1]_
 `OpenMP`_                        11.0.0+   Optional, OpenMP library and headers [#f2]_

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ torchvision
 scipy
 requests>=2.25,<3
 numpy>=1.18
-dataclasses==0.7; python_version < '3.7'
 protobuf>=3.15.0,<4

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ add_select = D204,D215,D401,D404
 match-dir = ^(?!helpers|definitions).*
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 namespace_packages = True
 ignore_missing_imports = True
 warn_redundant_casts = True

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ INSTALL_REQUIRES = [
     'scipy',
     'requests>=2.25,<3',
     'numpy>=1.18',
-    'dataclasses==0.7; python_version < "3.7"',
     'protobuf>=3.13.0,<4'
 ]
 
@@ -74,7 +73,7 @@ setup(
         'aihwkit': ['VERSION.txt']
     },
     install_requires=INSTALL_REQUIRES,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     zip_safe=False,
     extras_require={
         'visualization': ['matplotlib>=3.0']

--- a/src/aihwkit/utils/visualization.py
+++ b/src/aihwkit/utils/visualization.py
@@ -19,6 +19,10 @@ extras mechanism::
     pip install aihwkit[visualization]
 """
 
+# Allow untyped calls for `np.*`, as proper support for numpy typing requires
+# 1.20+ (https://numpy.org/devdocs/reference/typing.html).
+# mypy: disallow-untyped-calls=False
+
 from copy import deepcopy
 from typing import Any, Tuple, Union
 


### PR DESCRIPTION
## Related issues

Closes #364

## Description

Make Python `3.7` the lowest supported version, along with checking for compatibility with Python `3.10` in CI, via:
* updating the travis jobs, with `3.7` as the "default" version and adding new `3.10` stages
* update the `cibuildwheel` variables in order to produce `3.10` wheels when a new version is released
* bump the minimal version in build metadata (and mypy syntax)

## Details

* There seems to be no warnings from `aihwkit` in 3.10 ([only some from `torchvision`](https://app.travis-ci.com/github/IBM/aihwkit/jobs/566778103#L3247))
* The bit in `visualization.py` is a quick fix for allowing `mypy` to pass ([errored](https://app.travis-ci.com/github/IBM/aihwkit/jobs/566770618#L723) in an earlier commit). A proper fix would be bumping `numpy` to a more recent version (some relation to #346 as well likely) - but it felt overkill to bump the version of one of the main libraries in this PR only due to typing.
* The `dataclasses` dependency has been dropped (as it was `<3.7` specific, and on 3.7+ is part of the standard library)
