### PR TITLE
Remapping weights functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 * Index error when loading the state dict with a model use previously. (\#387)
+* Weights that were not contiguous could have set wrongly. (\#388) 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 * Notebook for exploring analog sensitivities. (\#380)
+* Remapping functionality for ``InferenceRPUConfig``. (\#388)
 
 ### Fixed
 * Index error when loading the state dict with a model use previously. (\#387)

--- a/src/aihwkit/nn/modules/base.py
+++ b/src/aihwkit/nn/modules/base.py
@@ -345,6 +345,29 @@ class AnalogModuleBase(Module):
             bias = analog_bias
         return weight, bias
 
+    def remap_weights(self, weight_scaling_omega: Optional[float] = None) -> None:
+        """Remap the out-scaling alpha to analog weight conversion.
+
+        Note:
+
+            This remapping is most useful for hardware-aware training
+            for inference.  For analog training it should not be
+            applied. If the realistic write/read setting is turned on
+            (which should be the case of analog training), then it
+            will do a full refresh read-write of the array.
+
+        Args:
+            weight_scaling_omega: The optional value to remap the
+                weight max to. Will take the previous value used otherwise
+                (typically the one from ``RPUConfig.mapping``)
+
+        """
+
+        weights_and_bias = self.get_weights(apply_out_scales=True)
+        self.set_weights(*weights_and_bias,
+                         weight_scaling_omega=weight_scaling_omega,
+                         remap_weights=True)
+
     def _sync_weights_from_tile(self) -> None:
         """Update the layer weight and bias from the values on the analog tile.
 

--- a/src/aihwkit/nn/modules/container.py
+++ b/src/aihwkit/nn/modules/container.py
@@ -173,6 +173,18 @@ class AnalogSequential(Sequential):
                     break
         self._ddp_params_and_buffers_to_ignore = exclude_params
 
+    def remap_analog_weights(self, weight_scaling_omega: Optional[float] = None) -> None:
+        """Remap the out-scaling alpha to analog weight conversion.
+
+        Args:
+            weight_scaling_omega: The optional value to remap the
+                weight max to. Will take the previous value used
+                (typically the one from ``RPUConfig.mapping``)
+        """
+
+        self._apply_to_analog(lambda m: m.remap_weights(
+            weight_scaling_omega=weight_scaling_omega))
+
     def drift_analog_weights(self, t_inference: float = 0.0) -> None:
         """(Program) and drift all analog inference layers of a given model.
 

--- a/src/aihwkit/simulator/tiles/base.py
+++ b/src/aihwkit/simulator/tiles/base.py
@@ -15,6 +15,7 @@
 from collections import OrderedDict
 from typing import Dict, Generic, List, Optional, Tuple, TypeVar, Union
 from copy import deepcopy
+from numpy import ascontiguousarray
 
 from torch import (
     Tensor, stack, zeros, as_tensor, cat, unsqueeze, squeeze, ones_like
@@ -207,7 +208,7 @@ class BaseTile(Generic[RPUConfigGeneric]):
             raise TileError('Mismatch with loaded analog state: '
                             'Hidden parameter structure is unexpected.')
         self.tile.set_hidden_parameters(Tensor(hidden_parameters))
-        self.tile.set_weights(weights)
+        self.tile.set_weights(ascontiguousarray(weights))
 
         self.tile.set_learning_rate(analog_lr)
 
@@ -312,10 +313,12 @@ class BaseTile(Generic[RPUConfigGeneric]):
             # Use only the ``[out_size, in_size]`` matrix.
             combined_weights = weights_torch
 
-        if realistic:
-            return self.tile.set_weights_realistic(combined_weights.numpy(), n_loops)
+        numpy_weights = ascontiguousarray(combined_weights.numpy())
 
-        return self.tile.set_weights(combined_weights.numpy())
+        if realistic:
+            return self.tile.set_weights_realistic(numpy_weights, n_loops)
+
+        return self.tile.set_weights(numpy_weights)
 
     def get_weights(self, realistic: bool = False) -> Tuple[Tensor, Optional[Tensor]]:
         """Get the tile weights (and biases).
@@ -453,9 +456,10 @@ class BaseTile(Generic[RPUConfigGeneric]):
         # update the mapping field
         self.rpu_config.mapping.weight_scaling_omega = omega  # type: ignore
 
+        numpy_weights = ascontiguousarray(combined_weights.numpy())
         if realistic:
-            return self.tile.set_weights_realistic(combined_weights.numpy(), n_loops)
-        return self.tile.set_weights(combined_weights.numpy())
+            return self.tile.set_weights_realistic(numpy_weights, n_loops)
+        return self.tile.set_weights(numpy_weights)
 
     def get_weights_scaled(self, realistic: bool = False) -> Tuple[Tensor, Optional[Tensor]]:
         """Get the tile weights (and biases) and applies the current alpha

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,7 @@ from numpy import array
 from numpy.random import rand
 from numpy.testing import assert_array_almost_equal, assert_raises
 from torch import Tensor, load, save, device, manual_seed
+from torch import abs as torch_abs
 from torch.nn import Module, Sequential
 from torch.nn import Linear as torch_linear
 from torch.nn.functional import mse_loss
@@ -30,7 +31,7 @@ from aihwkit.nn import (
     AnalogConv2d, AnalogConv2dMapped, AnalogSequential, AnalogLinearMapped
 )
 from aihwkit.optim import AnalogSGD
-from aihwkit.simulator.configs import SingleRPUConfig, FloatingPointRPUConfig
+from aihwkit.simulator.configs import SingleRPUConfig, InferenceRPUConfig, FloatingPointRPUConfig
 from aihwkit.simulator.configs.devices import ConstantStepDevice, LinearStepDevice
 from aihwkit.simulator.configs.utils import IOParameters, UpdateParameters, MappingParameter
 from aihwkit.simulator.rpu_base import cuda
@@ -481,6 +482,40 @@ class SerializationTest(ParametrizedTestCase):
         new_analog_tile = self.get_analog_tile(new_model)
         alpha_new = new_analog_tile.get_out_scaling_alpha().detach().cpu()
         assert_array_almost_equal(array(alpha), array(alpha_new))
+
+    def test_remapping(self):
+        """Test remapping of the weights."""
+        # Create the device and the array.
+        rpu_config = InferenceRPUConfig(mapping=MappingParameter(
+            weight_scaling_omega=0.4,
+            weight_scaling_omega_columnwise=True))
+
+        model = self.get_layer(rpu_config=rpu_config)
+        analog_tile = self.get_analog_tile(model)
+
+        user_weights = Tensor(model.out_features, model.in_features).uniform_(-0.1, 0.1)
+        if self.bias:
+            user_biases = Tensor(model.out_features).uniform_(-0.1, 0.1)
+        else:
+            user_biases = None
+        model.set_weights(user_weights, user_biases, remap_weights=True,
+                          force_exact=True)
+
+        alpha_initial = analog_tile.get_out_scaling_alpha().detach().cpu()
+        self.assertNotEqual(alpha_initial.max(), 1.0)
+
+        # remap
+        model.remap_weights(weight_scaling_omega=1.0)
+
+        weights, _ = model.get_weights(apply_out_scales=True, force_exact=True)
+        analog_weights, _ = model.get_weights(apply_out_scales=False, force_exact=True)
+
+        assert_array_almost_equal(array(user_weights), array(weights))
+
+        alpha = analog_tile.get_out_scaling_alpha().detach().cpu()
+        assert_raises(AssertionError, assert_array_almost_equal, array(alpha), array(alpha_initial))
+
+        self.assertEqual(torch_abs(analog_weights).max(), 1.0)
 
     def test_save_load_state_dict_hidden_parameters(self):
         """Test saving and loading via state_dict with hidden parameters."""


### PR DESCRIPTION
## Related issues

When learning the out-scaling alpha, weight might become too small in relation to the weight max. In particular, when non-fixed clipping is used during HWA training.

Note: this function does only apply for hardware-aware training for analog inference. During analog in-memory training it should not be used. 

## Description

Added a `remap_weights` for `AnalogSequential` and `AnalogModuleBase` level. This function needs to be called by the user if used.

## Details
* also fixes an issue with setting contiguous weights
 
<!-- A more elaborate description of the changes, if needed. -->