### PR TITLE
Fixing programming noise visualization and `program_analog_noise` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 * Index error when loading the state dict with a model use previously. (\#387)
-* Weights that were not contiguous could have set wrongly. (\#388) 
+* Weights that were not contiguous could have set wrongly. (\#388)
+* Programming noise would not be applied if drift compensation was not
+  used. (\#389)
 
 ### Changed
-
+* Weight noise visualization now shows the programming noise and drift
+  noise difference. (\#389)
 
 ## [0.6.0] - 2022/05/16
 

--- a/src/aihwkit/inference/noise/pcm.py
+++ b/src/aihwkit/inference/noise/pcm.py
@@ -82,9 +82,11 @@ class PCMLikeNoiseModel(BaseNoiseModel):
 
     def __str__(self) -> str:
         return ('{}(prog_coeff={}, g_converter={}, g_max={:1.2f}, t_read={}, '
-                't_0={:1.2f})').format(
+                't_0={:1.2f}, prog_noise_scale={}, '
+                'read_noise_scale={}, drift_scale={})').format(
                     self.__class__.__name__, self.prog_coeff, self.g_converter,
-                    self.g_max, self.t_read, self.t_0)
+                    self.g_max, self.t_read, self.t_0, self.prog_noise_scale,
+                    self.read_noise_scale, self.drift_scale)
 
     @no_grad()
     def apply_programming_noise_to_conductance(self, g_target: Tensor) -> Tensor:

--- a/src/aihwkit/simulator/configs/configs.py
+++ b/src/aihwkit/simulator/configs/configs.py
@@ -13,7 +13,7 @@
 """Configurations for resistive processing units."""
 
 from dataclasses import dataclass, field
-from typing import ClassVar, Type
+from typing import ClassVar, Type, Optional
 
 from aihwkit.simulator.configs.devices import (
     ConstantStepDevice, FloatingPointDevice, IdealDevice, PulsedDevice,
@@ -130,7 +130,8 @@ class InferenceRPUConfig(_PrintableMixin):
     noise_model: BaseNoiseModel = field(default_factory=PCMLikeNoiseModel)
     """Statistical noise model to be used during (realistic) inference."""
 
-    drift_compensation: BaseDriftCompensation = field(default_factory=GlobalDriftCompensation)
+    drift_compensation: Optional[BaseDriftCompensation] = field(
+        default_factory=GlobalDriftCompensation)
     """For compensating the drift during inference only."""
 
     clip: WeightClipParameter = field(default_factory=WeightClipParameter)

--- a/src/aihwkit/simulator/tiles/inference.py
+++ b/src/aihwkit/simulator/tiles/inference.py
@@ -117,10 +117,10 @@ class InferenceTile(AnalogTile):
         self.programmed_weights, self.nu_drift_list = self.noise_model.apply_programming_noise(
             self.reference_combined_weights)
 
-        if self.drift_compensation is not None:
-            self.tile.set_weights(self.programmed_weights.numpy())
-            forward_output = self._forward_drift_readout_tensor()
+        self.tile.set_weights(self.programmed_weights.numpy())
 
+        if self.drift_compensation is not None:
+            forward_output = self._forward_drift_readout_tensor()
             self.drift_baseline = self.drift_compensation.init_baseline(forward_output)
 
     @no_grad()
@@ -142,6 +142,7 @@ class InferenceTile(AnalogTile):
                 noise model used for details.
         """
         # pylint: disable=arguments-differ,arguments-renamed
+
         if self.programmed_weights is None:
             self.program_weights()
 

--- a/src/aihwkit/utils/visualization.py
+++ b/src/aihwkit/utils/visualization.py
@@ -33,16 +33,18 @@ from matplotlib import ticker
 from matplotlib.figure import Figure
 from numpy import ndarray
 from torch import device as torch_device
-from torch import eye, from_numpy, ones
+from torch import eye, from_numpy, ones, stack
 
 from aihwkit.exceptions import ConfigError
-from aihwkit.simulator.configs import SingleRPUConfig, UnitCellRPUConfig
+from aihwkit.simulator.configs import (
+    SingleRPUConfig, UnitCellRPUConfig, InferenceRPUConfig
+)
 from aihwkit.simulator.configs.devices import PulsedDevice, UnitCell
 from aihwkit.simulator.configs.utils import (
     BoundManagementType, IOParameters, NoiseManagementType, PulseType,
     UpdateParameters, WeightNoiseType
 )
-from aihwkit.simulator.tiles import AnalogTile, BaseTile
+from aihwkit.simulator.tiles import AnalogTile, BaseTile, InferenceTile
 from aihwkit.simulator.rpu_base import cuda
 from aihwkit.inference.noise.base import BaseNoiseModel
 from aihwkit.inference.noise.pcm import PCMLikeNoiseModel
@@ -608,6 +610,7 @@ def plot_weight_drift(noise_model: BaseNoiseModel = None,
         w_inits: Numpy array of target weights to program
         n_repeats: How many repeats to estimate the standard deviation
     """
+    # pylint: disable=too-many-locals
 
     plt.figure(figsize=[10, 5])
     if noise_model is None:
@@ -617,19 +620,29 @@ def plot_weight_drift(noise_model: BaseNoiseModel = None,
     if w_inits is None:
         w_inits = np.linspace(-1., 1., 9)
 
+    rpu_config = InferenceRPUConfig(noise_model=noise_model, drift_compensation=None)
+
     weights = w_inits.flatten()
     weights.sort()
     weights = np.tile(weights, [n_repeats, 1])
 
+    analog_tile = InferenceTile(weights.shape[0], weights.shape[1], rpu_config)
+    analog_tile.set_weights(from_numpy(weights))
+    analog_tile.program_weights()
+    programmed_weights, _ = analog_tile.get_weights()
+
     m_list = []
     s_list = []
-    for t_inference in t_inference_list:
-        noisy_weights = noise_model.apply_noise(from_numpy(weights), t_inference).numpy()
-        m_list.append(noisy_weights.mean(axis=0))
-        s_list.append(noisy_weights.std(axis=0))
 
-    m_array = np.stack(m_list, axis=1)
-    s_array = np.stack(s_list, axis=1)
+    for t_inference in t_inference_list:
+        analog_tile.drift_weights(t_inference=t_inference)
+        noisy_weights, _ = analog_tile.get_weights()
+
+        m_list.append(noisy_weights.mean(axis=0))
+        s_list.append((programmed_weights - noisy_weights).std(axis=0))
+
+    m_array = stack(m_list, axis=1)
+    s_array = stack(s_list, axis=1)
 
     for i in range(w_inits.size):
         curve = plt.plot(t_inference_list, m_array[i])


### PR DESCRIPTION
* Fix: `program_analog_noise` would not change the weights alone (only together with `drift_analog_weights`)) in case no drift compensation was used
* Set drift compensation to optional
* `plot_weight_drift` would program the noise for each t_inference not clearly showing the programing versus read noise.    

## Details

* visualization now shows error bar only for read noise, programming noise can be seen from the onset. 