### PR TITLE
Concatenating updates in optimizer for performance reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Changed
 * Weight noise visualization now shows the programming noise and drift
   noise difference. (\#389)
+* Concatenate the gradients before applying to the tile update
+  function (some speedup for CUDA expected). (\#390)
 
 ## [0.6.0] - 2022/05/16
 


### PR DESCRIPTION
## Related issues


In the gradient trace for analog tiles, repeated gradients are appended to a list. Currently, the tile update function is called for each of these values. Thus, e.g. for LSTMs the optimizer loops through single updates for analog, so that analog training is slow (on GPUs). 

## Description
Here the update vectors are concatenated to the batch dimension, which will optimize the update computation in particular for CUDA
