### PR TITLE
LSTM cell with combined weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ## Unreleased
 
 ### Added
+* Example 22: 2 layer LSTM network trained on War and Peace dataset. (\#391)
 * Notebook for exploring analog sensitivities. (\#380)
 * Remapping functionality for ``InferenceRPUConfig``. (\#388)
 

--- a/examples/22_war_and_peace_lstm.py
+++ b/examples/22_war_and_peace_lstm.py
@@ -1,0 +1,462 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""aihwkit example 22: 2-layers LSTM
+
+War and Peace dataset on a 2-layers LSTM inspired network based on the paper:
+https://www.frontiersin.org/articles/10.3389/fnins.2018.00745/full
+"""
+
+# pylint: disable=redefined-outer-name, too-many-locals, invalid-name, too-many-statements
+
+# Imports from PyTorch.
+import os
+import argparse
+import time
+import sys
+
+from typing import Tuple
+from torch import tensor, device, FloatTensor, Tensor, transpose, save, load
+from torch.nn import CrossEntropyLoss
+from torch.utils.data import Dataset, DataLoader
+from torch.utils.data.sampler import Sampler
+from torch.nn.functional import one_hot
+
+import numpy as np
+
+from aihwkit.nn import AnalogSequential, AnalogRNN, AnalogLinear, AnalogLSTMCellCombinedWeight
+from aihwkit.optim import AnalogSGD
+from aihwkit.simulator.configs import InferenceRPUConfig, UnitCellRPUConfig, SingleRPUConfig
+from aihwkit.simulator.configs.devices import BufferedTransferCompound, SoftBoundsDevice, \
+    ConstantStepDevice
+from aihwkit.simulator.configs.utils import MappingParameter
+from aihwkit.simulator.rpu_base import cuda
+from aihwkit.simulator.configs.utils import IOParameters, UpdateParameters
+
+# Check device
+USE_CUDA = 0
+if cuda.is_compiled():
+    USE_CUDA = 1
+DEVICE = device('cuda' if USE_CUDA else 'cpu')
+
+HIDDEN_DIM = 64
+P_DROP = 0.0
+TEST_FREQ = 1
+
+
+def parse_args():
+    """Parse arguments for the experiment."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--bs', type=int, default=128, help='Batch size')
+    parser.add_argument('--sl', type=int, default=100, help='Sequence length')
+    parser.add_argument('--lr', type=float, default=0.005, help='Learning rate')
+    parser.add_argument('--epochs', type=int, default=50, help='Training epochs')
+    parser.add_argument('--rpu_conf', type=str, default='FP',
+                        help='Configuration for the rpu_config. FP is floating point tile with'
+                             'is_perfect=True. TTV2 is the unit cell tile for tiki-takaV2 '
+                             'training')
+    parser.add_argument('--file_name', type=str, default=None, help='Training epochs')
+    parser.add_argument('--results_path', type=str, default=None,
+                        help='Path where the results will be saved')
+    parser.add_argument('--use_analog', action='store_true', default=True,
+                        help='Run the training on AnalogLSTMLayer')
+
+    return parser.parse_args()
+
+
+class WarAndPeaceDataset(Dataset):
+    """Custom dataset to load the War and Peace train and test dataset"""
+
+    def __init__(self,
+                 path,
+                 seq_length: int = 1,
+                 train: bool = True):
+        super().__init__()
+
+        self.seq_length = seq_length
+
+        # Read the text file
+        file_path = os.path.join(path, 'wp_train.txt')
+        with open(file_path, 'r', encoding='iso-8859-1') as file:
+            text = file.read()
+        chars = sorted(list(set(text)))
+
+        # char to index and index to char maps
+        char_to_ix = {ch: i for i, ch in enumerate(chars)}
+
+        # If train load the training dataset, otherwise load the test dataset but use the
+        # vocabulary of the train dataset for the conversion as some characters are missing
+        # from the test dataset
+        if train:
+            print('Loaded train dataset: ', file_path,
+                  '\nTotal character: ', len(text),
+                  '\nTotal vocabulary: ', len(chars))
+        else:
+            file_path = os.path.join(path, 'wp_test.txt')
+            with open(file_path, 'r', encoding='iso-8859-1') as file:
+                text = file.read()
+            print('Loaded test dataset: ', file_path,
+                  '\nTotal character: ', len(text),
+                  '\nTotal vocabulary: ', len(chars))
+
+        # Convert the letter to integers
+        self.characters = tensor([char_to_ix[ch] for ch in text[:-1]])
+        # The labels get shifted by one since we want to predict the
+        # next character
+        self.labels = tensor([char_to_ix[ch] for ch in text[1:]])
+
+        # One hot encoding
+        self.characters = one_hot(self.characters, len(chars)).type(FloatTensor)
+
+        # Drop the last characters that won't fit in the multiple of the SEQ_LENGTH
+        self.characters = self.characters[
+                          0:self.characters.size(0) // self.seq_length * self.seq_length, :]
+        self.labels = self.labels[
+                      0:self.characters.size(0) // self.seq_length * self.seq_length]
+
+        self.characters = self.characters.view(-1, self.seq_length, len(chars))
+        self.labels = self.labels.view(-1, self.seq_length)
+
+    def __len__(self):
+
+        return len(self.characters)
+
+    def __getitem__(self, idx):
+        characters = self.characters[idx, :, :]
+        labels = self.labels[idx, :]
+
+        return characters, labels
+
+
+class WarAndPeaceSampler(Sampler):
+    """Custom sampler to load the War and Peace dataset"""
+
+    def __init__(self,
+                 dataset,
+                 batch_size):
+        super().__init__(dataset)
+
+        num_sequence = int(len(dataset))
+        num_batches = int(num_sequence / batch_size)
+
+        self.idx_list = []
+        for i in range(num_batches):
+            for j in range(batch_size):
+                self.idx_list.append(i + num_batches * j)
+
+    def __iter__(self):
+        return iter(self.idx_list)
+
+    def __len__(self):
+        return len(self.idx_list)
+
+
+class AnalogLSTMLayer(AnalogSequential):
+    """Create an LSTM network analogous to the LSTM2-64WP based on the paper:
+    https://www.frontiersin.org/articles/10.3389/fnins.2018.00745/full
+    """
+
+    def __init__(self,
+                 seq_length,
+                 vocab_size,
+                 hidden_dim,
+                 batch_size,
+                 rpu_config,
+                 p_dropout):
+        super().__init__()
+
+        self.seq_length = seq_length
+        self.vocab_size = vocab_size
+        self.hidden_dim = hidden_dim
+        self.batch_size = batch_size
+
+        self.lstm_1 = AnalogRNN(AnalogLSTMCellCombinedWeight, self.vocab_size, self.hidden_dim,
+                                num_layers=2, rpu_config=rpu_config, dropout=p_dropout)
+        self.linear = AnalogLinear(self.hidden_dim, self.vocab_size, rpu_config=rpu_config)
+
+    def forward(self, x_in, in_states):
+        # pylint: disable=arguments-differ
+
+        x_in = transpose(x_in, 0, 1).contiguous()
+
+        out, _ = self.lstm_1(x_in, in_states)
+        out = transpose(out, 0, 1).contiguous()
+        out = out.reshape(self.seq_length * self.batch_size, -1)
+        out = self.linear(out)
+
+        return out
+
+    def init_hidden(
+            self,
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Initialize the hidden states."""
+
+        weight = next(self.parameters()).data
+        hidden = (weight.new(2, self.batch_size, self.hidden_dim).zero_().to(DEVICE),
+                  weight.new(2, self.batch_size, self.hidden_dim).zero_().to(DEVICE))
+
+        return hidden
+
+
+def create_rpu_config(config='FP'):
+    """Create an rpu_config for the lstm network
+
+    Args:
+        config (str): name of the rpu_config to be returned
+
+    Returns:
+        rpu_config: rpu_config to be used in the analog layers
+
+    Type:
+        rpu_config: rpu_config
+
+    Raises:
+        ValueError: In case config is not found
+    """
+
+    mapping = MappingParameter(digital_bias=False, max_input_size=0, max_output_size=0)
+
+    if config == 'FP':
+        rpu_config = InferenceRPUConfig(forward=IOParameters(is_perfect=True), mapping=mapping)
+
+    elif config == 'RPU_Baseline':
+        rpu_config = SingleRPUConfig(device=SoftBoundsDevice(),
+                                     update=UpdateParameters(desired_bl=10), mapping=mapping)
+        adc_bit = 9
+        dac_bit = 7
+        rpu_config.forward.out_res = 1 / (2 ** adc_bit - 2)
+        rpu_config.forward.inp_res = 1 / (2 ** dac_bit - 2)
+
+    elif config == 'RPU_Symmetric':
+        rpu_config = SingleRPUConfig(device=ConstantStepDevice(dw_min=0.00025, up_down_dtod=0),
+                                     update=UpdateParameters(desired_bl=10), mapping=mapping)
+        adc_bit = 9
+        dac_bit = 7
+        rpu_config.forward.out_res = 1 / (2 ** adc_bit - 2)
+        rpu_config.forward.inp_res = 1 / (2 ** dac_bit - 2)
+
+    elif config == 'TTv2':
+        rpu_config = UnitCellRPUConfig(
+            device=BufferedTransferCompound(
+                # Devices that compose the Tiki-taka compound.
+                unit_cell_devices=[
+                    SoftBoundsDevice(dw_min=0.001, up_down_dtod=0),
+                    SoftBoundsDevice(dw_min=0.001, up_down_dtod=0)
+                ],
+                transfer_update=UpdateParameters(desired_bl=1,
+                                                 update_bl_management=False,
+                                                 update_management=False),
+
+                # Make some adjustments of the way Tiki-Taka is performed.
+                units_in_mbatch=False,  # batch_size=1 anyway
+                transfer_every=2,
+                n_reads_per_transfer=1,  # one forward read for each transfer
+                gamma=0.0,
+                scale_transfer_lr=True,  # in relative terms to SGD LR
+                transfer_lr=1.0,  # same transfer LR as for SGD
+                fast_lr=5.0,
+                thresh_scale=1/0.001
+            ),
+            update=UpdateParameters(desired_bl=10),
+            mapping=mapping
+        )
+
+        adc_bit = 9
+        dac_bit = 7
+        rpu_config.forward.out_res = 1 / (2 ** adc_bit - 2)
+        rpu_config.forward.inp_res = 1 / (2 ** dac_bit - 2)
+
+    else:
+        raise ValueError('Selected rpu_config is not available')
+
+    return rpu_config
+
+
+def load_dataset(path, seq_length=1, batch_size=1):
+    """Load the dataset and reshape it to provide an input
+    of shape [SEQ_LENGTH, BATCH_SIZE, VOCABULARY_SIZE]
+
+    Args:
+        path (path): dataset path
+        seq_length (int): lenght of the sequence
+        batch_size (int): batch size
+
+    Returns:
+        train_data: data for the training
+        test_data: data for the testing
+
+    Type:
+        train_data: dataset
+        test_data: dataset
+    """
+
+    train_set = WarAndPeaceDataset(path,
+                                   seq_length=seq_length,
+                                   train=True)
+    test_set = WarAndPeaceDataset(path,
+                                  seq_length=seq_length,
+                                  train=False)
+
+    train_data = DataLoader(train_set,
+                            batch_size=batch_size,
+                            sampler=WarAndPeaceSampler(train_set, batch_size),
+                            drop_last=True)
+    test_data = DataLoader(test_set,
+                           batch_size=batch_size,
+                           sampler=WarAndPeaceSampler(test_set, batch_size),
+                           drop_last=True)
+
+    return train_data, test_data
+
+
+def create_sgd_optimizer(model, learning_rate, momentum):
+    """Create the analog-aware optimizer.
+
+    Args:
+        model (nn.Module): model to be trained
+        learning_rate (float): global parameter to define learning rate
+        momentum (float): momentum
+
+    Returns:
+        nn.Module: Analog optimizer
+    """
+    optimizer = AnalogSGD(model.parameters(), lr=learning_rate, momentum=momentum)
+    optimizer.regroup_param_groups(model)
+
+    return optimizer
+
+
+def main():
+    """Train an AnalogLSTM model with the War and Peace dataset."""
+
+    args = parse_args()
+    print("Setting Arguments.. : ", args)
+
+    batch_size = args.bs
+    seq_lenght = args.sl
+    learning_rate = args.lr
+    epochs = args.epochs
+    momentum = 0
+    rpu_conf = args.rpu_conf
+
+    path_dataset = os.path.join(os.getcwd(), 'data', 'DATASET', 'war_and_peace')
+    results = os.path.join(os.getcwd(), 'results', 'LSTM')
+
+    # Set the file name
+    file_name = 'LSTM_' + str(args.rpu_conf) + '_E' + str(args.epochs) + '_BS' \
+                + str(args.bs) + '_LR' + str(args.lr) + '_' + time.strftime("%Y%m%d-%H%M%S") \
+        if args.file_name is None else args.file_name
+
+    path_file = os.path.join(results, file_name)
+    print('Saving data to: ', path_file)
+
+    # Load datasets.
+    train_data, test_data = load_dataset(path_dataset, seq_lenght, batch_size)
+
+    # Create rpu_config.
+    rpu_config = create_rpu_config(config=rpu_conf)
+
+    # Create model.
+    model = AnalogLSTMLayer(seq_length=seq_lenght,
+                            vocab_size=87,
+                            hidden_dim=HIDDEN_DIM,
+                            batch_size=batch_size,
+                            rpu_config=rpu_config,
+                            p_dropout=P_DROP).to(DEVICE)
+    print(model)
+    print('\nInfo about the instantiated C++ tile:\n')
+    print(model.lstm_1.rnn.layers[0].cell.weight.analog_tile.tile)
+    print('\nPretty-print of RPU non-default settings:\n')
+    print(rpu_config)
+
+    for name, mod in model.named_children():
+        if name == 'lstm_1':
+            for layer in mod.rnn.layers:
+                layer.cell.weight.analog_tile.set_out_scaling_alpha = 2 / 0.6
+        else:
+            mod.analog_tile.set_out_scaling_alpha = 2 / 0.6
+
+    epoch_start = 0
+    epoch_losses = []
+
+    if args.file_name is not None:
+        print('Loading state dict from: ', (args.file_name + '.ckpt'))
+        model.load_state_dict(load((path_file + '.ckpt')))
+
+        with open((path_file + '.csv'), 'rb') as file:
+            epoch_losses = np.loadtxt(file.read, delimiter=",")
+        epoch_start = int(epoch_losses[-1, 0])
+        epoch_losses = epoch_losses.tolist()
+
+    # Create optimizer and define loss function
+    optimizer = create_sgd_optimizer(model, learning_rate, momentum)
+    criterion = CrossEntropyLoss()
+
+    for epoch_number in range(epoch_start + 1, epochs):
+        in_states = model.init_hidden()
+        model.train()
+        train_total_loss = 0
+
+        for characters, labels in train_data:
+            characters = characters.to(DEVICE)
+            labels = labels.to(DEVICE)
+            labels = labels.view(seq_lenght * batch_size)
+            optimizer.zero_grad()
+            prediction = model(characters, in_states)
+            loss = criterion(prediction, labels)
+
+            loss.backward()
+            optimizer.step()
+
+            train_total_loss += loss.item() * characters.size(0)
+
+        test_total_loss = 0
+        if epoch_number % TEST_FREQ == 0:
+            in_states = model.init_hidden()
+            model.eval()
+
+            for characters, labels in test_data:
+                characters = characters.to(DEVICE)
+                labels = labels.to(DEVICE)
+                labels = labels.view(seq_lenght * batch_size)
+                prediction = model(characters, in_states)
+                loss = criterion(prediction, labels)
+                test_total_loss += loss.item() * characters.size(0)
+
+        epoch_losses.append((epoch_number,
+                             train_total_loss / len(train_data.dataset),
+                             test_total_loss / len(test_data.dataset)))
+
+        print('Epoch {} - Train loss: {:.8f} - Test loss: {:.8f}'.format(
+            epoch_number,
+            train_total_loss / len(train_data.dataset),
+            test_total_loss / len(test_data.dataset)))
+
+        original_stdout = sys.stdout
+        with open((path_file + '.config'), "w") as f:
+            sys.stdout = f
+            print('==========================')
+            print('Info about all settings:\n')
+            print(rpu_config)
+            print('==========================')
+            print('\nInfo about the instantiated C++ tile:\n')
+            print(model.lstm_1.rnn.layers[0].cell.weight.analog_tile.tile)
+            sys.stdout = original_stdout
+
+        np.savetxt((path_file + '.csv'), epoch_losses, delimiter=",")
+        save(model.state_dict(), (path_file + '.ckpt'))
+
+
+if __name__ == '__main__':
+    # Execute only if run as the entry point into the program
+    main()

--- a/src/aihwkit/nn/__init__.py
+++ b/src/aihwkit/nn/__init__.py
@@ -18,7 +18,8 @@ from aihwkit.nn.modules.container import AnalogSequential
 from aihwkit.nn.modules.conv import AnalogConv1d, AnalogConv2d, AnalogConv3d
 from aihwkit.nn.modules.linear import AnalogLinear
 from aihwkit.nn.modules.rnn.rnn import AnalogRNN
-from aihwkit.nn.modules.rnn.cells import AnalogGRUCell, AnalogLSTMCell, AnalogVanillaRNNCell
+from aihwkit.nn.modules.rnn.cells import AnalogGRUCell, AnalogLSTMCell, AnalogVanillaRNNCell, \
+    AnalogLSTMCellCombinedWeight
 from aihwkit.nn.modules.linear_mapped import AnalogLinearMapped
 from aihwkit.nn.modules.conv_mapped import (
     AnalogConv1dMapped, AnalogConv2dMapped, AnalogConv3dMapped

--- a/src/aihwkit/nn/modules/rnn/layers.py
+++ b/src/aihwkit/nn/modules/rnn/layers.py
@@ -22,7 +22,8 @@ class AnalogRNNLayer(AnalogSequential):
     """Analog RNN Layer.
 
     Args:
-        cell: RNNCell type (AnalogLSTMCell/AnalogGRUCell/AnalogVanillaRNNCell)
+        cell: RNNCell type (AnalogLSTMCell/AnalogGRUCell/AnalogVanillaRNNCell/
+              AnalogLSTMCellSingleRPU)
         cell_args: arguments to RNNCell (e.g. input_size, hidden_size, rpu_configs)
     """
     # pylint: disable=abstract-method

--- a/src/aihwkit/simulator/configs/utils.py
+++ b/src/aihwkit/simulator/configs/utils.py
@@ -21,8 +21,8 @@ from typing import ClassVar, Type
 from aihwkit.simulator.configs.helpers import _PrintableMixin
 from aihwkit.simulator.rpu_base import devices, tiles
 
-
 # Helper enums.
+
 
 class BoundManagementType(Enum):
     """Bound management type.
@@ -710,7 +710,6 @@ class MappingParameter(_PrintableMixin):
 
         Some of these parameters have only an affect for modules that
         support tile mappings.
-
     """
 
     digital_bias: bool = True

--- a/tests/helpers/layers.py
+++ b/tests/helpers/layers.py
@@ -22,7 +22,7 @@ from torch.nn import RNN as RNN_nn
 
 from aihwkit.nn import (
     AnalogConv1d, AnalogConv2d, AnalogConv3d, AnalogLinear,
-    AnalogRNN, AnalogLSTMCell,
+    AnalogRNN, AnalogLSTMCell, AnalogLSTMCellCombinedWeight,
     AnalogGRUCell, AnalogVanillaRNNCell,
     AnalogLinearMapped, AnalogConv1dMapped,
     AnalogConv2dMapped, AnalogConv3dMapped
@@ -177,7 +177,26 @@ class LSTM:
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
         kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
+        kwargs['rpu_config'].mapping.max_input_size = 0
+        kwargs['rpu_config'].mapping.max_output_size = 0
         return AnalogRNN(AnalogLSTMCell, input_size, hidden_size, **kwargs)
+
+    def get_native_layer_comparison(self, *args, **kwargs):
+        return LSTM_nn(*args, **kwargs)
+
+
+class LSTMCombinedWeight:
+    """AnalogLSTM on a single RPU tile."""
+
+    use_cuda = False
+
+    def get_layer(self, input_size=2, hidden_size=3, **kwargs):
+        kwargs.setdefault('rpu_config', self.get_rpu_config())
+        kwargs.setdefault('bias', self.bias)
+        kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
+        kwargs['rpu_config'].mapping.max_input_size = 0
+        kwargs['rpu_config'].mapping.max_output_size = 0
+        return AnalogRNN(AnalogLSTMCellCombinedWeight, input_size, hidden_size, **kwargs)
 
     def get_native_layer_comparison(self, *args, **kwargs):
         return LSTM_nn(*args, **kwargs)
@@ -192,6 +211,9 @@ class GRU:
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
         kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
+        kwargs['rpu_config'].mapping.max_input_size = 0
+        kwargs['rpu_config'].mapping.max_output_size = 0
+
         return AnalogRNN(AnalogGRUCell, input_size, hidden_size, **kwargs)
 
     def get_native_layer_comparison(self, *args, **kwargs):
@@ -207,6 +229,8 @@ class VanillaRNN:
         kwargs.setdefault('rpu_config', self.get_rpu_config())
         kwargs.setdefault('bias', self.bias)
         kwargs['rpu_config'].mapping.digital_bias = self.digital_bias
+        kwargs['rpu_config'].mapping.max_input_size = 0
+        kwargs['rpu_config'].mapping.max_output_size = 0
         return AnalogRNN(AnalogVanillaRNNCell, input_size, hidden_size, **kwargs)
 
     def get_native_layer_comparison(self, *args, **kwargs):
@@ -295,6 +319,18 @@ class LSTMCuda(LSTM):
 
     def get_native_layer_comparison(self, *args, **kwargs):
         return LSTM.get_native_layer_comparison(self, *args, **kwargs).cuda()
+
+
+class LSTMCombinedWeightCuda(LSTMCombinedWeight):
+    """AnalogLSTMCuda."""
+
+    use_cuda = True
+
+    def get_layer(self, *args, **kwargs):
+        return LSTMCombinedWeight.get_layer(self, *args, **kwargs).cuda()
+
+    def get_native_layer_comparison(self, *args, **kwargs):
+        return LSTMCombinedWeight.get_native_layer_comparison(self, *args, **kwargs).cuda()
 
 
 class GRUCuda(GRU):

--- a/tests/test_layers_rnn.py
+++ b/tests/test_layers_rnn.py
@@ -11,17 +11,16 @@
 # that they have been altered from the originals.
 
 """Tests for RNN layers."""
-
-from torch import randn, ones
+from torch import randn, ones, no_grad
 from torch.nn import MSELoss
 from numpy.testing import assert_array_almost_equal, assert_raises
 
 from aihwkit.optim import AnalogSGD
-from aihwkit.simulator.configs.configs import InferenceRPUConfig
 from aihwkit.optim.context import AnalogContext
 
 from .helpers.decorators import parametrize_over_layers
-from .helpers.layers import LSTM, LSTMCuda, GRU, GRUCuda, VanillaRNN, VanillaRNNCuda
+from .helpers.layers import LSTM, LSTMCuda, GRU, GRUCuda, VanillaRNN, VanillaRNNCuda, \
+                            LSTMCombinedWeight, LSTMCombinedWeightCuda
 from .helpers.testcases import ParametrizedTestCase
 from .helpers.tiles import FloatingPoint, Inference
 
@@ -35,14 +34,22 @@ class RNNLayerTest(ParametrizedTestCase):
     """ Base test for RNNs"""
 
     @staticmethod
-    def train_once(model, y_in, y_out, analog_if):
+    def train_once(model, y_in, y_out, analog_if, lr=0.5, digital_bias_lr_scale=1.0):
         """Train once."""
+
         criterion = MSELoss()
-        optimizer = AnalogSGD(model.parameters(), lr=0.5, momentum=0.0, nesterov=0.0)
+        optimizer = AnalogSGD(model.parameters(), lr=lr, momentum=0.0, nesterov=0.0)
+        optimizer.regroup_param_groups()
         batch_size = y_in.size()[1]
 
         if analog_if:
+            for param_group in optimizer.param_groups:
+                if isinstance(param_group['params'][0], AnalogContext):
+                    param_group['lr'] = lr
+                else:
+                    param_group['lr'] = lr * digital_bias_lr_scale
             states = model.get_zero_state(batch_size)
+
         else:
             states = None
 
@@ -96,14 +103,12 @@ class RNNLayerTest(ParametrizedTestCase):
                 self.assertEqual(layer.cell.weight_ih.in_features, hidden_size)
             self.assertEqual(layer.cell.weight_hh.in_features, hidden_size)
             # Assert over the rpu_config.
-            if not isinstance(layer.cell.weight_ih.analog_tile.rpu_config, InferenceRPUConfig):
-                self.assertEqual(layer.cell.weight_ih.analog_tile.rpu_config, self.get_rpu_config())
-                self.assertEqual(layer.cell.weight_hh.analog_tile.rpu_config, self.get_rpu_config())
-            else:
-                self.assertEqual(layer.cell.weight_ih.analog_tile.rpu_config.__class__,
-                                 self.get_rpu_config().__class__)
-                self.assertEqual(layer.cell.weight_hh.analog_tile.rpu_config.__class__,
-                                 self.get_rpu_config().__class__)
+            analog_tile_ih = list(layer.cell.weight_ih.analog_tiles())[0]
+            analog_tile_hh = list(layer.cell.weight_hh.analog_tiles())[0]
+            self.assertEqual(analog_tile_ih.rpu_config.__class__,
+                             self.get_rpu_config().__class__)
+            self.assertEqual(analog_tile_hh.rpu_config.__class__,
+                             self.get_rpu_config().__class__)
 
     def get_native_layer_comparison(self, *args, **kwargs):
         """ Returns the torch native model """
@@ -121,7 +126,6 @@ class RNNLayerTest(ParametrizedTestCase):
                     weight, bias = param.analog_tile.get_weights()
                     splits = name.split('.')
                     add_on = '_' + splits[-2].split('_')[-1] + '_l' + splits[2]
-
                     dic['weight' + add_on] = weight
                     if bias is not None:
                         dic['bias' + add_on] = bias
@@ -134,10 +138,10 @@ class RNNLayerTest(ParametrizedTestCase):
 
             return dic
 
-        input_size = 4
-        hidden_size = 5
+        input_size = 2
+        hidden_size = 2
         num_layers = 2
-        seq_length = 10
+        seq_length = 3
         batch_size = 3
         test_for_update = False  # For debugging. Does test whether all weights are updated.
 
@@ -177,6 +181,10 @@ class RNNLayerTest(ParametrizedTestCase):
             y_out = y_out.cuda()
             rnn_analog.cuda()
             rnn.cuda()
+
+        with no_grad():
+            assert_array_almost_equal(rnn(y_in)[0].detach().clone().cpu(),
+                                      rnn_analog(y_in)[0].detach().clone().cpu())
 
         # First train analog and make sure weights differ.
         pred_analog = self.train_once(rnn_analog, y_in, y_out, True)
@@ -282,6 +290,10 @@ class RNNLayerTest(ParametrizedTestCase):
             rnn_analog.cuda()
             rnn.cuda()
 
+        with no_grad():
+            assert_array_almost_equal(rnn(y_in)[0].detach().clone().cpu(),
+                                      rnn_analog(y_in)[0].detach().clone().cpu())
+
         # First train analog and make sure weights differ.
         pred_analog = self.train_once_bidir(rnn_analog, y_in, y_out, True)
 
@@ -311,3 +323,134 @@ class RNNLayerTest(ParametrizedTestCase):
         for par_name, par_item in rnn_pars.items():
             assert_array_almost_equal(par_item.detach().cpu().numpy(),
                                       rnn_analog_pars[par_name].detach().cpu().numpy())
+
+
+@parametrize_over_layers(
+    layers=[LSTMCombinedWeight, LSTMCombinedWeightCuda],
+    tiles=[FloatingPoint],
+    biases=['digital', None]
+)
+class LSTMCombinedWeightTest(RNNLayerTest):
+    """ Base test for AnalogLSTMCombinedWeight"""
+
+    def test_layer_instantiation(self):
+        """Test AnalogLSTM layer instantiation."""
+        input_size = 2
+        hidden_size = 3
+        num_layers = 4
+
+        model = self.get_layer(input_size=input_size,
+                               hidden_size=hidden_size,
+                               num_layers=num_layers)
+
+        # Assert over the stacked layers.
+        self.assertEqual(len(model.rnn.layers), num_layers)
+        for i, layer in enumerate(model.rnn.layers):
+            # Assert over the size of weight_ih.
+            if i == 0:
+                self.assertEqual(layer.cell.weight.in_features, input_size+hidden_size)
+            else:
+                self.assertEqual(layer.cell.weight.in_features, 2 * hidden_size)
+            self.assertEqual(layer.cell.weight.out_features, 4 * hidden_size)
+            # Assert over the rpu_config.
+            analog_tile = list(layer.cell.weight.analog_tiles())[0]
+            self.assertEqual(analog_tile.rpu_config.__class__,
+                             self.get_rpu_config().__class__)
+
+    def get_native_layer_comparison(self, *args, **kwargs):
+        """ Returns the torch native model """
+        raise NotImplementedError
+
+    def test_layer_training(self):
+        """Test AnalogLSTM layer training."""
+        # pylint: disable=too-many-locals, too-many-statements
+        def get_parameters(model, analog_if) -> dict:
+            """Returns the parameter in an dict."""
+
+            dic = {}
+            for name, param in model.named_parameters():
+                if isinstance(param, AnalogContext):
+                    weight, bias = param.analog_tile.get_weights()
+                    lay = int(name.split('.')[2])
+                    add_on = '_l' + str(lay)
+                    if lay == 0:
+                        in_dim = input_size
+                    else:
+                        in_dim = hidden_size
+                    dic['weight_ih' + add_on] = weight[..., :in_dim]
+                    dic['weight_hh' + add_on] = weight[..., in_dim:]
+
+                    if bias is not None:
+                        dic['bias_ih' + add_on] = bias
+                        dic['bias_hh' + add_on] = 0.0 * bias
+
+                elif analog_if and name.endswith('bias'):  # digital bias
+                    add_on = '_l' + name.split('.')[2]
+                    dic['bias_ih' + add_on] = param
+                    dic['bias_hh' + add_on] = 0.0 * param
+                else:
+                    dic[name] = param
+
+            return dic
+
+        input_size = 5
+        hidden_size = 3
+        num_layers = 2
+        seq_length = 10
+        batch_size = 4
+        test_for_update = True  # For debugging. Does test whether all weights are updated.
+
+        # Make dataset (just random).
+        y_in = randn(seq_length, batch_size, input_size)
+        y_out = ones(seq_length, batch_size, 1)
+
+        rnn_analog = self.get_layer(input_size=input_size,
+                                    hidden_size=hidden_size,
+                                    num_layers=num_layers,
+                                    realistic_read_write=False,
+                                    dropout=0.0)
+
+        rnn = self.get_native_layer_comparison(input_size=input_size,
+                                               hidden_size=hidden_size,
+                                               num_layers=num_layers,
+                                               dropout=0.0,
+                                               bias=self.bias)
+
+        rnn_pars0 = get_parameters(rnn, False)
+        rnn_analog_pars0 = get_parameters(rnn_analog, True)
+
+        for par_name, par_item in rnn_pars0.items():
+            par_item.data = rnn_analog_pars0[par_name].detach().clone()
+
+        if test_for_update:
+            weights_org = []
+            # pylint: disable=protected-access
+            rnn_analog._apply_to_analog(lambda lay: weights_org.append(
+                lay.get_weights()))
+
+        if self.use_cuda:
+            y_in = y_in.cuda()
+            y_out = y_out.cuda()
+            rnn_analog.cuda()
+            rnn.cuda()
+
+        with no_grad():
+            assert_array_almost_equal(rnn(y_in)[0].detach().clone().cpu(),
+                                      rnn_analog(y_in)[0].detach().clone().cpu())
+
+        # First train analog and make sure weights differ.
+        # since there is only one bias the LR of the bias is changed
+        pred_analog = self.train_once(rnn_analog, y_in, y_out, True, digital_bias_lr_scale=2.0)
+
+        if test_for_update:
+            analog_weights = []
+            # pylint: disable=protected-access
+            rnn_analog._apply_to_analog(lambda lay: analog_weights.append(
+                lay.get_weights()))
+            for weight, weight_org in zip(analog_weights, weights_org):
+                assert_raises(AssertionError, assert_array_almost_equal, weight[0], weight_org[0])
+
+        # Compare with RNN.
+        pred = self.train_once(rnn, y_in, y_out, False)
+
+        assert_array_almost_equal(pred, pred_analog)


### PR DESCRIPTION
## Description

Added a new LSTM cell which combines the weights of the LSTM network on a single Analog layer.

Added an example that explores the study done in https://www.frontiersin.org/articles/10.3389/frai.2021.699148/full on a 2-layer LSTM network trained with the War and Peace dataset.

## Details
In the example, there are 4 different RPU that can be used: a floating point tile to run the workload; an analog tile with ideal devices that use SGD for training; an analog tile with ideal and symmetric device that use SGD for training; an analog tile which uses ideal device with tiki-taka v2 algorithm that achieves better performance than SGD.
