### PR TITLE
fix to analog_summary when model is on cuda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Remapping functionality for ``InferenceRPUConfig``. (\#388)
 
 ### Fixed
+* Analog_summary error when model is on cuda device. (\#392)
 * Index error when loading the state dict with a model use previously. (\#387)
 * Weights that were not contiguous could have set wrongly. (\#388)
 * Programming noise would not be applied if drift compensation was not

--- a/src/aihwkit/utils/analog_info.py
+++ b/src/aihwkit/utils/analog_info.py
@@ -206,7 +206,8 @@ class AnalogInfo:
             layer_summary.append(LayerInfo(_, self.rpu_config, input_size, output_size))
 
         self.register_hooks_recursively(self.model, get_size_hook)
-        dummy_var = torch.zeros(self.input_size)
+        device = next(self.model.parameters()).device
+        dummy_var = torch.zeros(self.input_size).to(device)
         self.model(dummy_var)
         return layer_summary
 


### PR DESCRIPTION
## Description

The analog_info utils failed when the model was moved to cuda because of a discrepancy between model and input tensor device.

## Details

Now the model device is inferred from its parameter and the input tensor moved accordingly.
