### PR TITLE
Analog matrix-vector-product examples using analog tiles directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 ## Unreleased
 
 ### Added
+* Example 23: how to use ``AnalogTile`` directly to implement an
+  analog matrix-vector product without using pytorch modules. (\#393)
 * Example 22: 2 layer LSTM network trained on War and Peace dataset. (\#391)
 * Notebook for exploring analog sensitivities. (\#380)
 * Remapping functionality for ``InferenceRPUConfig``. (\#388)

--- a/examples/22_war_and_peace_lstm.py
+++ b/examples/22_war_and_peace_lstm.py
@@ -17,6 +17,7 @@ https://www.frontiersin.org/articles/10.3389/fnins.2018.00745/full
 """
 
 # pylint: disable=redefined-outer-name, too-many-locals, invalid-name, too-many-statements
+# pylint: disable=not-callable
 
 # Imports from PyTorch.
 import os
@@ -52,6 +53,11 @@ HIDDEN_DIM = 64
 P_DROP = 0.0
 TEST_FREQ = 1
 
+# needs to be downloaded, e.g. from Gutenberg
+WP_TRAIN_FNAME = 'wp_train.txt'
+WP_TEST_FNAME = 'wp_test.txt'
+DATASET_PATH = os.path.join(os.getcwd(), 'data', 'DATASET', 'war_and_peace')
+
 
 def parse_args():
     """Parse arguments for the experiment."""
@@ -86,7 +92,7 @@ class WarAndPeaceDataset(Dataset):
         self.seq_length = seq_length
 
         # Read the text file
-        file_path = os.path.join(path, 'wp_train.txt')
+        file_path = os.path.join(path, WP_TRAIN_FNAME)
         with open(file_path, 'r', encoding='iso-8859-1') as file:
             text = file.read()
         chars = sorted(list(set(text)))
@@ -102,7 +108,7 @@ class WarAndPeaceDataset(Dataset):
                   '\nTotal character: ', len(text),
                   '\nTotal vocabulary: ', len(chars))
         else:
-            file_path = os.path.join(path, 'wp_test.txt')
+            file_path = os.path.join(path, WP_TEST_FNAME)
             with open(file_path, 'r', encoding='iso-8859-1') as file:
                 text = file.read()
             print('Loaded test dataset: ', file_path,
@@ -349,7 +355,7 @@ def main():
     momentum = 0
     rpu_conf = args.rpu_conf
 
-    path_dataset = os.path.join(os.getcwd(), 'data', 'DATASET', 'war_and_peace')
+    path_dataset = DATASET_PATH
     results = os.path.join(os.getcwd(), 'results', 'LSTM')
 
     # Set the file name

--- a/examples/23_using_analog_tile_as_matrix.py
+++ b/examples/23_using_analog_tile_as_matrix.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021, 2022 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""aihwkit example 22: Simple example of how to use an analog tile as a matrix
+"""
+# pylint: disable=invalid-name
+# pylint: disable=too-many-locals
+
+# Imports from PyTorch.
+from torch import randn
+from torch import device as torch_device
+from torch import cuda as torch_cuda
+
+# Imports from aihwkit.
+from aihwkit.simulator.tiles import AnalogTile
+from aihwkit.simulator.presets import ReRamSBPreset
+
+# Check GPU device
+DEVICE = torch_device('cuda' if torch_cuda.is_available() else 'cpu')
+
+# config the hardware properties
+rpu_config = ReRamSBPreset()
+# rpu_config.forward.out_noise = 0.1  # set some properties
+
+# size of matrix
+n = 50
+m = 200
+t = 10
+matrix = 0.1 * randn(n, m)  # matrix A
+
+x_values = randn(t, m)
+d_values = randn(t, n)
+
+# create analog tile (a single crossbar array)
+analog_tile = AnalogTile(matrix.shape[0], matrix.shape[1], rpu_config)
+analog_tile.set_weights(matrix, realistic=True)  # program weights
+
+if DEVICE.type == 'cuda':
+    analog_tile = analog_tile.cuda(DEVICE)
+    x_values = x_values.cuda(DEVICE)
+    d_values = d_values.cuda(DEVICE)
+
+# compute matrix vector product (A * x)
+y1 = analog_tile.forward(x_values)
+
+# compute transposed matrix vector product (A' * d)
+y2 = analog_tile.backward(d_values)
+
+# compute rank update  A += - lr * x * d'
+analog_tile.set_learning_rate(0.01)
+analog_tile.update(x_values, - d_values)
+current_analog_matrix = analog_tile.get_weights()  # perfect read
+current_matrix = analog_tile.get_weights(realistic=True)  # actual read

--- a/examples/README.md
+++ b/examples/README.md
@@ -469,29 +469,53 @@ model and the weights are then saved so that these can be used for additional tr
 
 ## Example 19: [`19_analog_summary_lenet.py`]
 
-In this example, we define a Lenet model and apply the analog_summary function. 
-The `analog_summary(model, input_size)` function provides a per-layer analog information and statistics. 
-Given the model and the input size, it prints a table containing the following per-layer information: 
-* Layer Name 
+In this example, we define a Lenet model and apply the analog_summary function.
+The `analog_summary(model, input_size)` function provides a per-layer analog information and statistics.
+Given the model and the input size, it prints a table containing the following per-layer information:
+* Layer Name
 * Layer type (Analog or Digital)
-* Input Shape 
-* Output Shape 
+* Input Shape
+* Output Shape
 * Kernel Shape
-* Number of analog tiles used by the layer 
+* Number of analog tiles used by the layer
 * The re-use factor (the number of computed operations using the same tile)
-* Per-tile information : 
+* Per-tile information :
   * Logical tile shape (out, in)
   * Physical tile shape (out, in)
   * Utilization (%)
 
-The function also prints some general information, such as the total number of tiles or analog layers. 
+The function also prints some general information, such as the total number of tiles or analog layers.
 
 ## Example 20: [`20_mnist_ddp.py`]
 
-In this example we define a linear model that is trained using the MNIST dataset. The model is an 
-analog sequential model that is defined using both the analog linear and analog linear mapped layers. 
-The model also uses PyTorch's Distributed Data Parallel (DDP) for training, which efficiently uses 
+In this example we define a linear model that is trained using the MNIST dataset. The model is an
+analog sequential model that is defined using both the analog linear and analog linear mapped layers.
+The model also uses PyTorch's Distributed Data Parallel (DDP) for training, which efficiently uses
 multiple GPUs for parallel training in order to significantly decrease the training time.
+
+## Example 21: [`21_fit_device_data.py`]
+
+In this example shows how one could quickly fit real device data for
+analog training  using the `PiecewiseStepDevice`.
+
+## Example 22: [`22_war_and_peace_lstm.py`]
+
+This example explores the study done in [Gokmen T and Haensch W (2020)
+Algorithm for Training Neural Networks on Resistive Device
+Arrays. Front. Neurosci.] on a 2-layer LSTM network trained with the
+War and Peace dataset (which needs to be downloaded separately).
+
+In the example, there are 4 different RPU that can be used: a floating
+point tile to run the workload; an analog tile with ideal devices that
+use SGD for training; an analog tile with ideal and symmetric device
+that use SGD for training; an analog tile which uses ideal device with
+tiki-taka v2 algorithm that achieves better performance than SGD.
+
+## Example 23: [`23_using_analog_tile_as_matrix.py`]
+
+Here it is illustrated how the analog tiles can be directly used to
+implement an analog mat-vec (without a pytorch layer).
+
 
 [Resistive Processing Units]: https://aihwkit.readthedocs.io/en/latest/using_simulator.html#resistive-processing-units
 [Inference and PCM statistical model]: https://aihwkit.readthedocs.io/en/latest/pcm_inference.html
@@ -533,3 +557,6 @@ Front. Neurosci.]: https://www.frontiersin.org/articles/10.3389/fnins.2020.00103
 [`18_cifar10_on_resnet.py`]: 18_cifar10_on_resnet.py
 [`19_analog_summary_lenet.py`]: 19_analog_summary_lenet.py
 [`20_mnist_ddp.py`]: 20_mnist_ddp.py
+[`21_fit_device_data.py`]: 21_fit_device_data.py
+[`22_war_and_peace_lstm.py`]: 22_war_and_peace_lstm.py
+[`23_using_analog_tile_as_matrix.py`]: 23_using_analog_tile_as_matrix.py


### PR DESCRIPTION
## Description

For numerical computation, the auto grad functionality of pytorch is often not necessary. Here we add an example how to use the  `AnalogTile` class directly to implement a matrix-vector product in analog, without the pytorch modules. 
