### PR TITLE
Bugfix forward indexed for inference tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Added ``analog_modules`` generator in ``AnalogSequential``. (\#410)
 * Added ``SKIP_CUDA_TESTS`` to manually switch off the CUDA tests
 * Enabling comparisons of ``RPUConfig`` instances. (\#410)
+* Specific use-defined function for layer-wise setting for RPUConfigs
+  in conversions. (\#412)
 
 ### Fixed
 * Analog_summary error when model is on cuda device. (\#392)
@@ -34,12 +36,17 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Loading a new model state dict for inference does not overwrite the
   noise model setting. (\#410)
 * Avoid ``AnalogContext`` copying of self pointers. (\#410)
+* Fix issue that drift compensation is not applied to
+  conv-layers. (\#412)
+* Fix issue that noise modifiers are not applied to
+  conv-layers. (\#412)
 
 ### Changed
 * Weight noise visualization now shows the programming noise and drift
   noise difference. (\#389)
 * Concatenate the gradients before applying to the tile update
   function (some speedup for CUDA expected). (\#390)
+* Drift compensation uses eye instead of ones for readout. (\#412)
 
 ## [0.6.0] - 2022/05/16
 
@@ -49,8 +56,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Out scaling factors can be learnt even if weight scaling omega was set to 0. (\#360)
 * Reverse up / down option for ``LinearStepDevice``. (\#361)
 * Generic Analog RNN classes (LSTM, RNN, GRU) uni or bidirectional. (\#358)
-* Added new ``PiecewiseStepDevice`` where the update-step response function can be arbitrarily defined by the user
-  in a piece-wise linear manner. It can be conveniently used to fit any experimental device data. (\#356)
+* Added new ``PiecewiseStepDevice`` where the update-step response
+  function can be arbitrarily defined by the user in a piece-wise
+  linear manner. It can be conveniently used to fit any experimental
+  device data. (\#356)
 * Several enhancements to the public documentations: added a new
   section for hw-aware training, refreshed the reference API doc, and
   added the newly supported LSTM layers and the mapped conv

--- a/src/aihwkit/inference/compensation/base.py
+++ b/src/aihwkit/inference/compensation/base.py
@@ -58,6 +58,6 @@ class BaseDriftCompensation:
         """Read out the current value from the output of the forward
         pass and returns the drift compensation alpha scale."""
         current_value = self.readout(forward_output)
-        ratio = ref_value/current_value
+        ratio = ref_value / current_value
 
         return ratio

--- a/src/aihwkit/inference/compensation/drift.py
+++ b/src/aihwkit/inference/compensation/drift.py
@@ -14,7 +14,7 @@
 
 from torch.autograd import no_grad
 from torch import abs as torch_abs
-from torch import clamp, ones, Tensor
+from torch import clamp, Tensor, eye
 
 from aihwkit.inference.compensation.base import BaseDriftCompensation
 
@@ -27,16 +27,16 @@ class GlobalDriftCompensation(BaseDriftCompensation):
 
     @no_grad()
     def readout(self, out_tensor: Tensor) -> Tensor:
-        """Read outs the abs max."""
-        return clamp(torch_abs(out_tensor).max(), min=0.0001)
+        """Read outs the mean abs."""
+        return clamp(torch_abs(out_tensor).mean(), min=0.0001)
 
     @no_grad()
     def get_readout_tensor(self, in_size: int) -> Tensor:
         """Return the read-out tensor.
 
-        Uses a single all one vector.
+        Uses the set of one-hot vectors (eye).
         """
-        return ones((1, in_size))
+        return eye(in_size)
 
     def __str__(self) -> str:
         return '{}()'.format(self.__class__.__name__)

--- a/src/aihwkit/nn/modules/conv_mapped.py
+++ b/src/aihwkit/nn/modules/conv_mapped.py
@@ -410,7 +410,7 @@ class _AnalogConvNdMapped(AnalogModuleBase, _ConvNd):
         Returns:
             A string with the extra representation.
         """
-        output = AnalogModuleBase.extra_repr(self)[:-1]
+        output = AnalogModuleBase.extra_repr(self)
         output += ', mapping={}'.format((len(self.in_sizes), len(self.out_sizes)))
 
         return output

--- a/tests/test_inference_tiles.py
+++ b/tests/test_inference_tiles.py
@@ -192,7 +192,7 @@ class InferenceTileTest(ParametrizedTestCase):
         ('copy', WeightModifierType.COPY,),
     ])
     def test_post_forward_modifier_types(self, _, modifier_type):
-        """Tests whether post update diffusion is performed."""
+        """Tests whether modifier is performed."""
         rpu_config = self.get_rpu_config()
         rpu_config.drift_compensation = None
         rpu_config.forward.is_perfect = True


### PR DESCRIPTION
## Related issues

closes #405, closes #406, closes #407, closes #408

## Description

Adds the `forward_indexed` override in the inference tile, which has affected the drift compensation and noise model for convolution layers. 

Also adds a number of small enhancements. 

## Details
* drift compensation now uses eye instead of ones
* analog state names with constants
* specific layer conversions (see #408)
* Fix print for mapped layers