### PR TITLE
Unfolded convs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ## Unreleased
 
 ### Added
+
 * Example 23: how to use ``AnalogTile`` directly to implement an
   analog matrix-vector product without using pytorch modules. (\#393)
 * Example 22: 2 layer LSTM network trained on War and Peace dataset. (\#391)
@@ -28,20 +29,22 @@ The format is based on [Keep a Changelog], and this project adheres to
   in conversions. (\#412)
 
 ### Fixed
+
 * Analog_summary error when model is on cuda device. (\#392)
 * Index error when loading the state dict with a model use previously. (\#387)
 * Weights that were not contiguous could have set wrongly. (\#388)
 * Programming noise would not be applied if drift compensation was not
   used. (\#389)
-* Loading a new model state dict for inference does not overwrite the
-  noise model setting. (\#410)
+* Loading a new model state dict for inference does not overwrite the noise
+  model setting. (\#410)
 * Avoid ``AnalogContext`` copying of self pointers. (\#410)
-* Fix issue that drift compensation is not applied to
-  conv-layers. (\#412)
-* Fix issue that noise modifiers are not applied to
-  conv-layers. (\#412)
+* Fix issue that drift compensation is not applied to conv-layers. (\#412)
+* Fix issue that noise modifiers are not applied to conv-layers. (\#412)
+* The CPU ``AnalogConv2d`` layer now uses unfolded convolutions instead of
+  indexed covolutions (that are efficient only for GPUs). (\#415)
 
 ### Changed
+
 * Weight noise visualization now shows the programming noise and drift
   noise difference. (\#389)
 * Concatenate the gradients before applying to the tile update

--- a/src/aihwkit/nn/modules/conv.py
+++ b/src/aihwkit/nn/modules/conv.py
@@ -15,12 +15,11 @@
 from typing import Optional, Tuple, Union, List
 
 from torch import Tensor, arange, cat, float64, int32, ones
-from torch.nn import Unfold
-from torch.nn.functional import pad
+from torch.nn.functional import pad, unfold
 from torch.nn.modules.conv import _ConvNd, Conv1d, Conv2d, Conv3d
 from torch.nn.modules.utils import _single, _pair, _triple
 
-from aihwkit.nn.functions import AnalogIndexedFunction
+from aihwkit.nn.functions import AnalogIndexedFunction, AnalogFunction
 from aihwkit.nn.modules.base import AnalogModuleBase, RPUConfigAlias
 from aihwkit.simulator.configs import SingleRPUConfig
 
@@ -69,6 +68,7 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: Optional[float] = None,
+            use_indexed: Optional[bool] = None
     ):
         # pylint: disable=too-many-arguments, too-many-locals
         if groups != 1:
@@ -103,6 +103,8 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
                          weight_scaling_omega=weight_scaling_omega)
 
         # Set the index matrices.
+        self.use_indexed = use_indexed
+
         self.fold_indices = Tensor().detach()
         self.register_helper('fold_indices')
         self.input_size = 0
@@ -134,7 +136,7 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
         if self.analog_tile_count():
             self.set_weights(self.weight, self.bias)
 
-    def recalculate_indexes(self, x_input: Tensor) -> None:
+    def _recalculate_indexes(self, x_input: Tensor) -> None:
         """Calculate and set the indexes of the analog tile."""
 
         self.fold_indices, image_sizes, self.input_size = \
@@ -156,15 +158,44 @@ class _AnalogConvNd(AnalogModuleBase, _ConvNd):
         """
         raise NotImplementedError
 
-    def forward(self, x_input: Tensor) -> Tensor:
-        """Compute the forward pass."""
+    def _forward_indexed(self, x_input: Tensor) -> Tensor:
+        """Compute the forward pass in indexed fashion. This is fast and
+        memory-efficient indexed convolution (only for GPUs)"""
+
         input_size = x_input.numel() / x_input.size(0)
         if self.input_size != input_size or not self.analog_tile.is_indexed():
-            self.recalculate_indexes(x_input)
+            self._recalculate_indexes(x_input)
 
-        out = AnalogIndexedFunction.apply(
+        return AnalogIndexedFunction.apply(
             self.analog_tile.get_analog_ctx(), x_input,
             self.analog_tile.shared_weights, not self.training)
+
+    def _forward_unfold(self, x_input: Tensor) -> Tensor:
+        """Forward using explicit unfolding (more suitable for CPUs) """
+        im_shape = x_input.shape
+        x_input_ = unfold(x_input, kernel_size=self.kernel_size, dilation=self.dilation,
+                          padding=self.padding, stride=self.stride).transpose(1, 2)
+
+        out = AnalogFunction.apply(
+            self.analog_tile.get_analog_ctx(), x_input_,
+            self.analog_tile.shared_weights, not self.training).transpose(1, 2)
+
+        out_size = (im_shape[2] + 2 * self.padding[0]
+                    - self.dilation[0] * (self.kernel_size[0] - 1) - 1) // self.stride[0] + 1
+        return out.view(im_shape[0], self.out_channels, out_size, -1)
+
+    def forward(self, x_input: Tensor) -> Tensor:
+        """Compute the forward pass."""
+
+        if self.use_indexed is None:
+            use_indexed = self.analog_tile.device.type == 'cuda'
+        else:
+            use_indexed = self.use_indexed
+
+        if use_indexed:
+            out = self._forward_indexed(x_input)
+        else:
+            out = self._forward_unfold(x_input)
 
         out = self.analog_tile.apply_out_scaling(out, self.tensor_view)
 
@@ -234,7 +265,7 @@ class AnalogConv1d(_AnalogConvNd):
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,  # type: ignore
             False, _single(0), groups, bias, padding_mode,
-            rpu_config, realistic_read_write, weight_scaling_omega
+            rpu_config, realistic_read_write, weight_scaling_omega, True
         )
 
         self.tensor_view = (-1, 1)
@@ -310,9 +341,8 @@ class AnalogConv1d(_AnalogConvNd):
         if not all(item == 0 for item in self.padding):
             fold_indices = pad(fold_indices, pad=[self.padding[0], self.padding[0]],
                                mode='constant', value=0)
-        unfold = fold_indices.unfold(2, self.kernel_size[0], self.stride[0]).clone()
-
-        fold_indices = unfold.reshape(-1, self.kernel_size[0]).transpose(0, 1).flatten().round()
+        unfolded = fold_indices.unfold(2, self.kernel_size[0], self.stride[0]).clone()
+        fold_indices = unfolded.reshape(-1, self.kernel_size[0]).transpose(0, 1).flatten().round()
 
         # concatenate the matrix index for different channels
         fold_indices_orig = fold_indices.clone()
@@ -370,6 +400,9 @@ class AnalogConv2d(_AnalogConvNd):
         weight_scaling_omega: If non-zero, the analog weights will be
             scaled by ``weight_scaling_omega`` divided by the absolute
             maximum value of the original weight matrix.
+        use_indexed: Whether to use explicit unfolding or implicit indexing. If
+            None (default), it will use implicit indexing for CUDA and
+            explicit unfolding for CPU
     """
     # pylint: disable=abstract-method
 
@@ -387,6 +420,7 @@ class AnalogConv2d(_AnalogConvNd):
             rpu_config: Optional[RPUConfigAlias] = None,
             realistic_read_write: bool = False,
             weight_scaling_omega: Optional[float] = None,
+            use_indexed: Optional[bool] = None
     ):
         # pylint: disable=too-many-arguments
         kernel_size = _pair(kernel_size)
@@ -397,7 +431,7 @@ class AnalogConv2d(_AnalogConvNd):
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,  # type: ignore
             False, _pair(0), groups, bias, padding_mode,
-            rpu_config, realistic_read_write, weight_scaling_omega
+            rpu_config, realistic_read_write, weight_scaling_omega, use_indexed
         )
 
         self.tensor_view = (-1, 1, 1)
@@ -470,11 +504,11 @@ class AnalogConv2d(_AnalogConvNd):
         fold_indices = arange(2, input_size + 2, dtype=float64).detach()
         shape = [1] + list(x_input.shape[1:])
         fold_indices = fold_indices.reshape(*shape)
-        unfold = Unfold(kernel_size=self.kernel_size,
-                        stride=self.stride,
-                        padding=self.padding,
-                        dilation=self.dilation)
-        fold_indices = unfold(fold_indices).flatten().round().to(dtype=int32)
+        fold_indices = unfold(fold_indices,
+                              kernel_size=self.kernel_size,
+                              stride=self.stride,
+                              padding=self.padding,
+                              dilation=self.dilation).flatten().round().to(dtype=int32)
 
         if self.analog_bias:
             out_image_size = fold_indices.numel() // (self.kernel_size[0] * self.kernel_size[1])
@@ -553,7 +587,7 @@ class AnalogConv3d(_AnalogConvNd):
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,  # type: ignore
             False, _triple(0), groups, bias, padding_mode,
-            rpu_config, realistic_read_write, weight_scaling_omega
+            rpu_config, realistic_read_write, weight_scaling_omega, True
         )
 
         self.tensor_view = (-1, 1, 1, 1)
@@ -634,12 +668,12 @@ class AnalogConv3d(_AnalogConvNd):
                 self.padding[2], self.padding[2],
                 self.padding[1], self.padding[1],
                 self.padding[0], self.padding[0]], mode='constant', value=0)
-        unfold = fold_indices.unfold(2, self.kernel_size[0], self.stride[0]). \
+        unfolded = fold_indices.unfold(2, self.kernel_size[0], self.stride[0]). \
             unfold(3, self.kernel_size[1], self.stride[1]). \
             unfold(4, self.kernel_size[2], self.stride[2]).clone()
 
-        fold_indices = unfold.reshape(-1, self.kernel_size[0] * self.kernel_size[1] *
-                                      self.kernel_size[2]).transpose(0, 1).flatten().round()
+        fold_indices = unfolded.reshape(-1, self.kernel_size[0] * self.kernel_size[1] *
+                                        self.kernel_size[2]).transpose(0, 1).flatten().round()
 
         # concatenate the matrix index for different channels
         fold_indices_orig = fold_indices.clone()

--- a/tests/test_layers_convolution.py
+++ b/tests/test_layers_convolution.py
@@ -383,6 +383,42 @@ class Convolution2dLayerTest(ConvolutionLayerTest):
         y_analog = analog_model(x)
         self.assertTensorAlmostEqual(y_analog, y)
 
+    def test_torch_original_layer_indexed(self):
+        """Test a single layer, having the digital layer as reference."""
+        # This tests the forward pass
+        model = self.get_digital_layer(in_channels=2, out_channels=3, kernel_size=4, padding=2)
+        x = randn(3, 2, 4, 4)
+
+        if self.use_cuda:
+            x = x.cuda()
+
+        y = model(x)
+
+        analog_model = self.get_layer(in_channels=2, out_channels=3, kernel_size=4, padding=2)
+        analog_model.use_indexed = True
+        self.set_weights_from_digital_model(analog_model, model)
+
+        y_analog = analog_model(x)
+        self.assertTensorAlmostEqual(y_analog, y)
+
+    def test_torch_original_layer_not_indexed(self):
+        """Test a single layer, having the digital layer as reference."""
+        # This tests the forward pass
+        model = self.get_digital_layer(in_channels=2, out_channels=3, kernel_size=4, padding=2)
+        x = randn(3, 2, 4, 4)
+
+        if self.use_cuda:
+            x = x.cuda()
+
+        y = model(x)
+
+        analog_model = self.get_layer(in_channels=2, out_channels=3, kernel_size=4, padding=2)
+        analog_model.use_indexed = False
+        self.set_weights_from_digital_model(analog_model, model)
+
+        y_analog = analog_model(x)
+        self.assertTensorAlmostEqual(y_analog, y)
+
     def test_torch_train_original_layer(self):
         """Test the forward and update pass, having the digital layer as reference."""
         model = self.get_digital_layer(in_channels=2, out_channels=3, kernel_size=4, padding=2)


### PR DESCRIPTION
## Description

Internally an implicit unfolding was used for all convolutions. However, this is inefficient for CPUs and only intended for GPUs. Now, conv2D is unfolded for CPU by default, which speeds up the 2D convolutions on CPUs 