### PR TITLE
Fix hidden weights from cuda for write noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Fix issue that noise modifiers are not applied to conv-layers. (\#412)
 * The CPU ``AnalogConv2d`` layer now uses unfolded convolutions instead of
   indexed covolutions (that are efficient only for GPUs). (\#415)
+* Fix issue that write noise hidden weights are not transferred to
+  pytorch when using ``get_hidden_parameters`` in case of CUDA. (\#417)
 
 ### Changed
 

--- a/src/rpucuda/cuda/rpucuda_pulsed_device.cu
+++ b/src/rpucuda/cuda/rpucuda_pulsed_device.cu
@@ -282,6 +282,25 @@ template <typename T> void PulsedRPUDeviceCuda<T>::initResetRnd() {
   this->rnd_context_->synchronize();
 }
 
+template <typename T> std::vector<T> PulsedRPUDeviceCuda<T>::getHiddenWeights() const {
+  std::vector<T> data;
+  if (!getPar().usesPersistentWeight()) {
+    return data;
+  }
+  int offset = 0;
+
+  std::vector<T> w_vec(this->size_);
+  data.resize(this->size_);
+  if (dev_persistent_weights_) {
+    dev_persistent_weights_->copyTo(w_vec.data());
+    for (int i = 0; i < this->size_; i++) {
+      // transpose d_size maj -> x_size maj
+      data[offset + i] = w_vec[TRANSPOSE_X2D(i, this->x_size_, this->d_size_)];
+    }
+  }
+  return data;
+}
+
 template <typename T> void PulsedRPUDeviceCuda<T>::applyUpdateWriteNoise(T *dev_weights) {
 
   const auto &par = getPar();

--- a/src/rpucuda/cuda/rpucuda_pulsed_device.h
+++ b/src/rpucuda/cuda/rpucuda_pulsed_device.h
@@ -149,6 +149,7 @@ public:
   PulsedRPUDeviceMetaParameter<T> &getPar() const override {
     return static_cast<PulsedRPUDeviceMetaParameter<T> &>(SimpleRPUDeviceCuda<T>::getPar());
   };
+  std::vector<T> getHiddenWeights() const override;
 
   void runUpdateKernel(
       pwukp_t<T> kpars,

--- a/src/rpucuda/cuda/rpucuda_vector_device.cu
+++ b/src/rpucuda/cuda/rpucuda_vector_device.cu
@@ -354,8 +354,6 @@ template <typename T> std::vector<T> VectorRPUDeviceCuda<T>::getHiddenWeights() 
   for (int k = 0; k < n_devices_; k++) {
     w_vec[k].resize(this->size_);
 
-    // dev_w.assignFromDevice(this->dev_weights_ptrs_[k]); //this->dev_weights_vec_->getData() +
-    // k*this->size_); //
     dev_w.assignFromDevice(
         this->dev_weights_vec_->getData() + k * this->size_); // this copies the "empty" hidden
     dev_w.copyTo(w_vec[k].data());

--- a/src/rpucuda/rpu_pulsed_device.cpp
+++ b/src/rpucuda/rpu_pulsed_device.cpp
@@ -333,6 +333,25 @@ void PulsedRPUDevice<T>::setDeviceParameter(T **out_weights, const std::vector<T
   this->onSetWeights(out_weights);
 };
 
+template <typename T> int PulsedRPUDevice<T>::getHiddenWeightsCount() const {
+  return getPar().usesPersistentWeight()? 1 : 0;
+}
+
+template <typename T> void PulsedRPUDevice<T>::setHiddenWeights(const std::vector<T> &data) {
+  /* hidden weights are expected in the usual row-major format (first x_size then d_size)*/
+  int m = getHiddenWeightsCount();
+  if (m == 0) {
+    return;
+  }
+  if (data.size() != (size_t) this->size_ * m || m != 1) {
+      RPU_FATAL("Size mismatch for hidden weights.");
+  }
+  // first this device's hidden weights
+  for (int i = 0; i < this->size_; i++) {
+    w_persistent_[0][i] = data[i];
+  }
+}
+
 /********************************************************************************/
 /* compute functions  */
 

--- a/src/rpucuda/rpu_pulsed_device.h
+++ b/src/rpucuda/rpu_pulsed_device.h
@@ -213,6 +213,8 @@ public:
   void getDeviceParameter(std::vector<T *> &data_ptrs) const override;
   void setDeviceParameter(T **out_weights, const std::vector<T *> &data_ptrs) override;
   void printDP(int x_count, int d_count) const override;
+  int getHiddenWeightsCount() const override;
+  void setHiddenWeights(const std::vector<T> &data) override;
 
   inline T **getPersistentWeights() const { return w_persistent_; };
   inline T **getMaxBound() const { return w_max_bound_; };


### PR DESCRIPTION
## Related issues

#401, #404

The hidden weight in case of write noise is not transferred to the `get_hidden_parameters` in case of CUDA.    

## Description

Implement the missing `getHiddenWeights` function in case of write noise 

<!-- A more elaborate description of the changes, if needed. -->
