### PR TITLE
Expose stochastic rounding options for mixed precision 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Enabling comparisons of ``RPUConfig`` instances. (\#410)
 * Specific use-defined function for layer-wise setting for RPUConfigs
   in conversions. (\#412)
+* Added stochastic rounding options for ``MixedPrecisionCompound``. (\#418)
 
 ### Fixed
 

--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -1592,6 +1592,14 @@ class MixedPrecisionCompound(DigitalRankUpdateCell):
     error vector. Quantization can be turned off by setting this to 0.
     """
 
+    stoc_round_x: bool = True
+    """Whether to use stochastic rounding in case of quantization of the input x.
+    """
+
+    stoc_round_d: bool = True
+    """Whether to use stochastic rounding in case of quantization of the error d.
+    """
+
     def as_bindings(self) -> devices.MixedPrecResistiveDeviceParameter:
         """Return a representation of this instance as a simulator bindings object."""
         mixed_prec_parameter = parameters_to_bindings(self)

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_devices.cpp
@@ -655,6 +655,8 @@ void declare_rpu_devices(py::module &m) {
       .def_readwrite("compute_sparsity", &MixedPrecParam::compute_sparsity)
       .def_readwrite("n_x_bins", &MixedPrecParam::n_x_bins)
       .def_readwrite("n_d_bins", &MixedPrecParam::n_d_bins)
+      .def_readwrite("stoc_round_d", &MixedPrecParam::stoc_round_d)
+      .def_readwrite("stoc_round_x", &MixedPrecParam::stoc_round_x)
       .def_readwrite("transfer_lr", &MixedPrecParam::transfer_lr)
       .def(
           "set_device_parameter",


### PR DESCRIPTION
## Description

Adds options to the `MixedPrecisionCompound` to use stochastic rounding in case of quantization of the gradients and/or activations (`stoc_round_x` and `stoc_round_d`)