### PR TITLE
Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+* Example 24: analog inference and hardware-aware training on BERT (\#440)
 * Example 23: how to use ``AnalogTile`` directly to implement an
   analog matrix-vector product without using pytorch modules. (\#393)
 * Example 22: 2 layer LSTM network trained on War and Peace dataset. (\#391)
@@ -38,7 +39,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
-* Analog_summary error when model is on cuda device. (\#392)
+* Indexing error in ``OneSidedDevice`` for CPU (\#447) 
+* Analog summary error when model is on cuda device. (\#392)
 * Index error when loading the state dict with a model use previously. (\#387)
 * Weights that were not contiguous could have set wrongly. (\#388)
 * Programming noise would not be applied if drift compensation was not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ## Unreleased
 
 ### Added
-
+* Added stand-alone functions for applying inference drift to any model (\#419)
 * Example 24: analog inference and hardware-aware training on BERT (\#440)
 * Example 23: how to use ``AnalogTile`` directly to implement an
   analog matrix-vector product without using pytorch modules. (\#393)
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Fixed
 
 * Missing zero-grad call in example 02 (\#446)
-* Indexing error in ``OneSidedDevice`` for CPU (\#447) 
+* Indexing error in ``OneSidedDevice`` for CPU (\#447)
 * Analog summary error when model is on cuda device. (\#392)
 * Index error when loading the state dict with a model use previously. (\#387)
 * Weights that were not contiguous could have set wrongly. (\#388)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
+* Missing zero-grad call in example 02 (\#446)
 * Indexing error in ``OneSidedDevice`` for CPU (\#447) 
 * Analog summary error when model is on cuda device. (\#392)
 * Index error when loading the state dict with a model use previously. (\#387)

--- a/examples/02_multiple_layer.py
+++ b/examples/02_multiple_layer.py
@@ -45,6 +45,9 @@ opt = AnalogSGD(model.parameters(), lr=0.5)
 opt.regroup_param_groups(model)
 
 for epoch in range(100):
+
+    opt.zero_grad()
+
     # Add the training Tensor to the model (input).
     pred = model(x_b)
     # Add the expected output Tensor.
@@ -53,4 +56,5 @@ for epoch in range(100):
     loss.backward()
 
     opt.step()
+
     print('Loss error: {:.16f}'.format(loss))

--- a/src/aihwkit/inference/__init__.py
+++ b/src/aihwkit/inference/__init__.py
@@ -21,3 +21,4 @@ from aihwkit.inference.noise.pcm import PCMLikeNoiseModel
 from aihwkit.inference.noise.custom import StateIndependentNoiseModel
 from aihwkit.inference.compensation.base import BaseDriftCompensation
 from aihwkit.inference.compensation.drift import GlobalDriftCompensation
+from aihwkit.inference.utils import drift_analog_weights, program_analog_weights

--- a/src/aihwkit/inference/utils.py
+++ b/src/aihwkit/inference/utils.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 # (C) Copyright 2020, 2021, 2022 IBM. All Rights Reserved.
@@ -15,7 +14,6 @@
 
 from torch.nn import Module
 from aihwkit.exceptions import ModuleError
-from aihwkit.nn.modules.base import AnalogModuleBase
 
 
 def drift_analog_weights(model: Module, t_inference: float = 0.0) -> None:
@@ -28,6 +26,9 @@ def drift_analog_weights(model: Module, t_inference: float = 0.0) -> None:
     Raises:
         ModuleError: if the layer is not in evaluation mode.
     """
+    # avoid circular import
+    # pylint: disable=import-outside-toplevel
+    from aihwkit.nn.modules.base import AnalogModuleBase
     if model.training:
         raise ModuleError('drift_analog_weights can only be applied in '
                           'evaluation mode')
@@ -47,6 +48,9 @@ def program_analog_weights(model: Module) -> None:
     Raises:
         ModuleError: if the layer is not in evaluation mode.
     """
+    # avoid circular import
+    # pylint: disable=import-outside-toplevel
+    from aihwkit.nn.modules.base import AnalogModuleBase
     if model.training:
         raise ModuleError('program_analog_weights can only be applied in '
                           'evaluation mode')

--- a/src/aihwkit/inference/utils.py
+++ b/src/aihwkit/inference/utils.py
@@ -1,0 +1,57 @@
+
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021, 2022 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utilities for inference."""
+
+from torch.nn import Module
+from aihwkit.exceptions import ModuleError
+from aihwkit.nn.modules.base import AnalogModuleBase
+
+
+def drift_analog_weights(model: Module, t_inference: float = 0.0) -> None:
+    """(Program) and drift all analog inference layers of a given model.
+
+    Args:
+        model: torch model with analog layers
+        t_inference: assumed time of inference (in sec)
+
+    Raises:
+        ModuleError: if the layer is not in evaluation mode.
+    """
+    if model.training:
+        raise ModuleError('drift_analog_weights can only be applied in '
+                          'evaluation mode')
+
+    for module in model.modules():
+        if not isinstance(module, AnalogModuleBase):
+            continue
+        module.drift_analog_weights(t_inference)
+
+
+def program_analog_weights(model: Module) -> None:
+    """Program all analog inference layers of a given model.
+
+    Args:
+        model: torch model with analog layers
+
+    Raises:
+        ModuleError: if the layer is not in evaluation mode.
+    """
+    if model.training:
+        raise ModuleError('program_analog_weights can only be applied in '
+                          'evaluation mode')
+
+    for module in model.modules():
+        if not isinstance(module, AnalogModuleBase):
+            continue
+        module.program_analog_weights()

--- a/src/rpucuda/rpu_onesided_device.cpp
+++ b/src/rpucuda/rpu_onesided_device.cpp
@@ -84,7 +84,10 @@ template struct OneSidedRPUDeviceMetaParameter<double>;
 
 // ctor
 template <typename T>
-OneSidedRPUDevice<T>::OneSidedRPUDevice(int x_sz, int d_sz) : VectorRPUDevice<T>(x_sz, d_sz) {}
+OneSidedRPUDevice<T>::OneSidedRPUDevice(int x_sz, int d_sz) : VectorRPUDevice<T>(x_sz, d_sz) {
+  a_indices_.resize(x_sz);
+  b_indices_.resize(x_sz);
+}
 
 template <typename T>
 OneSidedRPUDevice<T>::OneSidedRPUDevice(
@@ -202,18 +205,6 @@ template <typename T> inline void OneSidedRPUDevice<T>::invert() {
   std::swap(g_plus_, g_minus_);
   this->reduce_weightening_[g_plus_] = 1;
   this->reduce_weightening_[g_minus_] = -1;
-}
-
-template <typename T>
-void OneSidedRPUDevice<T>::initUpdateCycle(
-    T **weights, const PulsedUpdateMetaParameter<T> &up, T current_lr, int m_batch_info) {
-
-  VectorRPUDevice<T>::initUpdateCycle(weights, up, current_lr, m_batch_info);
-
-  if (a_indices_.size() < (size_t)up.desired_BL) {
-    a_indices_.resize(up.desired_BL);
-    b_indices_.resize(up.desired_BL);
-  }
 }
 
 template <typename T>

--- a/src/rpucuda/rpu_onesided_device.h
+++ b/src/rpucuda/rpu_onesided_device.h
@@ -106,8 +106,6 @@ public:
 
   void invert();
   virtual const T *getRefreshVecs() const { return refresh_vecs_.data(); };
-  void initUpdateCycle(
-      T **weights, const PulsedUpdateMetaParameter<T> &up, T current_lr, int m_batch_info) override;
   void finishUpdateCycle(
       T **weights, const PulsedUpdateMetaParameter<T> &up, T current_lr, int m_batch_info) override;
 


### PR DESCRIPTION
## Related issues

closes #447
closes #446
closes #419 

## Description

* fix indexing error 
* add `zero_grad` call in example 02
* changelog update
* added stand-alone functions for applying drift : 

##Details
Apply drift to any model had required the model to be of `AnalogSequential`. Now one can simply use: 

```python
from aihwkit.inference import drift_analog_weights
model.eval()
drift_analog_weights(model, t_inference=100.)
# ... do inference with drifted model
```   