### PR TITLE
sync the private repo with public: adding the decay fix in public

### DIFF
--- a/src/rpucuda/rpu_pulsed_device.cpp
+++ b/src/rpucuda/rpu_pulsed_device.cpp
@@ -674,8 +674,13 @@ void PulsedRPUDevice<T>::populate(const PulsedRPUDeviceMetaParameter<T> &p, Real
       //--------------------
       // decay
       {
-        T t = par.lifetime * ((T)1.0 + par.lifetime_dtod * rng->sampleGauss());
-        w_decay_scale_[i][j] = t > 1.0 ? (T)((T)1. - ((T)1. / t)) : (T)0.0;
+        if (par.lifetime > (T)0.0) {
+          T t = par.lifetime * ((T)1.0 + par.lifetime_dtod * rng->sampleGauss());
+          w_decay_scale_[i][j] = (t > 1.0) ? (T)((T)1. - ((T)1. / t)) : (T)0.0;
+        } else {
+          // meaning no decay
+          w_decay_scale_[i][j] = (T)1.0;
+        }
       }
     }
   }


### PR DESCRIPTION
## Related issues



## Description

* For vector devices, the default decay scale was 0 (meaning turning off this feature, ie infinite lifetime), which had the effect that if lifetime=0.0 for some devices in the compound, they actually had a extremely short lifetime of zero and not the desired lifetime of  infinity.  

## Details

* decay scale now defaults to 1.0 if `lifetime <= 0`

Authored by @maljoras 