### PR TITLE
chore: update CUDA.Dockerfile to use multistage builds

### DIFF
--- a/CUDA.Dockerfile
+++ b/CUDA.Dockerfile
@@ -1,10 +1,8 @@
-# Build argumnets
-ARG CUDA_VER=11.8.0
-ARG UBUNTU_VER=22.04
+# Stage 0: Intel MKL
+FROM intel/oneapi-basekit AS mkl-env
 
-# Download the base image
-FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu${UBUNTU_VER}
-# you can check for all available images at https://hub.docker.com/r/nvidia/cuda/tags
+# Stage 1: Build dependencies
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 AS build-env
 
 # Install as root
 USER root
@@ -13,23 +11,78 @@ USER root
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
     --no-install-recommends \
-    bash \
-    bash-completion \
     cmake \
-    curl \
     git \
-    libopenblas-dev \
     linux-headers-$(uname -r) \
-    nano \
-    python3 python3-dev python3-pip python-is-python3 \
-    sudo \
-    wget && \
-    apt-get autoremove -y && \
-    apt-get clean && \
+    python3 python3-dev python3-pip python-is-python3 && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Add a user `${USERNAME}` so that you're not developing as the `root` user
-ARG USERNAME=ibm
+# Install Python build dependencies
+RUN pip install --no-cache-dir --upgrade --no-warn-script-location pip && \
+    pip install --no-cache-dir --no-warn-script-location pybind11 scikit-build protobuf
+
+ARG USERNAME=coder
+ARG USERID=1000
+ARG GROUPID=1000
+
+# Add user
+RUN groupadd -g ${GROUPID} ${USERNAME} && \
+    useradd ${USERNAME} \
+    --create-home \
+    --uid ${USERID} \
+    --gid ${GROUPID} \
+    --shell=/bin/bash
+
+# Copy MKL libraries from mkl-env
+COPY --from=mkl-env /opt/intel/oneapi/mkl /opt/intel/oneapi/mkl
+
+# Change to your user
+USER ${USERNAME}
+
+# Install PyTorch
+ARG PYTORCH_PIP_URL=https://download.pytorch.org/whl/cu118
+RUN pip install --no-cache-dir --no-warn-script-location torch torchvision --extra-index-url ${PYTORCH_PIP_URL}
+
+# Copy IBM aihwkit and build
+WORKDIR /home/${USERNAME}
+COPY . /home/${USERNAME}/aihwkit
+WORKDIR /home/${USERNAME}/aihwkit
+ENV MKLROOT /opt/intel/oneapi/mkl/latest
+ENV CUDACXX /usr/local/cuda/bin/nvcc
+ARG CUDA_ARCH=86
+RUN python setup.py install --user -j$(nproc) \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE \
+    -DRPU_BLAS=MKL \
+    -DINTEL_MKL_DIR=${MKLROOT} \
+    -DUSE_CUDA=ON \
+    -DRPU_CUDA_ARCHITECTURES=${CUDA_ARCH}
+
+# Stage 2: Final runtime environment
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+
+# Copy from build-env
+COPY --from=build-env /opt/intel/oneapi/mkl/latest/lib/intel64 /opt/intel/oneapi/mkl/latest/lib/intel64
+
+# Install as root
+USER root
+
+# Install utilities
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
+    --no-install-recommends \
+    bash-completion \
+    curl \
+    git \
+    nano \
+    python3 python3-pip python-is-python3 \
+    sudo \
+    vim \
+    wget && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Create a user
+ARG USERNAME=coder
 ARG USERID=1000
 ARG GROUPID=1000
 RUN groupadd -g ${GROUPID} ${USERNAME} && \
@@ -40,26 +93,20 @@ RUN groupadd -g ${GROUPID} ${USERNAME} && \
     --shell=/bin/bash && \
     echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
 
-# Change to your user
+# Copy aihwkit and .local from build-env
+COPY --from=build-env /home/${USERNAME}/aihwkit /home/${USERNAME}/aihwkit
+COPY --from=build-env /home/${USERNAME}/.local /home/${USERNAME}/.local
+
+# Install Python packages
+RUN pip install --no-cache-dir --upgrade --no-warn-script-location pip
+
+# Install Python packages
+RUN pip install --no-cache-dir --no-warn-script-location \
+    matplotlib
+
+# Environment variables
+ENV PATH /home/${USERNAME}/.local/bin:$PATH
+ENV LD_LIBRARY_PATH /opt/intel/oneapi/mkl/latest/lib/intel64:${LD_LIBRARY_PATH}
+
+# Switch to your user
 USER ${USERNAME}
-WORKDIR /home/${USERNAME}
-
-ARG PYTORCH_PIP_URL=https://download.pytorch.org/whl/cu117
-
-# Install python packages as your user
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir pybind11 scikit-build protobuf>=4.21.6 && \
-    pip install --no-cache-dir torch torchvision torchaudio --extra-index-url ${PYTORCH_PIP_URL} && \
-# Set path of python packages
-    echo 'export PATH=$HOME/.local/bin:$PATH' >> /home/${USERNAME}/.bashrc
-
-# Copy the source code inside to image and change to the source directory
-COPY . ./aihwkit
-WORKDIR /home/${USERNAME}/aihwkit
-
-# Default value for NVIDIA RTX A5000, find your own GPU model and replace it
-# use the k: https://developer.nvidia.com/cuda-gpus
-ARG CUDA_ARCH=86
-RUN echo "Detected CUDA_ARCHITECTURE is = ${CUDA_ARCH}"
-# Build and install IBM aihwkit
-RUN pip install . --install-option="-DUSE_CUDA=ON" --install-option="-DRPU_CUDA_ARCHITECTURES="${CUDA_ARCH}"" --install-option="-DRPU_BLAS=OpenBLAS"

--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -259,8 +259,8 @@ The image can be built via::
     --build-arg CUDA_ARCH=${CUDA_ARCH} \
     --file CUDA.Dockerfile .
 
-If building your image against a different CUDA or PyTorch version, please
-ensure setting the build arguments accordingly.
+If building your image against a different CUDA version, please make sure to
+update the ``CUDA_ARCH`` build argument accordingly.
 
 .. note::
 

--- a/docs/source/advanced_install.rst
+++ b/docs/source/advanced_install.rst
@@ -257,9 +257,6 @@ The image can be built via::
     --build-arg USERID=(id -u $USER) \
     --build-arg GROUPID=(id -g $USER) \
     --build-arg CUDA_ARCH=${CUDA_ARCH} \
-    --build-arg CUDA_VER=11.8.0 \
-    --build-arg UBUNTU_VER=22.04 \
-    --build-arg PYTORCH_PIP_URL=https://download.pytorch.org/whl/cu117 \
     --file CUDA.Dockerfile .
 
 If building your image against a different CUDA or PyTorch version, please


### PR DESCRIPTION
1. Updates the Dockerfile to use a multistage build
2. Use Intel MKL instead of OpenBLAS
3. Reduced the Final image size from 17+ GB to ~12 GB