### PR TITLE
Add readthedocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,28 +8,16 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
-    # You can also specify other tool versions:
-    # nodejs: "20"
-    # rust: "1.70"
-    # golang: "1.20"
+    python: "3.11"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
-  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
-  # builder: "dirhtml"
-  # Fail on all warnings to avoid broken references
-  # fail_on_warning: true
-
-# Optionally build your docs in additional formats such as PDF and ePub
-# formats:
-#   - pdf
-#   - epub
+  configuration: docs/source/conf.py
 
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - requirements: requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx==6.2.1
 sphinx-rtd-theme==1.2.2
 recommonmark==0.6.0
+myst-parser==2.0.0


### PR DESCRIPTION
## Related issues

N/A

## Description

Add a configuration file for readthedocs, in order to re-enable the building of documentation.

## Details

Since a few months ago, it seems `readthedocs` requires a config file to be present in the repo in order to render the documentation, which in turned caused the documentation not to be automatically updated since 776242d4. Thanks to @kaoutar55 for raising the issue.

Extra notes:
* In the process, I added a missing dependency to the doc requirements.
* I tested locally by invoking `make doc` under a 3.11 environment - there is a small number of  warnings (documents not included in toctrees, etc), but felt outside the scope of the PR (hopefully this is only for re-enabling doc rendering)
* the real test will be once the PR is merged, and the readthedocs integration is (hopefully) triggered

References:
* announcement: https://blog.readthedocs.com/migrate-configuration-v2/
* config file documentation: https://docs.readthedocs.io/en/stable/config-file/v2.html