### PR TITLE
Fix sphinx warnings

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,6 @@ Sphinx==6.2.1
 sphinx-rtd-theme==1.2.2
 recommonmark==0.6.0
 myst-parser==2.0.0
+# Dependencies for extras in `setup.py` needed for documentation.
+matplotlib>=3.0
+lmfit

--- a/docs/source/api/aihwkit.inference.converter.rst
+++ b/docs/source/api/aihwkit.inference.converter.rst
@@ -14,3 +14,4 @@ Submodules
 
    aihwkit.inference.converter.base
    aihwkit.inference.converter.conductance
+   aihwkit.inference.converter.fusion

--- a/docs/source/api/aihwkit.inference.noise.rst
+++ b/docs/source/api/aihwkit.inference.noise.rst
@@ -14,5 +14,6 @@ Submodules
 
    aihwkit.inference.noise.base
    aihwkit.inference.noise.custom
+   aihwkit.inference.noise.fusion
    aihwkit.inference.noise.pcm
    aihwkit.inference.noise.reram

--- a/docs/source/api/aihwkit.inference.rst
+++ b/docs/source/api/aihwkit.inference.rst
@@ -12,6 +12,7 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   aihwkit.inference.calibration
    aihwkit.inference.compensation
    aihwkit.inference.converter
    aihwkit.inference.noise

--- a/docs/source/api/aihwkit.simulator.parameters.rst
+++ b/docs/source/api/aihwkit.simulator.parameters.rst
@@ -15,4 +15,3 @@ Submodules
    aihwkit.simulator.parameters.base
    aihwkit.simulator.parameters.enums
    aihwkit.simulator.parameters.helpers
-   aihwkit.simulator.parameters.utils

--- a/docs/source/api/aihwkit.simulator.parameters.utils.rst
+++ b/docs/source/api/aihwkit.simulator.parameters.utils.rst
@@ -1,7 +1,0 @@
-aihwkit.simulator.parameters.utils module
-=========================================
-
-.. automodule:: aihwkit.simulator.parameters.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api/aihwkit.utils.rst
+++ b/docs/source/api/aihwkit.utils.rst
@@ -13,6 +13,7 @@ Submodules
    :maxdepth: 4
 
    aihwkit.utils.analog_info
+   aihwkit.utils.export
    aihwkit.utils.fitting
    aihwkit.utils.legacy
    aihwkit.utils.visualization

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -7,16 +7,17 @@ The preferred way to install this package is by using the `Python package index`
 
 Similarly this package can also be installed using ``Conda`` package for AIHWKIT
 available in Conda-forge,
- * CPU ::
+
+* CPU ::
 
     conda install -c conda-forge aihwkit
 
- * GPU ::
+* GPU ::
 
     conda install -c conda-forge aihwkit-gpu
 
 Similarly for GPU support, you can also build a ``docker`` container following the `CUDA Dockerfile instructions`_. 
-You can then run a GPU enabled docker container using the follwing command from your peoject dircetory ::
+You can then run a GPU enabled docker container using the following command from your project directory ::
 
     docker run --rm -it --gpus all -v $(pwd):$HOME --name aihwkit aihwkit:cuda bash
 


### PR DESCRIPTION
## Related issues

N/A

## Description

Checking the output of the documentation builds since #570 , there were several warnings raised by `sphinx`. This PR aims to solve them, via updating the dependencies and revising the content of the `docs/source/api/` apidocs stubs. 

## Details

There are two warnings that are left unresolved:
1.  `WARNING: A mocked object is detected: 'aihwkit.simulator.rpu_base'`
   This is caused as the actual `aihwkit` package is not built in readthedocs, so the module is not present in the final documentation - and it is actually a long-standing wish, #9. It might be possible to build it nowadays, as it seems we now can set the apt-installed packages.
2. `aihwkit/docs/source/api/modules.rst: WARNING: document isn't included in any toctree`
   This might be required by `apidoc`, even if not explicitly linked in the rest of the documentation tree. I'm not fully up to date with the latest changes, and the warning has been present since some time ago - so I'm being conservative and keeping the file and the warning.