### PR TITLE
Render aihwkit.simulator.rpu_base in readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,11 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
-
+    python: "3.10"
+  apt_packages:
+    - libopenblas-dev
+    - libpython-dev
+    - gcc
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,3 +24,8 @@ python:
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - visualization
+        - fitting

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -48,6 +48,7 @@ API Reference
    aihwkit.simulator
    aihwkit.simulator.configs
    aihwkit.simulator.presets
+   aihwkit.simulator.rpu_base
    aihwkit.simulator.tiles
    aihwkit.nn
    aihwkit.nn.conversion
@@ -73,11 +74,3 @@ API Reference
    aihwkit.utils.visualization_web
    aihwkit.utils.export
    aihwkit.version
-
-
-.. only:: env_local
-
-   .. autosummary::
-        :recursive:
-
-        aihwkit.simulator.rpu_base

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,11 +75,3 @@ html_static_path = [""]
 
 autodoc_typehints = "description"
 autodoc_mock_imports = ["aihwkit.simulator.rpu_base"]
-
-# -- Options specific to readthedocs -----------------------------------------
-
-on_readthedocs = os.environ.get("READTHEDOCS") == "True"
-if on_readthedocs:
-    tags.add("env_readthedocs")
-else:
-    tags.add("env_local")


### PR DESCRIPTION
## Related issues

Closes #9 

## Description

Take advantage of the new `readthedocs` config file features in order to (hopefully) have `aihwkit.simulator.rpu_base` displayed in the readthedocs documentation, by:
* installing required non-Python requirements via `apt`
* installing the package using `pip`
* cleaning up some extra tweaks in the docs config that were needed due to the exclusion of the module under readthedocs

## Details

Please note I have **not** been able to test the changes, as currently they will only be exercised if the PR is merged (ie. after a commit to `master`, and reviewing the readthedocs build log) ... and it might take a few rounds of iterating over the changes in order to get it to work (with the risk of the documentation being broken until fixed/reverted).

It should be possible to enable [building the docs on PRs](https://docs.readthedocs.io/en/stable/pull-requests.html) to ease iterating on the changes, although this might also require the PR to be issued from a branch in the `aihwkit` repo rather than from a fork. I'd suggest trying that route instead of merging-and-reverting-if-fails - please feel free to hijack the PR as needed to your liking!
