### PR TITLE
Fix readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
     python: "3.10"
   apt_packages:
     - libopenblas-dev
-    - libpython-dev
+    - libpython3-dev
     - gcc
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,5 @@ myst-parser==2.0.0
 # Dependencies for extras in `setup.py` needed for documentation.
 matplotlib>=3.0
 lmfit
+# Dependencies needed for building the package
+mypy==0.991

--- a/docs/source/api/aihwkit.simulator.rpu_base.rst
+++ b/docs/source/api/aihwkit.simulator.rpu_base.rst
@@ -5,3 +5,11 @@ aihwkit.simulator.rpu\_base module
    :members:
    :undoc-members:
    :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   aihwkit.simulators.rpu_base.tiles

--- a/docs/source/api/aihwkit.simulator.rpu_base.rst
+++ b/docs/source/api/aihwkit.simulator.rpu_base.rst
@@ -12,4 +12,4 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
-   aihwkit.simulators.rpu_base.tiles
+   aihwkit.simulator.rpu_base.tiles

--- a/docs/source/api/aihwkit.simulator.rpu_base.tiles.rst
+++ b/docs/source/api/aihwkit.simulator.rpu_base.tiles.rst
@@ -1,0 +1,7 @@
+aihwkit.simulator.rpu\_base.tiles
+=================================
+
+.. automodule:: aihwkit.simulator.rpu_base.tiles
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../../src"))
+# sys.path.insert(0, os.path.abspath("../../src"))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,4 +74,3 @@ html_static_path = [""]
 # -- Options specific to this project ----------------------------------------
 
 autodoc_typehints = "description"
-autodoc_mock_imports = ["aihwkit.simulator.rpu_base"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,15 @@
 import os
 import sys
 
-# sys.path.insert(0, os.path.abspath("../../src"))
+# -- Options specific to readthedocs -----------------------------------------
+
+on_readthedocs = os.environ.get("READTHEDOCS") == "True"
+if not on_readthedocs:
+    # If not invoked from the `readthedocs` build environment, use the source
+    # files instead of assuming the package is installed, and mock `rpu_base`.
+    import sys
+    sys.path.insert(0, os.path.abspath("../../src"))
+    autodoc_mock_imports = ["aihwkit.simulator.rpu_base"]
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
## Related issues

#585 

## Description

Unfortunately, as hinted during #585, the initial build with `rpu_base` enabled has failed, due to an issue with the name of one `apt` dependency. This PR resolves the failure - and additionally, adds more tweaks in order to get a passing build.
