### PR TITLE
sync with jub/IR-fix

### DIFF
--- a/src/aihwkit/simulator/configs/devices.py
+++ b/src/aihwkit/simulator/configs/devices.py
@@ -699,9 +699,11 @@ class SoftBoundsReferenceDevice(PulsedDevice):
 
         \delta W_- = \alpha_{-}(1 - \frac{w}{\beta_{min}}) (1 + \sigma \xi)
 
-    Where the same device-to-device varition can be given as for the
+    Where the same device-to-device variation can be given as for the
     ``PulsedDevice``. In addition, a device-to-device variation can be
-    directly given on the slope.
+    directly given on the slope.  The :math:`\alpha_{+}` and :math:`\alpha_{-}` are
+    the scaling factors that determine the magnitude of positive and negative
+    weight updates.
 
     Moreover, a fixed reference conductance can be subtracted from the
     resulting weight, which implemented a differential read of :math:`w - r`.


### PR DESCRIPTION
## Related issues

No issues were opened.

## Description

In the torch tile, the backward of the input ranges was wrong when a model is evaluated in, for example, a for loop.

## Details

For the torch tile, before the forward, I added a torch.autograd.Function that takes as argument the input (before dividing by the input range) and the input range (which can be None).
It outputs the same input (unchanged), but implements a backward. In that backward, I implemented the custom input range gradient.
The backward receives d L / d x_divided_by_IR and x_not_divided_by_IR (saved from ctx) and computes it more or less exactly like in periphery.py.

Why is that better than what we had before?

Before, we were storing the raw inputs in the pre_forward and were adding a backward hook on the input that calculates the input range gradient. Not elegant at all! And it is not even correct: Backpropagating through this code would produce the wrong gradients:

inp  = inp = randn((3, 256))
out = cat([torch_linear(inp[i]) for i in range(3)]).mean()
out.backward()

Now, we are making use of the autograd capabilities.
I added a new test and made sure the other tests are passing.