### PR TITLE
Added WeightModifierType.DISCRETIZE_PER_CHANNEL

### DIFF
--- a/src/aihwkit/simulator/parameters/enums.py
+++ b/src/aihwkit/simulator/parameters/enums.py
@@ -197,7 +197,10 @@ class WeightModifierType(Enum):
     """No weight modifier. Nothing happens to the weight. """
 
     DISCRETIZE = "Discretize"
-    """Quantize the weights."""
+    """Quantize the weights per tensor."""
+
+    DISCRETIZE_PER_CHANNEL = "DiscretizePerChannel"
+    """Quantize the weights per channel."""
 
     MULT_NORMAL = "MultNormal"
     """Multiplicative Gaussian noise."""

--- a/src/aihwkit/simulator/rpu_base_src/rpu_base_utils.cpp
+++ b/src/aihwkit/simulator/rpu_base_src/rpu_base_utils.cpp
@@ -37,6 +37,7 @@ void declare_utils(py::module &m_devices, py::module &m_tiles) {
   py::enum_<RPU::WeightModifierType>(m_tiles, "WeightModifierType")
       .value("Copy", RPU::WeightModifierType::Copy)
       .value("Discretize", RPU::WeightModifierType::Discretize)
+      .value("DiscretizePerChannel", RPU::WeightModifierType::DiscretizePerChannel)
       .value("MultNormal", RPU::WeightModifierType::MultNormal)
       .value("AddNormal", RPU::WeightModifierType::AddNormal)
       .value("DiscretizeAddNormal", RPU::WeightModifierType::DiscretizeAddNormal)

--- a/src/rpucuda/cuda/weight_modifier_cuda.cu
+++ b/src/rpucuda/cuda/weight_modifier_cuda.cu
@@ -14,19 +14,6 @@
 #include "cuda_math_util.h"
 #include "weight_modifier_cuda.h"
 
-#define cudaSafeCall(call)                                                     \
-  do {                                                                         \
-    cudaError_t err = call;                                                    \
-    if (cudaSuccess != err) {                                                  \
-      std::cerr << "CUDA error in " << __FILE__ << "(" << __LINE__             \
-                << "): " << cudaGetErrorString(err);                           \
-      exit(EXIT_FAILURE);                                                      \
-    }                                                                          \
-  } while (0)
-template <class T> __host__ __device__ T min_(T a, T b) {
-  return !(b < a) ? a : b;
-};
-
 namespace RPU {
 
 #define RPU_WM_KERNEL_LOOP(STOCH_IF, BODY)                                                         \

--- a/src/rpucuda/weight_modifier.cpp
+++ b/src/rpucuda/weight_modifier.cpp
@@ -64,7 +64,6 @@ void WeightModifier<T>::apply(
       PRAGMA_SIMD
       for (int col = 0; col < d_size_; col++) {
         T amax_col = 0.0;
-        PRAGMA_SIMD
         for (int row = 0; row < x_size_; row++) {
           T a = (T)fabsf(weights[col * x_size_ + row]);
           amax_col = a > amax_col ? a : amax_col;

--- a/src/rpucuda/weight_modifier.h
+++ b/src/rpucuda/weight_modifier.h
@@ -20,6 +20,7 @@ namespace RPU {
 enum class WeightModifierType {
   Copy, // does nothing, just copy (e.g. for delayed weight update), however, could also drop
   Discretize,
+  DiscretizePerChannel,
   MultNormal,
   AddNormal,
   DiscretizeAddNormal,
@@ -62,6 +63,8 @@ template <typename T> struct WeightModifierParameter {
       return "MultNormal";
     case WeightModifierType::Discretize:
       return "Discretize";
+    case WeightModifierType::DiscretizePerChannel:
+      return "DiscretizePerChannel";
     case WeightModifierType::AddNormal:
       return "AddNormal";
     case WeightModifierType::DoReFa:

--- a/tests/test_cuda_discretize_per_channel.py
+++ b/tests/test_cuda_discretize_per_channel.py
@@ -1,0 +1,97 @@
+from typing import Union
+import torch
+from torch import allclose, randn
+
+from aihwkit.nn import AnalogLinear
+from aihwkit.simulator.configs import (
+    TorchInferenceRPUConfig,
+    InferenceRPUConfig,
+    WeightModifierType,
+    NoiseManagementType,
+    BoundManagementType,
+)
+
+
+def test_weight_modifier(modifier_res: float, wm_type: WeightModifierType):
+    """
+    Test correctness of discretization.
+    """
+    # pylint: disable-msg=too-many-locals
+    device_ = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device_ = torch.device("cpu")
+
+    def populate_rpu(
+        rpu_config: Union[TorchInferenceRPUConfig, InferenceRPUConfig],
+        modifier_res: float,
+        wm_type: WeightModifierType,
+    ):
+        rpu_config.forward.bound_management = BoundManagementType.NONE
+        rpu_config.forward.noise_management = NoiseManagementType.NONE
+        rpu_config.noise_model = None
+        rpu_config.modifier.type = wm_type
+        rpu_config.modifier.res = modifier_res
+        rpu_config.modifier.sto_round = False
+        rpu_config.forward.inp_res = -1
+        rpu_config.forward.out_res = -1
+        rpu_config.forward.inp_bound = -1
+        rpu_config.forward.out_bound = -1
+        rpu_config.forward.out_noise = 0.0
+        rpu_config.forward.is_perfect = True
+        return rpu_config
+
+    torch.manual_seed(0)
+    inp_dim = 256
+    out_dim = 255
+
+    tile_weights = torch.randn(inp_dim, out_dim).to(device_)
+    inp = randn((1, inp_dim)).to(device_)
+    rpu_config_torch = populate_rpu(TorchInferenceRPUConfig(), modifier_res, wm_type)
+    rpu_config = populate_rpu(InferenceRPUConfig(), modifier_res, wm_type)
+
+    # One target will be to remove this line
+    rpu_config.modifier.res = 2 * (1 / modifier_res if modifier_res > 1.0 else modifier_res)
+
+    linear = AnalogLinear(in_features=inp_dim, out_features=out_dim, bias=False, rpu_config=rpu_config)
+    linear_torch = AnalogLinear(
+        in_features=inp_dim, out_features=out_dim, bias=False, rpu_config=rpu_config_torch
+    )
+    linear_torch.set_weights(tile_weights.T)
+
+    # move to device
+    linear = linear.to(device_)
+    linear_torch = linear_torch.to(device_)
+
+    # load the state dict
+    linear.load_state_dict(linear_torch.state_dict(), load_rpu_config=False)
+
+    # post update step generates the weight modification, needed for rpu tile
+    linear.analog_module.post_update_step()
+    assumed_wmax = rpu_config_torch.modifier.assumed_wmax
+    if rpu_config_torch.modifier.rel_to_actual_wmax:
+        assumed_wmax = (
+            tile_weights.abs().max()
+            if wm_type == WeightModifierType.DISCRETIZE
+            else tile_weights.abs().amax(0)
+        )
+
+    n_states = rpu_config_torch.modifier.res
+    n_states = n_states if n_states > 1.0 else 1 / n_states
+    res = 2 * (1 / n_states) * assumed_wmax
+    quantized_weights = (tile_weights / res).round() * res
+    cpp_quantized_weights = tile_weights / res
+    cpp_quantized_weights = (
+        torch.trunc(cpp_quantized_weights + 0.5 * torch.sign(cpp_quantized_weights)) * res
+    )
+    # Test if quantization is as expected.
+    # pylint: disable=not-callable
+    assert allclose(linear_torch(inp), torch.matmul(inp, quantized_weights), atol=1e-4)
+
+    # test if C++ tile is the same
+    cpp_out = linear(inp)
+    quantized_groundtruth = torch.matmul(inp, cpp_quantized_weights)
+    assert allclose(cpp_out, quantized_groundtruth, atol=1e-4)
+
+
+if __name__ == "__main__":
+    test_weight_modifier(2**8 - 2, WeightModifierType.DISCRETIZE_PER_CHANNEL)
+    # test_weight_modifier(2**8 - 2, WeightModifierType.DISCRETIZE)

--- a/tests/test_torch_tiles.py
+++ b/tests/test_torch_tiles.py
@@ -501,17 +501,20 @@ def test_weight_modifier(modifier_res: float, wm_type: WeightModifierType):
         return rpu_config
 
     torch.manual_seed(0)
-    tile_weights = torch.randn(256, 255).to(device_)
-    inp = randn((1, 256)).to(device_)
+    inp_dim = 256
+    out_dim = 255
+
+    tile_weights = torch.randn(inp_dim, out_dim).to(device_)
+    inp = randn((1, inp_dim)).to(device_)
     rpu_config_torch = populate_rpu(TorchInferenceRPUConfig(), modifier_res, wm_type)
     rpu_config = populate_rpu(InferenceRPUConfig(), modifier_res, wm_type)
 
     # One target will be to remove this line
     rpu_config.modifier.res = 2 * (1 / modifier_res if modifier_res > 1.0 else modifier_res)
 
-    linear = AnalogLinear(in_features=256, out_features=255, bias=False, rpu_config=rpu_config)
+    linear = AnalogLinear(in_features=inp_dim, out_features=out_dim, bias=False, rpu_config=rpu_config)
     linear_torch = AnalogLinear(
-        in_features=256, out_features=255, bias=False, rpu_config=rpu_config_torch
+        in_features=inp_dim, out_features=out_dim, bias=False, rpu_config=rpu_config_torch
     )
     linear_torch.set_weights(tile_weights.T)
 


### PR DESCRIPTION
## Related issues

No related issue for this new feature, but in this PR, I also want to address [this issue](https://github.com/IBM/aihwkit/issues/614).


## Description

I added a new `WeightModifierType.DISCRETIZE_PER_CHANNEL` type.

## Details

So far, we only have `WeightModifierType.DISCRETIZE` which discretizes the weight per-tensor. However, that induces too much quantization noise, so people resort to per-channel discretization, which is what I have implemented.
I also implemented a test that checks the correctness against a by-hand quantization in pure torch.
