### PR TITLE
Fixed minor documentation error in reram.py

### DIFF
--- a/src/aihwkit/inference/noise/reram.py
+++ b/src/aihwkit/inference/noise/reram.py
@@ -42,7 +42,7 @@ class ReRamWan2022NoiseModel(BaseNoiseModel):
 
         To account for short-term read noise (about 1\%) one should
         additional set the ``forward.w_noise`` parameter to about 0.01
-        (with w_noise_type=WeightNoiseType.ADD_NORMAL)
+        (with w_noise_type=WeightNoiseType.ADDITIVE_CONSTANT)
 
     Args:
 


### PR DESCRIPTION
## Description

Closes #608 with a small fix for the erroneous referral to `.ADD_NORMAL` as requested
