### PR TITLE
Added Example 30

### DIFF
--- a/examples/30_external_hardware_aware_model.py
+++ b/examples/30_external_hardware_aware_model.py
@@ -1,0 +1,316 @@
+# type: ignore
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021, 2022, 2023, 2024 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""aihwkit example 30: Importing and using external hardware-aware trained models.
+
+This example demonstrates how to import and perform inference using a model which has been trained
+in a hardware-aware fashion using an external library (i.e., not the AIHWKIT).
+
+The external model is in the form of a standard pytorch model with hardware-aware trained weights.
+Input and output bounds, in addition to output scales are not defined.
+
+"""
+# pylint: disable=invalid-name
+
+import torch
+import torch.nn.functional as F
+from aihwkit.nn.conversion import convert_to_analog
+from aihwkit.simulator.presets.utils import IOParameters
+from aihwkit.simulator.presets import StandardHWATrainingPreset
+from aihwkit.inference.noise.pcm import PCMLikeNoiseModel
+from aihwkit.inference.compensation.drift import GlobalDriftCompensation
+from aihwkit.simulator.configs import InferenceRPUConfig
+from aihwkit.simulator.configs.utils import (
+    WeightModifierType,
+    BoundManagementType,
+    WeightClipType,
+    NoiseManagementType,
+    WeightRemapType,
+)
+from aihwkit.inference.calibration import (
+    calibrate_input_ranges,
+    InputRangeCalibrationType,
+)
+import torchvision
+
+
+class LambdaLayer(torch.nn.Module):
+    def __init__(self, lambd):
+        super(LambdaLayer, self).__init__()
+        self.lambd = lambd
+
+    def forward(self, x):
+        return self.lambd(x)
+
+
+class BasicBlock(torch.nn.Module):
+    expansion = 1
+
+    def __init__(self, in_planes, planes, stride=1, option="A"):
+        super(BasicBlock, self).__init__()
+        self.conv1 = torch.nn.Conv2d(
+            in_planes, planes, kernel_size=3, stride=stride, padding=1, bias=False
+        )
+        self.bn1 = torch.nn.BatchNorm2d(planes)
+        self.conv2 = torch.nn.Conv2d(
+            planes, planes, kernel_size=3, stride=1, padding=1, bias=False
+        )
+        self.bn2 = torch.nn.BatchNorm2d(planes)
+
+        self.shortcut = torch.nn.Sequential()
+        if stride != 1 or in_planes != planes:
+            if option == "A":
+                """
+                For CIFAR10 ResNet paper uses option A.
+                """
+                self.shortcut = LambdaLayer(
+                    lambda x: F.pad(
+                        x[:, :, ::2, ::2],
+                        (0, 0, 0, 0, planes // 4, planes // 4),
+                        "constant",
+                        0,
+                    )
+                )
+            elif option == "B":
+                self.shortcut = torch.nn.Sequential(
+                    torch.nn.Conv2d(
+                        in_planes,
+                        self.expansion * planes,
+                        kernel_size=1,
+                        stride=stride,
+                        bias=False,
+                    ),
+                    torch.nn.BatchNorm2d(self.expansion * planes),
+                )
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out += self.shortcut(x)
+        out = F.relu(out)
+        return out
+
+
+class Resnet9(torch.nn.Module):
+    """
+    From https://github.com/matthias-wright/cifar10-resnet/
+    """
+
+    def __init__(self, channels):
+        super(Resnet9, self).__init__()
+
+        self.channels = channels
+
+        # resnet9 [56,112,224,224]
+        # resnet9s [28,28,28,56]
+
+        self.bn1 = torch.nn.BatchNorm2d(num_features=channels[0], momentum=0.9)
+        self.bn2 = torch.nn.BatchNorm2d(num_features=channels[1], momentum=0.9)
+        self.bn3 = torch.nn.BatchNorm2d(num_features=channels[2], momentum=0.9)
+        self.bn4 = torch.nn.BatchNorm2d(num_features=channels[3], momentum=0.9)
+
+        self.conv = torch.nn.Sequential(
+            # prep
+            torch.nn.Conv2d(
+                in_channels=3,
+                out_channels=channels[0],
+                kernel_size=3,
+                stride=1,
+                padding=1,
+                bias=False,
+            ),
+            self.bn1,
+            torch.nn.ReLU(inplace=True),
+            # Layer 1
+            torch.nn.Conv2d(
+                in_channels=channels[0],
+                out_channels=channels[1],
+                kernel_size=3,
+                stride=1,
+                padding=1,
+                bias=False,
+            ),
+            self.bn2,
+            torch.nn.ReLU(inplace=True),
+            torch.nn.MaxPool2d(kernel_size=2, stride=2),
+            BasicBlock(in_planes=channels[1], planes=channels[1], stride=1),
+            # Layer 2
+            torch.nn.Conv2d(
+                in_channels=channels[1],
+                out_channels=channels[2],
+                kernel_size=3,
+                stride=1,
+                padding=1,
+                bias=False,
+            ),
+            self.bn3,
+            torch.nn.ReLU(inplace=True),
+            torch.nn.MaxPool2d(kernel_size=2, stride=2),
+            # Layer 3
+            torch.nn.Conv2d(
+                in_channels=channels[2],
+                out_channels=channels[3],
+                kernel_size=3,
+                stride=1,
+                padding=1,
+                bias=False,
+            ),
+            self.bn4,
+            torch.nn.ReLU(inplace=True),
+            torch.nn.MaxPool2d(kernel_size=2, stride=2),
+            BasicBlock(in_planes=channels[3], planes=channels[3], stride=1),
+            torch.nn.MaxPool2d(kernel_size=4, stride=4),
+        )
+
+        self.fc = torch.nn.Linear(in_features=channels[3], out_features=10, bias=True)
+
+    def forward(self, x):
+        out = self.conv(x)
+        out = out.view(-1, self.channels[3])
+        out = self.fc(out)
+        return out
+
+
+def resnet9s():
+    return Resnet9(channels=[28, 28, 28, 56])
+
+
+def get_test_loader(batch_size=128):
+    transform_test = torchvision.transforms.Compose(
+        [
+            torchvision.transforms.ToTensor(),
+            torchvision.transforms.Normalize(
+                (0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)
+            ),
+        ]
+    )
+    testset = torchvision.datasets.CIFAR10(
+        root="~/data/cifar10", train=False, download=True, transform=transform_test
+    )
+    test_loader = torch.utils.data.DataLoader(
+        testset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=0,
+        pin_memory=True,
+    )
+    return test_loader
+
+
+def gen_rpu_config():
+    rpu_config = InferenceRPUConfig()
+    rpu_config.modifier.std_dev = 0.06
+    rpu_config.modifier.type = WeightModifierType.ADD_NORMAL
+
+    rpu_config.mapping.digital_bias = True
+    rpu_config.mapping.weight_scaling_omega = 1.0
+    rpu_config.mapping.weight_scaling_columnwise = False
+    rpu_config.mapping.out_scaling_columnwise = False
+    rpu_config.remap.type = WeightRemapType.LAYERWISE_SYMMETRIC
+
+    rpu_config.clip.type = WeightClipType.LAYER_GAUSSIAN
+    rpu_config.clip.sigma = 2.0
+
+    rpu_config.forward = IOParameters()
+    rpu_config.forward.is_perfect = False
+    rpu_config.forward.out_noise = 0.0
+    rpu_config.forward.inp_bound = 1.0
+    rpu_config.forward.inp_res = 1 / (2**8 - 2)
+    rpu_config.forward.out_bound = 12
+    rpu_config.forward.out_res = 1 / (2**8 - 2)
+    rpu_config.forward.bound_management = BoundManagementType.NONE
+    rpu_config.forward.noise_management = NoiseManagementType.NONE
+
+    rpu_config.pre_post.input_range.enable = True
+    rpu_config.pre_post.input_range.decay = 0.01
+    rpu_config.pre_post.input_range.init_from_data = 50
+    rpu_config.pre_post.input_range.init_std_alpha = 3.0
+    rpu_config.pre_post.input_range.input_min_percentage = 0.995
+    rpu_config.pre_post.input_range.manage_output_clipping = False
+
+    rpu_config.noise_model = PCMLikeNoiseModel(g_max=25.0)
+    rpu_config.drift_compensation = GlobalDriftCompensation()
+    return rpu_config
+
+
+class Sampler:
+    """Example of a sampler used for calibration."""
+
+    def __init__(self, loader, device):
+        self.device = device
+        self.loader = iter(loader)
+        self.idx = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        x, _ = next(self.loader)
+        self.idx += 1
+        if self.idx > 100:
+            raise StopIteration
+
+        return ([x.to(self.device)], {})
+
+
+def evaluate_model(model, test_loader, device):
+    model.eval()
+    with torch.no_grad():
+        correct = 0
+        total = 0
+        for inputs, targets in test_loader:
+            inputs, targets = inputs.to(device), targets.to(device)
+            outputs = model(inputs)
+            _, predicted = outputs.max(1)
+            total += targets.size(0)
+            correct += predicted.eq(targets).sum().item()
+
+        return 100.0 * correct / total
+
+
+if __name__ == "__main__":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = resnet9s().to(device)
+    state_dict = torch.load("resnet9s.th", device)  # TODO: Get this from the cloud.
+    # The state dict of the model with hardware-aware trained weights is stored in the
+    # model_state_dict key of the external checkpoint.
+    model.load_state_dict(state_dict["model_state_dict"], strict=True)
+    model = convert_to_analog(model, gen_rpu_config())
+    model.eval()
+    test_loader = get_test_loader()
+    t_inferences = [0.0, 3600.0, 86400.0]  # Infernece times to perform infernece.
+    n_reps = 5  # Number of inference repetitions.
+    # Calibrate input ranges
+    print("Performing input range calibration")
+    calibrate_input_ranges(
+        model=model,
+        calibration_type=InputRangeCalibrationType.CACHE_QUANTILE,
+        dataloader=Sampler(test_loader, device),
+    )
+    # Determine the inference accuracy with the specified rpu configuration.
+    print("Evaluating imported model.")
+    inference_accuracy_values = torch.zeros((len(t_inferences), n_reps))
+    for t_id, t in enumerate(t_inferences):
+        for i in range(n_reps):
+            model.drift_analog_weights(t)
+            inference_accuracy_values[t_id, i] = evaluate_model(
+                model, test_loader, device
+            )
+
+        print(
+            f"Test set accuracy (%) at t={t}s: mean: {inference_accuracy_values[t_id].mean()}, \
+                std: {inference_accuracy_values[t_id].std()}"
+        )

--- a/examples/30_external_hardware_aware_model.py
+++ b/examples/30_external_hardware_aware_model.py
@@ -1,7 +1,5 @@
 # type: ignore
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-class-docstring
-# pylint: disable=missing-function-docstring
+# pylint: disable-all
 # -*- coding: utf-8 -*-
 
 # (C) Copyright 2020, 2021, 2022, 2023, 2024 IBM. All Rights Reserved.

--- a/examples/README.md
+++ b/examples/README.md
@@ -585,6 +585,10 @@ GMRES algorithm with analog preconditioner. Note that the example
 needs additional python packages which can be installed with `pip
 install -r requirements-examples.txt`.
 
+## Example 30: [`30_external_hardware_aware_model.py`]
+Example of how to import and perform inference using a model which
+has been trained in a hardware-aware fashion using an external 
+library (i.e., not the AIHWKIT).
 
 [Resistive Processing Units]: https://aihwkit.readthedocs.io/en/latest/using_simulator.html#resistive-processing-units
 [Inference and PCM statistical model]: https://aihwkit.readthedocs.io/en/latest/pcm_inference.html
@@ -637,3 +641,4 @@ offset-corrected in-memeory training. ArXiv preprint]: https://arxiv.org/abs/230
 [`27_input_range_calibration`]: 27_input_range_calibration.py
 [`28_advanced_irdrop.py`]: 28_advanced_irdrop.py
 [`29_linalg_krylov.py`]: 29_linalg_krylov.py
+[`30_external_hardware_aware_model.py`]: 30_external_hardware_aware_model.py

--- a/tests/helpers/testcases.py
+++ b/tests/helpers/testcases.py
@@ -25,7 +25,7 @@ SKIP_CUDA_TESTS = os.getenv("SKIP_CUDA_TESTS") or not cuda.is_compiled()
 class AihwkitTestCase(TestCase):
     """Test case that contains common asserts and functions for aihwkit."""
 
-    def assertTensorAlmostEqual(self, tensor_a, tensor_b, decimal=4):
+    def assertTensorAlmostEqual(self, tensor_a, tensor_b, decimal=3):
         """Assert that two tensors are almost equal."""
         # pylint: disable=invalid-name
         array_a = tensor_a.detach().cpu().numpy()

--- a/tests/helpers/testcases.py
+++ b/tests/helpers/testcases.py
@@ -32,7 +32,7 @@ class AihwkitTestCase(TestCase):
         array_b = tensor_b.detach().cpu().numpy()
         assert_array_almost_equal(array_a, array_b, decimal=decimal)
 
-    def assertNotAlmostEqualTensor(self, tensor_a, tensor_b, decimal=4):
+    def assertNotAlmostEqualTensor(self, tensor_a, tensor_b, decimal=3):
         """Assert that two tensors are not equal."""
         # pylint: disable=invalid-name
         assert_raises(

--- a/tests/helpers/testcases.py
+++ b/tests/helpers/testcases.py
@@ -25,14 +25,14 @@ SKIP_CUDA_TESTS = os.getenv("SKIP_CUDA_TESTS") or not cuda.is_compiled()
 class AihwkitTestCase(TestCase):
     """Test case that contains common asserts and functions for aihwkit."""
 
-    def assertTensorAlmostEqual(self, tensor_a, tensor_b, decimal=3):
+    def assertTensorAlmostEqual(self, tensor_a, tensor_b, decimal=4):
         """Assert that two tensors are almost equal."""
         # pylint: disable=invalid-name
         array_a = tensor_a.detach().cpu().numpy()
         array_b = tensor_b.detach().cpu().numpy()
         assert_array_almost_equal(array_a, array_b, decimal=decimal)
 
-    def assertNotAlmostEqualTensor(self, tensor_a, tensor_b, decimal=3):
+    def assertNotAlmostEqualTensor(self, tensor_a, tensor_b, decimal=4):
         """Assert that two tensors are not equal."""
         # pylint: disable=invalid-name
         assert_raises(


### PR DESCRIPTION
This example demonstrates how to import and perform inference using a model which has been trained in a hardware-aware fashion using an external library (i.e., not the AIHWKIT).

The external model is in the form of a standard pytorch model with hardware-aware trained weights. Input and output bounds, in addition to output scales are not defined. Here, we set these using input range calibration and determine the model accuracy at different evaluation (drift) times.