### PR TITLE
Added Example 31 for GPT-2 transformer model

### DIFF
--- a/examples/31_gpt2_on_wikitext.py
+++ b/examples/31_gpt2_on_wikitext.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2020, 2021, 2022, 2023, 2024 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""aihwkit example: Example using convert_to_analog to run GPT-2 transformer on wikitext-2-raw-v1
+**Source**:
+    The example is adapted from code in
+    https://github.com/huggingface/notebooks/blob/main/examples/language_modeling.ipynb
+"""
+# pylint: disable=invalid-name, too-many-locals, import-error
+
+from datetime import datetime
+from argparse import ArgumentParser
+from transformers.integrations import TensorBoardCallback
+
+from transformers import (
+    AutoTokenizer,
+    AutoModelForCausalLM,
+    Trainer,
+    TrainingArguments,
+    DataCollatorForLanguageModeling,
+)
+
+from torch import save as torch_save, load as torch_load
+from torch.utils.tensorboard import SummaryWriter
+
+from datasets import load_dataset
+
+from aihwkit.simulator.configs import (
+    TorchInferenceRPUConfig,
+    WeightModifierType,
+    WeightClipType,
+    WeightNoiseType,
+    BoundManagementType,
+    NoiseManagementType,
+    WeightClipParameter,
+    WeightModifierParameter,
+    MappingParameter,
+)
+
+from aihwkit.simulator.presets import PresetIOParameters
+from aihwkit.inference import PCMLikeNoiseModel, GlobalDriftCompensation
+from aihwkit.nn.conversion import convert_to_analog
+from aihwkit.optim import AnalogSGD
+
+import numpy as np
+
+# GPT-2 model from Hugging Face model hub
+MODEL_NAME = "distilgpt2"  # Smallest GPT-2 model
+TOKENIZER = AutoTokenizer.from_pretrained(MODEL_NAME)
+
+# Set the padding token to eos_token
+TOKENIZER.pad_token = TOKENIZER.eos_token
+
+# Parse some arguments
+PARSER = ArgumentParser("Analog GPT-2 on wikitext-2-raw-v1 example")
+PARSER.add_argument("-d", "--digital", help="Add to use digital inference", action="store_true")
+PARSER.add_argument(
+    "-i",
+    "--ideal",
+    help="Add to use ideal config instead of default noisy one",
+    action="store_true",
+)
+PARSER.add_argument("-w", "--wandb", help="Add to use wandb", action="store_true")
+PARSER.add_argument("-n", "--noise", help="Modifier noise", default=0.1, type=float)
+PARSER.add_argument(
+    "-r",
+    "--run_name",
+    help="Tensorboard run name",
+    default=datetime.now().strftime("%Y%m%d-%H%M%S"),
+    type=str,
+)
+PARSER.add_argument("-t", "--train_hwa", help="Use Hardware-Aware training", action="store_true")
+PARSER.add_argument(
+    "-L", "--load", help="Use when loading from training checkpoint", action="store_true"
+)
+
+PARSER.add_argument(
+    "-c",
+    "--checkpoint",
+    help="File name specifying where to load/save a checkpoint",
+    default="./saved_chkpt.pth",
+    type=str,
+)
+PARSER.add_argument(
+    "-l", "--learning_rate", help="Learning rate for training", default=2e-4, type=float
+)
+
+ARGS = PARSER.parse_args()
+
+if ARGS.wandb:
+    import wandb
+
+    # Define weights noise sweep configuration
+    SWEEP_CONFIG = {
+        "method": "random",
+        "name": "modifier noise sweep",
+        "metric": {"goal": "maximize", "name": "perplexity"},
+        "parameters": {"modifier_noise": {"values": [0, 0.05, 0.1, 0.2]}},
+    }
+
+    SWEEP_ID = wandb.sweep(sweep=SWEEP_CONFIG, project="gpt2-weight-noise-experiment")
+
+
+def create_ideal_rpu_config(tile_size=512):
+    """Create RPU Config with ideal conditions"""
+    rpu_config = TorchInferenceRPUConfig(
+        mapping=MappingParameter(
+            digital_bias=True,
+            learn_out_scaling=True,
+            weight_scaling_omega=1.0,
+            out_scaling_columnwise=False,
+            weight_scaling_columnwise=True,
+            max_input_size=tile_size,
+            max_output_size=0,
+        ),
+        forward=PresetIOParameters(is_perfect=True),
+        noise_model=PCMLikeNoiseModel(prog_noise_scale=0.0, read_noise_scale=0.0, drift_scale=0.0),
+        drift_compensation=None,
+    )
+    return rpu_config
+
+
+def create_rpu_config(modifier_noise, tile_size=512, dac_res=256, adc_res=256):
+    """Create RPU Config emulated typical PCM Device"""
+    if ARGS.wandb:
+        modifier_noise = wandb.config.modifier_noise
+
+    rpu_config = TorchInferenceRPUConfig(
+        clip=WeightClipParameter(type=WeightClipType.FIXED_VALUE, fixed_value=1.0),
+        modifier=WeightModifierParameter(
+            rel_to_actual_wmax=True, type=WeightModifierType.ADD_NORMAL, std_dev=modifier_noise
+        ),
+        mapping=MappingParameter(
+            digital_bias=True,
+            learn_out_scaling=True,
+            weight_scaling_omega=1.0,
+            out_scaling_columnwise=True,
+            weight_scaling_columnwise=True,
+            max_input_size=tile_size,
+            max_output_size=0,
+        ),
+        forward=PresetIOParameters(
+            inp_res=dac_res,
+            out_res=adc_res,
+            out_bound=10.0,
+            out_noise=0.04,
+            bound_management=BoundManagementType.ITERATIVE,
+            noise_management=NoiseManagementType.ABS_MAX,
+        ),
+        noise_model=PCMLikeNoiseModel(),
+        drift_compensation=GlobalDriftCompensation(),
+    )
+    return rpu_config
+
+
+def create_model(rpu_config):
+    """Return Causal Language Model and whether or not it was loaded from a checkpoint"""
+    model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+
+    # Update model config to use the new pad_token_id
+    model.config.pad_token_id = TOKENIZER.pad_token_id
+
+    if not ARGS.digital:
+        model = convert_to_analog(model, rpu_config)
+        model.remap_analog_weights()
+
+    print(model)
+    return model
+
+
+def preprocess_function(examples):
+    """Preprocess the dataset"""
+    return TOKENIZER(examples["text"], truncation=True, padding="max_length", max_length=128)
+
+
+def create_datasets():
+    """Load the wikitext-2-raw-v1 dataset"""
+    try:
+        dataset = load_dataset("wikitext", "wikitext-2-raw-v1")
+        print("Dataset loaded successfully.")
+    except Exception as e:
+        print(f"Error loading dataset: {e}")
+        return None, None
+    
+    try:
+        tokenized_datasets = dataset.map(preprocess_function, batched=True, remove_columns=["text"], num_proc=4)
+        print("Dataset tokenized successfully.")
+    except Exception as e:
+        print(f"Error tokenizing dataset: {e}")
+        return None, None
+
+    return tokenized_datasets["train"], tokenized_datasets["validation"]
+
+
+def create_optimizer(model):
+    """Create the analog-aware optimizer"""
+    optimizer = AnalogSGD(model.parameters(), lr=ARGS.learning_rate)
+    optimizer.regroup_param_groups(model)
+    return optimizer
+
+
+def make_trainer(model, optimizer, train_dataset, eval_dataset):
+    """Create the Huggingface Trainer"""
+    training_args = TrainingArguments(
+        output_dir="./",
+        save_strategy="no",
+        per_device_train_batch_size=4,
+        per_device_eval_batch_size=4,
+        num_train_epochs=3,
+        weight_decay=0.001,
+        no_cuda=False,
+    )
+
+    collator = DataCollatorForLanguageModeling(tokenizer=TOKENIZER, mlm=False)
+
+    log_dir = "logs/fit/" + ARGS.run_name
+    writer = SummaryWriter(log_dir=log_dir)
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        data_collator=collator,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        tokenizer=TOKENIZER,
+        optimizers=(optimizer, None),
+        callbacks=[TensorBoardCallback(writer)],
+    )
+
+    return trainer, writer
+
+
+def do_inference(model, trainer, eval_dataset, writer, max_inference_time=1e6, n_times=9):
+    """Perform inference experiment at weight noise level specified at runtime."""
+    def predict():
+        # Perform inference + evaluate metric here
+        result = trainer.evaluate()
+        return result["eval_loss"]
+
+    def write_metrics(eval_loss, t_inference):
+        # Add information to tensorboard
+        writer.add_scalar("val/loss", eval_loss, t_inference)
+
+        if ARGS.wandb:
+            wandb.log({"t_inference": t_inference, "loss": eval_loss})
+
+        print(f"Loss: {eval_loss: .2f}\t" f"Drift: {t_inference: .2e}")
+
+    model.eval()
+
+    t_inference_list = np.logspace(0, np.log10(float(max_inference_time)), n_times).tolist()
+
+    # Get the initial metrics
+    eval_loss = predict()
+    write_metrics(eval_loss, 0.0)
+
+    for t_inference in t_inference_list:
+        model.drift_analog_weights(t_inference)
+        eval_loss = predict()
+        write_metrics(eval_loss, t_inference)
+
+
+def main():
+    """Provide the lambda function for WandB sweep. If WandB is not used, then this
+    is what is executed in the job
+    """
+    if ARGS.wandb:
+        wandb.init()
+
+    # Define RPU configuration and use it to create model and tokenizer
+    if ARGS.ideal:
+        rpu_config = create_ideal_rpu_config()
+    else:
+        rpu_config = create_rpu_config(modifier_noise=ARGS.noise)
+
+    model = create_model(rpu_config)
+
+    train_dataset, eval_dataset = create_datasets()
+    if train_dataset is None or eval_dataset is None:
+        print("Error: train_dataset or eval_dataset is None.")
+        return
+
+    optimizer = create_optimizer(model)
+    trainer, writer = make_trainer(model, optimizer, train_dataset, eval_dataset)
+
+    if ARGS.load:
+        print(f"Load model from '{ARGS.checkpoint}'.")
+        model.load_state_dict(torch_load(ARGS.checkpoint))
+
+    # Do hw-aware training if in analog domain and the model isn't loaded from
+    # an existing checkpoint
+    if ARGS.train_hwa and not ARGS.digital and not ARGS.load:
+        trainer.train()
+        torch_save(model.state_dict(), ARGS.checkpoint)
+    do_inference(model, trainer, eval_dataset, writer)
+
+
+if ARGS.wandb:
+    wandb.agent(SWEEP_ID, function=main, count=4)
+else:
+    main()


### PR DESCRIPTION
## Related issues
New example added for the GPT-2 demonstration
<!-- Link to the issues that are related to this pull request. -->

## Description
This pull request includes a new example implementation for running GPT-2 based model `distilgpt2` transformer on the `wikitext-2-raw-v1` dataset using AIHWKit. The example demonstrates how to convert the model to analog, run training and inference, and visualize the performance metrics using TensorBoard.

## Details
<b> Key Changes and Additions </b>
1. Model and Dataset:
- Implemented an example using the smallest GPT-2 model (distilgpt2).
- Utilized the wikitext-2-raw-v1 dataset for training and validation, which is smaller and faster to process compared to openwebtext.

2. Training and Inference Setup:
- Configured the model to use analog inference with specified noise levels.
- Added support for digital inference as an option.
- Implemented preprocessing functions to handle dataset tokenization.
- Provided functionality to train the model and save/load checkpoints.

3. Logging and Monitoring:
- Integrated TensorBoard for logging training and validation metrics.
- Added TensorBoardCallback to the Trainer for seamless logging.
- Configured the script to save logs in a specific directory and visualize them using TensorBoard.

4. Performance Metrics:
- Calculated validation loss and perplexity as the primary performance metrics.
- Achieved a validation loss of 4.059

## README
Example 31: ['31_gpt2_on_wikitext.py']
This example is adapted from <a>https://github.com/huggingface/notebooks/blob/main/examples/language_modeling.ipynb</a>

The example loads a pre-trained GPT-2 model trained on the wikitext dataset. It then applies `convert_to_analog()` to examine the effects of `drift_analog_weights()` on inference performance at different weight noise levels. Tensorboard is used to display the perplexity metrics evaluated using the model at various times after training completed.

Commandline arguments can be used to control certain options. For example: `python /path/to/aihwkit/examples/31_gpt2_on_wikitext.py -n 0.1 -r "run 1" -l 0.0005 -t` to set the weight noise to 0.1, name the run in Tensorboard "run 1", set the learning rate to 0.0005, and do hardware-aware training.