### PR TITLE
Remove reset bias clamp in rpu_pulsed_device.h (issue #755)

### DIFF
--- a/src/rpucuda/rpu_pulsed_device.h
+++ b/src/rpucuda/rpu_pulsed_device.h
@@ -110,7 +110,6 @@ template <typename T> struct PulsedRPUDeviceMetaParameter : PulsedRPUDeviceMetaP
     }
     reset_dtod = MAX(reset_dtod, (T)0.0);
     this->reset_std = MAX(this->reset_std, (T)0.0);
-    reset = MAX(reset, (T)0.0);
   };
 };
 


### PR DESCRIPTION
## Related issues

Issue #755
https://github.com/IBM/aihwkit/issues/755

## Description

Just remove of a line which clamps 'reset' (decay convergence point) in rpu_pulsed_device.h

## Details

It worked without any errors in build, as far as I could verify.
