### PR TITLE
fix(visualization): update ylim function call for consistency

### DIFF
--- a/src/aihwkit/utils/visualization.py
+++ b/src/aihwkit/utils/visualization.py
@@ -632,7 +632,7 @@ def plot_device_symmetry(
     )
 
     plot_pulse_response(analog_tile, direction, use_forward=False)
-    plt.ylim([-1, 1])
+    plt.ylim(-1, 1)
     plt.grid(True)
 
 


### PR DESCRIPTION
## Description

Address recent mypy errors on visualization matplotlib module:

```bash
mypy --show-error-codes src/
src/aihwkit/utils/visualization.py:635: error: No overload variant of "ylim" matches argument type "list[int]"  [call-overload]
src/aihwkit/utils/visualization.py:635: note: Possible overload variants:
src/aihwkit/utils/visualization.py:635: note:     def ylim() -> tuple[float, float]
src/aihwkit/utils/visualization.py:635: note:     def ylim(bottom: float | tuple[float, float] | None = ..., top: float | None = ..., *, emit: bool = ..., auto: bool | None = ..., ymin: float | None = ..., ymax: float | None = ...) -> tuple[float, float]
```

## Details

Passing -1, 1 as separate float-compatible arguments matches the overload signature ylim(bottom, top). A list[int] technically satisfied the tuple[float, float] variant in older mypy versions via looser checking, but newer mypy is stricter about the distinction between list and tuple.

https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.ylim.html
