### PR TITLE
fix(optim): support like factories for placeholder contexts

### DIFF
--- a/src/aihwkit/optim/context.py
+++ b/src/aihwkit/optim/context.py
@@ -21,6 +21,7 @@ from aihwkit.optim.weight_view import (
     raise_if_readonly_write_target,
     PlaceholderDataView,
     _PLACEHOLDER_METADATA_FUNCTIONS,
+    _PLACEHOLDER_LIKE_FACTORY_FUNCTIONS,
     _raise_placeholder_read_error,
 )
 from aihwkit.simulator.parameters.enums import AnalogContextDataViewMode
@@ -323,7 +324,10 @@ class AnalogContext(Parameter):
         """Return the tensor used to dispatch public torch operations."""
         mode = self._get_data_view_mode()
         if mode == AnalogContextDataViewMode.PLACEHOLDER:
-            if func_name not in _PLACEHOLDER_METADATA_FUNCTIONS:
+            if (
+                func_name not in _PLACEHOLDER_METADATA_FUNCTIONS
+                and func_name not in _PLACEHOLDER_LIKE_FACTORY_FUNCTIONS
+            ):
                 _raise_placeholder_read_error(func_name)
             return self._placeholder_data()
         if mode == AnalogContextDataViewMode.DATA_VIEW:

--- a/src/aihwkit/optim/weight_view.py
+++ b/src/aihwkit/optim/weight_view.py
@@ -130,6 +130,18 @@ _PLACEHOLDER_METADATA_FUNCTIONS = {
     "_is_zerotensor",
 }
 
+_PLACEHOLDER_LIKE_FACTORY_FUNCTIONS = {
+    # These factories copy tensor metadata only. They allocate new storage and
+    # never inspect or share the placeholder's meaningless backing values.
+    "empty_like",
+    "full_like",
+    "ones_like",
+    "rand_like",
+    "randint_like",
+    "randn_like",
+    "zeros_like",
+}
+
 
 def _raise_placeholder_read_error(func_name: str) -> None:
     """Raise the standard error for reads in placeholder mode."""
@@ -179,7 +191,10 @@ class PlaceholderDataView(Tensor):
 
             tree_map(block_out_target, kwargs["out"])
 
-        if func_name not in _PLACEHOLDER_METADATA_FUNCTIONS:
+        if (
+            func_name not in _PLACEHOLDER_METADATA_FUNCTIONS
+            and func_name not in _PLACEHOLDER_LIKE_FACTORY_FUNCTIONS
+        ):
             _raise_placeholder_read_error(func_name)
 
         if func_name == "detach":

--- a/tests/test_analog_ctx.py
+++ b/tests/test_analog_ctx.py
@@ -695,6 +695,51 @@ class AnalogCtxDataViewModeTest(ParametrizedTestCase):
                 with self.assertRaises(RuntimeError):
                     op()
 
+    def test_placeholder_allows_like_factories(self):
+        """Like factories should use placeholder metadata without reading values."""
+        _, ctx = self._get_tile_and_ctx(self._make_model())
+
+        factories = [
+            ("empty_like", torch.empty_like, (), None),
+            ("zeros_like", torch.zeros_like, (), 0.0),
+            ("ones_like", torch.ones_like, (), 1.0),
+            ("full_like", torch.full_like, (2.0,), 2.0),
+            ("rand_like", torch.rand_like, (), None),
+            ("randn_like", torch.randn_like, (), None),
+            ("randint_like", torch.randint_like, (10,), None),
+        ]
+
+        for source in [ctx, ctx.data]:
+            for name, factory, factory_args, expected_value in factories:
+                with self.subTest(source_type=type(source).__name__, factory=name):
+                    result = factory(source, *factory_args)
+                    self.assertIs(type(result), Tensor)
+                    self.assertEqual(result.shape, ctx.shape)
+                    self.assertEqual(result.dtype, ctx.dtype)
+                    self.assertEqual(result.device, ctx.device)
+                    if expected_value is not None:
+                        self.assertTrue(
+                            allclose(result, torch.full_like(result, expected_value))
+                        )
+
+    def test_cuda_zeros_like_context_uses_metadata_only(self):
+        """zeros_like(ctx) should work after moving an analog layer to CUDA."""
+        if SKIP_CUDA_TESTS:
+            raise SkipTest("not compiled with CUDA support")
+
+        rpu_config = SingleRPUConfig(device=ConstantStepDevice())
+        model = AnalogLinear(1, 1, bias=False, rpu_config=rpu_config).to(
+            device("cuda")
+        )
+        ctx = next(model.parameters())
+
+        result = torch.zeros_like(ctx)
+
+        self.assertIs(type(result), Tensor)
+        self.assertEqual(result.shape, ctx.shape)
+        self.assertEqual(result.device, ctx.device)
+        self.assertTrue(allclose(result, torch.zeros(1, 1, device=result.device)))
+
     def test_placeholder_state_dict_round_trip(self):
         """Saving and loading should not require public weight reads."""
         source = self._make_model()


### PR DESCRIPTION
## Why

`AnalogContext` exposes placeholder data by default so public tensor operations cannot accidentally read meaningless backing weights. Tensor `*_like` factories only need metadata such as shape, dtype, and device, and should be valid in this mode. Before this change, they were rejected as value-reading operations.

This is related to the placeholder-data feature introduced by [IBM/aihwkit#765](https://github.com/IBM/aihwkit/pull/765), and completes its compatibility with standard PyTorch `*_like` factories.

## Failure case

```python
model = AnalogLinear(1, 1, bias=False, rpu_config=SingleRPUConfig(
    device=ConstantStepDevice()
)).to("cuda")
ctx = next(model.parameters())
torch.zeros_like(ctx)
```

Before this fix, the final line raised:

```text
RuntimeError: AnalogContext data is in placeholder mode, so operation 'zeros_like' cannot read weight values.
```

This prevented metadata-only tensor construction during CUDA model setup and other generic PyTorch code paths.

## What changed

- Allow `empty_like`, `full_like`, `ones_like`, `rand_like`, `randint_like`, `randn_like`, and `zeros_like` in placeholder mode.
- Keep the placeholder backing storage unread while allowing PyTorch to allocate the result from metadata.
- Add CPU coverage for all seven public `*_like` factories and a CUDA regression test for `zeros_like`.
