### PR TITLE
Fix double bracket indexing bug on Hermes noise model

### DIFF
--- a/src/aihwkit/inference/__init__.py
+++ b/src/aihwkit/inference/__init__.py
@@ -18,6 +18,7 @@ from aihwkit.inference.converter.conductance import (
 from aihwkit.inference.noise.base import BaseNoiseModel
 from aihwkit.inference.noise.pcm import PCMLikeNoiseModel, CustomDriftPCMLikeNoiseModel
 from aihwkit.inference.noise.reram import ReRamWan2022NoiseModel, ReRamCMONoiseModel
+from aihwkit.inference.noise.hermes import HermesNoiseModel
 from aihwkit.inference.noise.custom import StateIndependentNoiseModel
 from aihwkit.inference.compensation.base import BaseDriftCompensation
 from aihwkit.inference.compensation.drift import GlobalDriftCompensation

--- a/src/aihwkit/inference/noise/hermes.py
+++ b/src/aihwkit/inference/noise/hermes.py
@@ -189,7 +189,7 @@ class HermesNoiseModel(BaseNoiseModel):
         # experimental data
         g_rel_low_mean, g_rel_high_mean = (
             g_relative[g_relative < 0.0945],
-            g_relative[[g_relative >= 0.0945]],
+            g_relative[g_relative >= 0.0945],
         )
         mu_drift[g_relative < 0.0945] = (-0.0387 * log(g_rel_low_mean) - 0.0182).clamp(
             min=0.0720, max=0.13
@@ -200,7 +200,7 @@ class HermesNoiseModel(BaseNoiseModel):
         if self.num_devices == 1:
             g_rel_low_std, g_rel_high_std = (
                 g_relative[g_relative < 0.3039],
-                g_relative[[g_relative >= 0.3039]],
+                g_relative[g_relative >= 0.3039],
             )
             sig_drift[g_relative < 0.3039] = (-0.0120 * log(g_rel_low_std) - 0.0023).clamp(
                 min=0.0124, max=0.04
@@ -211,7 +211,7 @@ class HermesNoiseModel(BaseNoiseModel):
         elif self.num_devices == 2:
             g_rel_low_std, g_rel_high_std = (
                 g_relative[g_relative < 0.3055],
-                g_relative[[g_relative >= 0.3055]],
+                g_relative[g_relative >= 0.3055],
             )
             sig_drift[g_relative < 0.3055] = (-0.0117 * log(g_rel_low_std) - 0.0057).clamp(
                 min=0.0091, max=0.04
@@ -245,7 +245,7 @@ class HermesNoiseModel(BaseNoiseModel):
             if self.num_devices == 1:
                 g_rel_low, g_rel_high = (
                     g_relative[g_relative < 0.1591],
-                    g_relative[[g_relative >= 0.1591]],
+                    g_relative[g_relative >= 0.1591],
                 )
                 q_s[g_relative < 0.1591] = (-0.0078 * log(g_rel_low) + 0.0038).clamp(
                     min=0.0179, max=0.04
@@ -256,7 +256,7 @@ class HermesNoiseModel(BaseNoiseModel):
             elif self.num_devices == 2:
                 g_rel_low, g_rel_high = (
                     g_relative[g_relative < 0.16],
-                    g_relative[[g_relative >= 0.16]],
+                    g_relative[g_relative >= 0.16],
                 )
                 q_s[g_relative < 0.16] = (-0.0117 * log(g_rel_low) - 0.0069).clamp(
                     min=0.015, max=0.04


### PR DESCRIPTION
## Description

Double brackets were used to index a torch tensor in the hermes noise model, leading to a UserWarning when using it. Fixed this by changing it to proper indexing.

## Details

The following warning was raised when using the hermes noise model (`model.program_analog_weights()`). 

```
UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result (Triggered internally at /__w/pytorch/pytorch/torch/csrc/autograd/python_variable_indexing.cpp:349.)
  g_relative[[g_relative >= 0.0945]],
```

Found 5 instances where this indexing pattern was used in the class. Single bracket solves the issue.
