### PR TITLE
Compile on blackwell with CUDA 13+

### DIFF
--- a/src/aihwkit/simulator/digital_low_precision/range_estimators.py
+++ b/src/aihwkit/simulator/digital_low_precision/range_estimators.py
@@ -359,7 +359,7 @@ class MSE_Estimator(RangeEstimatorBase):
             )  # 1D search space
             self.loss_array[:, 0] = np.inf  # exclude interval_start=interval_finish
             # Defining the search range for clipping thresholds
-            self.max_pos_thr = max(abs(float(data.min())), float(data.max())) + self.range_margin
+            self.max_pos_thr = max(abs(float(data.detach().min())), float(data.detach().max())) + self.range_margin
             self.max_neg_thr = -self.max_pos_thr
             self.max_search_range = self.max_pos_thr
         else:
@@ -370,8 +370,8 @@ class MSE_Estimator(RangeEstimatorBase):
             )  # 2D search space
             self.loss_array[:, 0, :, :] = np.inf  # exclude interval_start=interval_finish
             # Define the search range for clipping thresholds in asymmetric case
-            self.max_pos_thr = float(data.max()) + self.range_margin
-            self.max_neg_thr = float(data.min()) - self.range_margin
+            self.max_pos_thr = float(data.detach().max()) + self.range_margin
+            self.max_neg_thr = float(data.detach().min()) - self.range_margin
             self.max_search_range = max(abs(self.max_pos_thr), abs(self.max_neg_thr))
 
     def _perform_1D_search(self, data):

--- a/src/rpucuda/cuda/maximizer.cu
+++ b/src/rpucuda/cuda/maximizer.cu
@@ -18,6 +18,12 @@
 #include "io_iterator.h"
 #include "rpu_cub.h"
 
+// CUDA 13+ (CCCL) removed cub::TransformInputIterator and cub::CountingInputIterator.
+// They are now cuda::transform_iterator and cuda::counting_iterator.
+#if CUDART_VERSION >= 13000
+#include <cuda/iterator>
+#endif
+
 namespace RPU {
 
 namespace {
@@ -218,18 +224,25 @@ void debugMaxBatched(const T *indata, int size, int m_batch, bool trans, T *max_
   CUDA_CALL(cudaDeviceSynchronize());
 
   IndexReader<T> idx_reader(dev_in.getData());
+#if CUDART_VERSION >= 13000
+  auto in_itr = ::cuda::make_transform_iterator(dev_in_index.getData(), idx_reader);
+  auto index = ::cuda::make_counting_iterator(0);
+  BatchTransposer<T> batch_transposer(dev_in.getData(), size, m_batch);
+  auto in_trans_itr = ::cuda::make_transform_iterator(index, batch_transposer);
+  IndexReader<int> idx_reader_host(tmp);
+  auto test_host = ::cuda::make_transform_iterator(tmp, idx_reader_host);
+#else
   RPU_CUB_NS_QUALIFIER TransformInputIterator<T, IndexReader<T>, int *> in_itr(
       dev_in_index.getData(), idx_reader);
-
   RPU_CUB_NS_QUALIFIER CountingInputIterator<int> index(0);
   BatchTransposer<T> batch_transposer(dev_in.getData(), size, m_batch);
   RPU_CUB_NS_QUALIFIER
   TransformInputIterator<T, BatchTransposer<T>, RPU_CUB_NS_QUALIFIER CountingInputIterator<int>>
       in_trans_itr(index, batch_transposer);
-
   IndexReader<int> idx_reader_host(tmp);
   RPU_CUB_NS_QUALIFIER TransformInputIterator<int, IndexReader<int>, int *> test_host(
       tmp, idx_reader_host);
+#endif
   std::cout << test_host[0] << std::endl;
 
   CustomMaxAbs max_abs;

--- a/src/rpucuda/cuda/maximizer.cu
+++ b/src/rpucuda/cuda/maximizer.cu
@@ -18,7 +18,7 @@
 #include "io_iterator.h"
 #include "rpu_cub.h"
 
-// CUDA 13+ (CCCL) removed cub::TransformInputIterator and cub::CountingInputIterator.
+// cub::TransformInputIterator and cub::CountingInputIterator are getting deprecated.
 // They are now cuda::transform_iterator and cuda::counting_iterator.
 #if CUDART_VERSION >= 13000
 #include <cuda/iterator>

--- a/src/rpucuda/cuda/noise_manager.cu
+++ b/src/rpucuda/cuda/noise_manager.cu
@@ -16,6 +16,11 @@
 #include "cuda_util.h"
 #include "rpu_cub.h"
 
+// CUDA 13+ (CCCL) removed cub::TransformInputIterator; use cuda::transform_iterator instead.
+#if CUDART_VERSION >= 13000
+#include <cuda/iterator>
+#endif
+
 #include "io_iterator.h"
 
 namespace RPU {
@@ -239,7 +244,7 @@ template <typename T> void NoiseManager<T>::initializeBatchBuffer(int m_batch) {
     size_t temp_storage_bytes = 0;
     RPU_CUB_NS_QUALIFIER DeviceSegmentedReduce::Reduce(
         nullptr, temp_storage_bytes, dev_psum_values_->getData(), dev_psum_values_->getData(),
-        m_batch, dev_offsets_->getData(), dev_offsets_->getData() + 1, psum_op_, 0,
+        m_batch, dev_offsets_->getData(), dev_offsets_->getData() + 1, psum_op_, (T)0,
         context_->getStream());
     dev_m_temp_storage_ = RPU::make_unique<CudaArray<char>>(context_, temp_storage_bytes);
 
@@ -496,8 +501,13 @@ void NoiseManager<T>::compute(
 
         if (m_batch > 1) {
           NonZeroFunctor<T> nonzero_functor;
+#if CUDART_VERSION >= 13000
+          auto nz_input =
+              ::cuda::make_transform_iterator(amaximizer_->getMaxValues(), nonzero_functor);
+#else
           RPU_CUB_NS_QUALIFIER TransformInputIterator<T, NonZeroFunctor<T>, T *> nz_input(
               amaximizer_->getMaxValues(), nonzero_functor);
+#endif
           // temp storage already requested above
           size_t ssz = dev_a_temp_storage_->getSize();
           RPU_CUB_NS_QUALIFIER DeviceReduce::Sum(

--- a/src/rpucuda/cuda/noise_manager.cu
+++ b/src/rpucuda/cuda/noise_manager.cu
@@ -16,7 +16,7 @@
 #include "cuda_util.h"
 #include "rpu_cub.h"
 
-// CUDA 13+ (CCCL) removed cub::TransformInputIterator; use cuda::transform_iterator instead.
+// cub::TransformInputIterator is getting deprecated. Using cuda::transform_iterator instead.
 #if CUDART_VERSION >= 13000
 #include <cuda/iterator>
 #endif

--- a/src/rpucuda/cuda/weight_clipper_cuda.cu
+++ b/src/rpucuda/cuda/weight_clipper_cuda.cu
@@ -10,7 +10,7 @@
 #include "rpu_cub.h"
 #include "weight_clipper_cuda.h"
 
-// CUDA 13+ (CCCL) removed cub::TransformInputIterator; use cuda::transform_iterator instead.
+// cub::TransformInputIterator is getting deprecated. Using cuda::transform_iterator instead.
 #if CUDART_VERSION >= 13000
 #include <cuda/iterator>
 #endif

--- a/src/rpucuda/cuda/weight_clipper_cuda.cu
+++ b/src/rpucuda/cuda/weight_clipper_cuda.cu
@@ -10,6 +10,11 @@
 #include "rpu_cub.h"
 #include "weight_clipper_cuda.h"
 
+// CUDA 13+ (CCCL) removed cub::TransformInputIterator; use cuda::transform_iterator instead.
+#if CUDART_VERSION >= 13000
+#include <cuda/iterator>
+#endif
+
 namespace RPU {
 
 template <typename T> struct StdFunctor {
@@ -51,7 +56,11 @@ WeightClipperCuda<T>::WeightClipperCuda(CudaContextPtr context, int x_size, int 
 
   T *tmp = nullptr;
   StdFunctor<T> std_functor((T)x_size_, tmp);
+#if CUDART_VERSION >= 13000
+  auto std_input = ::cuda::make_transform_iterator(tmp, std_functor);
+#else
   RPU_CUB_NS_QUALIFIER TransformInputIterator<T, StdFunctor<T>, T *> std_input(tmp, std_functor);
+#endif
 
   RPU_CUB_NS_QUALIFIER DeviceReduce::Sum(
       nullptr, temp_storage_bytes_, std_input, tmp, size_, context_->getStream());
@@ -96,8 +105,12 @@ void WeightClipperCuda<T>::apply(T *weights, const WeightClipParameter &wclpar) 
     }
 
     StdFunctor<T> std_functor((T)size_, dev_sum_value_->getData());
+#if CUDART_VERSION >= 13000
+    auto std_input = ::cuda::make_transform_iterator(weights, std_functor);
+#else
     RPU_CUB_NS_QUALIFIER TransformInputIterator<T, StdFunctor<T>, T *> std_input(
         weights, std_functor);
+#endif
 
     // mean (sum)
     RPU_CUB_NS_QUALIFIER DeviceReduce::Sum(


### PR DESCRIPTION
## Description

Compiling from source did not work properly when trying to compile on a Blackwell GPU with CUDA 13+. Found that cub::TransformInputIterator and cub::CountingInputIterator are getting deprecated and are moving to the new calls cuda::transform_iterator and cuda::counting_iterator. Changed them appropriately with `CUDART_VERSION >= 13000` guards.

## Details

Compiling on a Blackwell GPU using CUDA 13.2 failed due to errors with the cub iterators. Changed them to the new iterators in the CUDA namespace, and the repo compiles properly. Tests are passing.

When running tests found two warnings regarding the RangeEstimator class, which are now fixed (detaching before conversion to float).

GPU model:
RTX PRO 6000 Blackwell Workstation Edition

CUDA compiler version:
Cuda compilation tools, release 13.2, V13.2.86
Build cuda_13.2.r13.2/compiler.37953736_0
